### PR TITLE
Fixing OneFichierCom from user plugins

### DIFF
--- a/module/plugins/hoster/OneFichierCom.py
+++ b/module/plugins/hoster/OneFichierCom.py
@@ -7,10 +7,11 @@ class OneFichierCom(SimpleHoster):
     __name__ = "OneFichierCom"
     __type__ = "hoster"
     __pattern__ = r"(http://(\w+)\.((1fichier|d(es)?fichiers|pjointe)\.(com|fr|net|org)|(cjoint|mesfichiers|piecejointe|oi)\.(org|net)|tenvoi\.(com|org|net)|dl4free\.com|alterupload\.com|megadl.fr))"
-    __version__ = "0.44"
+    __version__ = "0.45"
     __description__ = """1fichier.com download hoster"""
-    __author_name__ = ("fragonib", "the-razer", "zoidberg")
-    __author_mail__ = ("fragonib[AT]yahoo[DOT]es", "daniel_ AT gmx DOT net", "zoidberg@mujmail.cz")
+    __author_name__ = ("fragonib", "the-razer", "zoidberg","imclem")
+    __author_mail__ = ("fragonib[AT]yahoo[DOT]es", "daniel_ AT gmx DOT net",
+    "zoidberg@mujmail.cz","imclem on github")
     
     FILE_NAME_PATTERN = r'">File name :</th>\s*<td>(?P<N>[^<]+)</td>'
     FILE_SIZE_PATTERN = r'<th>File size :</th>\s*<td>(?P<S>[^<]+)</td>'


### PR DESCRIPTION
Hi,

I don't know if I'm in the right place to submit user plugins changes but I don't know where "user plugins" are hosted.

I was encoutering a problem with the user plugin "OneFichierCom.py" actually there is 5 minute to wait between each download. The plugin wasn't waiting 5 minutes, was creating 8 KB file on file system and was marking the download as "finished".
It was really disturbing.

As said in the commit message, the problem was that the sentence saying to wait has changed.
I fixed the following attribute of "OneFichierCom" class:
WAITING_PATTERN

It now works perfectly.

Best regards,

imclem.
