### PR TITLE
Change from https:// to http:// for api.reload.cc requests

### DIFF
--- a/module/plugins/hooks/ReloadCc.py
+++ b/module/plugins/hooks/ReloadCc.py
@@ -5,25 +5,25 @@ from module.network.RequestFactory import getURL
 
 class ReloadCc(MultiHoster):
     __name__ = "ReloadCc"
-    __version__ = "0.2"
+    __version__ = "0.3"
     __type__ = "hook"
     __description__ = """Reload.cc hook plugin"""
 
     __config__ = [("activated", "bool", "Activated", "False"),
-                  ("hosterListMode", "all;listed;unlisted", "Use for hosters (if supported):", "all"), 
+                  ("hosterListMode", "all;listed;unlisted", "Use for hosters (if supported):", "all"),
                   ("hosterList", "str", "Hoster list (comma separated)", "")]
 
     __author_name__ = ("Reload Team")
     __author_mail__ = ("hello@reload.cc")
 
     interval = 0 # Disable periodic calls
-    
-    def getHoster(self):     
+
+    def getHoster(self):
         # If no accounts are available there will be no hosters available
         if not self.account or not self.account.canUse():
             print "ReloadCc: No accounts available"
             return []
-        
+
         # Get account data
         (user, data) = self.account.selectAccount()
 
@@ -41,25 +41,25 @@ class ReloadCc(MultiHoster):
         except Exception:
             query_params.update(dict(pwd=data['password']))
 
-        answer = getURL("https://api.reload.cc/login", get=query_params)
+        answer = getURL("http://api.reload.cc/login", get=query_params)
         data = json_loads(answer)
-        
-        
+
+
         # If account is not valid thera are no hosters available
         if data['status'] != "ok":
             print "ReloadCc: Status is not ok: %s" % data['status']
             return []
-        
-        # Extract hosters from json file 
-        return data['msg']['supportedHosters'] 
-            
+
+        # Extract hosters from json file
+        return data['msg']['supportedHosters']
+
     def coreReady(self):
         # Get account plugin and check if there is a valid account available
-        self.account = self.core.accountManager.getAccountPlugin("ReloadCc")     
+        self.account = self.core.accountManager.getAccountPlugin("ReloadCc")
         if not self.account.canUse():
             self.account = None
             self.logError("Please add a valid reload.cc account first and restart pyLoad.")
             return
-                  
-        # Run the overwriten core ready which actually enables the multihoster hook 
+
+        # Run the overwriten core ready which actually enables the multihoster hook
         return MultiHoster.coreReady(self)

--- a/module/plugins/hoster/ReloadCc.py
+++ b/module/plugins/hoster/ReloadCc.py
@@ -6,7 +6,7 @@ from module.network.HTTPRequest import BadHeader
 
 class ReloadCc(Hoster):
     __name__ = "ReloadCc"
-    __version__ = "0.3"
+    __version__ = "0.4"
     __type__ = "hoster"
     __description__ = """Reload.Cc hoster plugin"""
 
@@ -47,7 +47,7 @@ class ReloadCc(Hoster):
             query_params.update(dict(pwd=data['password']))
 
         try:
-            answer = self.load("https://api.reload.cc/dl", get=query_params)
+            answer = self.load("http://api.reload.cc/dl", get=query_params)
         except BadHeader, e:
             if e.code == 400:
                 self.fail("The URI is not supported by Reload.cc.")


### PR DESCRIPTION
Hi,

the api.reload.cc requests failed because https:// is not supported yet.

So they are changed back to http://, this way it's working.

Thanks
