### PR TITLE
Fixing OneFichierCom from user plugins

### DIFF
--- a/module/plugins/hoster/OneFichierCom.py
+++ b/module/plugins/hoster/OneFichierCom.py
@@ -19,8 +19,7 @@ class OneFichierCom(SimpleHoster):
     
     DOWNLOAD_LINK_PATTERN = r'<br/>&nbsp;<br/>&nbsp;<br/>&nbsp;\s+<a href="(?P<url>http://.*?)"'       
     PASSWORD_PROTECTED_TOKEN = "protected by password"
-    WAITING_PATTERN = "you must wait (\d+) minutes"
-    
+    WAITING_PATTERN = "Warning ! Without premium status, you can download only one file at a time and you must wait at least (\d+) minutes between each downloads."
     def process(self, pyfile):
         found = re.search(self.__pattern__, pyfile.url)
         file_id = found.group(2)      


### PR DESCRIPTION
Hi,

I don't know if I'm in the right place to submit user plugins changes but I don't know where "user plugins" are hosted.

I was encoutering a problem with the user plugin "OneFichierCom.py" actually there is 5 minute to wait between each download. The plugin wasn't waiting 5 minutes, was creating 8 KB file on file system and was marking the download as "finished".
It was really disturbing.

As said in the commit message, the problem was that the sentence saying to wait has changed.
I fixed the following attribute of "OneFichierCom" class:
WAITING_PATTERN

It now works perfectly.

Best regards,

imclem.
