### PR TITLE
YoutubeCom.py: Fixed regular expression.

### DIFF
--- a/module/plugins/crypter/YoutubeBatch.py
+++ b/module/plugins/crypter/YoutubeBatch.py
@@ -11,8 +11,8 @@ API_KEY = "AIzaSyCKnWLNlkX-L4oD1aEzqqhRw1zczeD6_k0"
 class YoutubeBatch(Crypter):
     __name__ = "YoutubeBatch"
     __type__ = "container"
-    __pattern__ = r"http://(?:[^/]*?)youtube\.com/((?:view_play_list|playlist|.*?feature=PlayList).*?[\?&](?:list|p)=)([a-zA-Z0-9-_]+)"
-    __version__ = "0.92"
+    __pattern__ = r"https?://(?:[^/]*?)youtube\.com/(?:(?:view_play_list|playlist|.*?feature=PlayList).*?[?&](?:list|p)=)([a-zA-Z0-9-_]+)"
+    __version__ = "0.93"
     __description__ = """Youtube.com Channel Download Plugin"""
     __author_name__ = ("RaNaN", "Spoob", "zoidberg", "roland")
     __author_mail__ = ("RaNaN@pyload.org", "spoob@pyload.org", "zoidberg@mujmail.cz", "roland@enkore.de")
@@ -35,7 +35,7 @@ class YoutubeBatch(Crypter):
     def decrypt(self, pyfile):
         match_id = re.match(self.__pattern__, self.pyfile.url)
         new_links = []
-        playlist_id = match_id.group(2)
+        playlist_id = match_id.group(1)
 
         new_links.extend(self.get_videos(playlist_id))
 

--- a/module/plugins/hoster/YoutubeCom.py
+++ b/module/plugins/hoster/YoutubeCom.py
@@ -33,7 +33,7 @@ def which(program):
 class YoutubeCom(Hoster):
     __name__ = "YoutubeCom"
     __type__ = "hoster"
-    __pattern__ = r"https?://(?:www\.)?(?:de\.)?youtube\.com/watch.*?[?&]v=.*"
+    __pattern__ = r"https?://(?:[^/]*?)youtube\.com/watch.*?[?&]v=.*"
     __version__ = "0.32"
     __config__ = [("quality", "sd;hd;fullhd;240p;360p;480p;720p;1080p;3072p", "Quality Setting", "hd"),
         ("fmt", "int", "FMT/ITAG Number (5-102, 0 for auto)", 0),


### PR DESCRIPTION
My intention for this was to also match watch?feature=player_embedded&v=

Note that the original Regex used \y. This was probably a mistake. I am wondering why this worked. It seams that Python ignores any unknown (to Pyhton) meta character.
