### PR TITLE
Changed the way of checking for offline youtube videos

### DIFF
--- a/module/plugins/hoster/YoutubeCom.py
+++ b/module/plugins/hoster/YoutubeCom.py
@@ -76,7 +76,7 @@ class YoutubeCom(Hoster):
     def process(self, pyfile):
         html = self.load(pyfile.url, decode=True)
 
-        if "watch-player-unavailable" in html:
+        if '<h1 id="unavailable-message" class="message">' in html:
             self.offline()
 
         if "We have been receiving a large volume of requests from your network." in html:


### PR DESCRIPTION
The other way didn't work, because the string doesn't always say "watch-player"

The new string appears in all blocked videos, like age, region blocked
