### PR TITLE
strip all whitespace chars from the end of the file name

### DIFF
--- a/module/plugins/hoster/EgoFilesCom.py
+++ b/module/plugins/hoster/EgoFilesCom.py
@@ -34,6 +34,7 @@ class EgoFilesCom(SimpleHoster):
     __author_mail__ = ("l.stickell@yahoo.it")
 
     FILE_INFO_PATTERN = r'<div class="down-file">\s+(?P<N>.+)\s+<div class="file-properties">\s+(File size|Rozmiar): (?P<S>[\w.]+) (?P<U>\w+) \|'
+    FILE_NAME_REPLACEMENTS = [(r'(\s+)$', '')]
     FILE_OFFLINE_PATTERN = r'(File size|Rozmiar): 0 KB'
     WAIT_TIME_PATTERN = r'For next free download you have to wait <strong>((?P<m>\d*)m)? ?((?P<s>\d+)s)?</strong>'
     DIRECT_LINK_PATTERN = r'<a href="(?P<link>[^"]+)">Download ></a>'


### PR DESCRIPTION
The egofiles.com plugin extracted the filename with some tabs after the extension of the file. The files were saved to disk with the additional chars.
