### PR TITLE
Fixed incorrect use of rstrip()

### DIFF
--- a/module/plugins/hoster/MegaNz.py
+++ b/module/plugins/hoster/MegaNz.py
@@ -55,7 +55,7 @@ class MegaNz(Hoster):
             self.fail(_("Decryption failed"))
 
         # Data is padded, 0-bytes must be stripped
-        return json.loads(attr.replace("MEGA", "").rsplit("\0")[0].strip())
+        return json.loads(attr.replace("MEGA", "").rstrip("\0").strip())
 
     def decryptFile(self, key):
         """  Decrypts the file at lastDownload` """


### PR DESCRIPTION
rstrip() ate the last "r" in .rar files. 

"The chars argument is not a suffix; rather, all combinations of its values are stripped"
(see http://docs.python.org/2/library/stdtypes.html#str.rstrip)

Using rsplit() instead.
