### PR TITLE
Add plugin for ZDF mediathek

### DIFF
--- a/module/plugins/hoster/ZDF.py
+++ b/module/plugins/hoster/ZDF.py
@@ -7,7 +7,7 @@ from module.plugins.Hoster import Hoster
 XML_API = "http://www.zdf.de/ZDFmediathek/xmlservice/web/beitragsDetails?id=%i"
 
 class ZDF(Hoster):
-    # Based on zdfm
+    # Based on zdfm by Roland Beermann
     # http://github.com/enkore/zdfm/
     __name__ = "ZDF Mediathek"
     __version__ = "0.7"


### PR DESCRIPTION
The ZDF Mediathek is a german website providing recordings of the german television broadcaster ZDF.

Supersedes #50 for merge into stable
