### PR TITLE
Plugin RestartFailed

### DIFF
--- a/module/plugins/hooks/RestartFailed.py
+++ b/module/plugins/hooks/RestartFailed.py
@@ -23,7 +23,7 @@ from time import time
 
 class RestartFailed(Hook):
     __name__ = "RestartFailed"
-    __version__ = "1.3"
+    __version__ = "1.5"
     __description__ = "Automatically restart failed/aborted downloads"
     __config__ = [
         ("activated", "bool", "Activated", "True"),
@@ -37,45 +37,36 @@ class RestartFailed(Hook):
     __author_name__ = ("Walter Purcaro")
     __author_mail__ = ("vuolter@gmail.com")
 
-    def setInterval(self, interval):
-        # self.logDebug("self.setInterval")
-        if interval != self.interval:
-            self.interval = interval
-
-    def restart(self):
+    def restart(self, arg=None):
         # self.logDebug("self.restart")
-        self.setInterval(0)
+        self.info["timerflag"] = False
         self.info["dlfailed"] = 0
         self.core.api.restartFailed()
         self.logDebug("self.restart: self.core.api.restartFailed")
-        now = time()
-        self.info["lastrstime"] = now
+        self.info["lastrstime"] = time()
 
     def periodical(self):
         # self.logDebug("self.periodical")
-        self.restart()
+        if self.info["timerflag"]:
+            self.restart()
 
-    def checkFailed_i(self):
-        # self.logDebug("self.checkFailed_i")
+    def checkInterval(self, arg=None):
+        # self.logDebug("self.checkInterval")
         now = time()
         lastrstime = self.info["lastrstime"]
         interval = self.getConfig("dlFail_i") * 60
         if now < lastrstime + interval:
-            self.setInterval(interval)
+            self.info["timerflag"] = True
         else:
             self.restart()
-
-    def checkFailed_n(self):
-        # self.logDebug("self.checkFailed_n")
-        curr = self.info["dlfailed"]
-        max = self.getConfig("dlFail_n")
-        if curr >= max:
-            self.checkFailed_i()
 
     def checkFailed(self, pyfile):
         # self.logDebug("self.checkFailed")
         self.info["dlfailed"] += 1
-        self.checkFailed_n()
+        curr = self.info["dlfailed"]
+        max = self.getConfig("dlFail_n")
+        if curr >= max:
+            self.checkInterval()
 
     def addEvent(self, event, handler):
         if event in self.manager.events:
@@ -99,38 +90,35 @@ class RestartFailed(Hook):
             # self.logDebug("self.removeEvent: " + event + ": NOT removed handler")
             return False
 
-    def onAfterReconnecting(self, ip):
-        # self.logDebug("self.onAfterReconnecting")
-        self.restart()
-
-    def configEvents(self, plugin, name, value):
+    def configEvents(self, plugin=None, name=None, value=None):
         # self.logDebug("self.configEvents")
-        if self.getConfig("dlFail"):
-            self.addEvent("downloadFailed", self.checkFailed)
+        self.interval = self.getConfig("dlFail_i") * 60
+        dlFail = self.getConfig("dlFail")
+        dlPrcs = self.getConfig("dlPrcs")
+        recnt = self.getConfig("recnt")
+        if dlPrcs:
+            self.addEvent("allDownloadsProcessed", self.checkInterval)
         else:
-            self.removeEvent("downloadFailed", self.checkFailed)
-            self.setInterval(0)
-        if self.getConfig("dlPrcs"):
-            self.addEvent("allDownloadsProcessed", self.restart)
+            self.removeEvent("allDownloadsProcessed", self.checkInterval)
+            if not dlFail:
+                self.info["timerflag"] = False
+        if recnt:
+            self.addEvent("afterReconnecting", self.restart)
         else:
-            self.removeEvent("allDownloadsProcessed", self.restart)
-        if self.getConfig("recnt"):
-            self.addEvent("afterReconnecting", self.onAfterReconnecting)
-        else:
-            self.removeEvent("afterReconnecting", self.onAfterReconnecting)
+            self.removeEvent("afterReconnecting", self.restart)
 
     def unload(self):
         # self.logDebug("self.unload")
         self.removeEvent("pluginConfigChanged", self.configEvents)
-        self.setInterval(0)
         self.removeEvent("downloadFailed", self.checkFailed)
-        self.removeEvent("allDownloadsProcessed", self.restart)
-        self.removeEvent("afterReconnecting", self.onAfterReconnecting)
+        self.removeEvent("allDownloadsProcessed", self.checkInterval)
+        self.removeEvent("afterReconnecting", self.restart)
 
     def coreReady(self):
         # self.logDebug("self.coreReady")
-        self.info = {"dlfailed": 0, "lastrstime": 0}
+        self.info = {"dlfailed": 0, "lastrstime": 0, "timerflag": False}
         if self.getConfig("rsLoad"):
             self.restart()
+        self.addEvent("downloadFailed", self.checkFailed)
         self.addEvent("pluginConfigChanged", self.configEvents)
-        self.configEvents(None, None, None)
+        self.configEvents()


### PR DESCRIPTION
Originally coded by forum user bambie, I've fully rewrited it using several api events. It is able to restart all failed and aborted downloads according to some settings.
