### PR TITLE
New SpeedLoadOrg account plugin

### DIFF
--- a/module/plugins/accounts/SpeedLoadOrg.py
+++ b/module/plugins/accounts/SpeedLoadOrg.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from module.plugins.internal.XFSPAccount import XFSPAccount
+
+class SpeedLoadOrg(XFSPAccount):
+    __name__ = "SpeedLoadOrg"
+    __version__ = "0.01"
+    __type__ = "account"
+    __description__ = """SpeedLoadOrg account plugin"""
+    __author_name__ = ("stickell")
+    __author_mail__ = ("l.stickell@yahoo.it")
+
+    MAIN_PAGE = "http://speedload.org/"


### PR DESCRIPTION
Allow SpeedLoadOrg to use premium/free registered users.

Tested only with free registered account, but premium should work fine.
