### PR TITLE
Wrote DownloadVimeoCom.

### DIFF
--- a/module/plugins/crypter/DownloadVimeoCom.py
+++ b/module/plugins/crypter/DownloadVimeoCom.py
@@ -8,7 +8,7 @@ from module.plugins.Crypter import Crypter
 class DownloadVimeoCom(Crypter):
 	__name__ = 'DownloadVimeoCom'
 	__type__ = 'crypter'
-	__pattern__ = r'(?:http://vimeo.com/\d*?|http://smotri.com/video/view/?id=.*)'
+	__pattern__ = r'(?:http://vimeo\.com/\d*|http://smotri\.com/video/view/\?id=.*)'
 	## The download from dailymotion failed with a 403
 	__version__ = '0.1'
 	__description__ = """Video Download Plugin based on downloadvimeo.com"""


### PR DESCRIPTION
The website is used to get the download URL from Vimeo.com, Smotri.com, and
Dailymotion.com. Some other video hosters are also supported but either there are already supported by other plugins or I could not find a video URL to test with http://downloadvimeo.com/.
