### PR TITLE
Add support for metalarea.org

### DIFF
--- a/pyload/plugins/hoster/IfolderRu.py
+++ b/pyload/plugins/hoster/IfolderRu.py
@@ -24,9 +24,9 @@ from module.network.RequestFactory import getURL
 class IfolderRu(SimpleHoster):
     __name__ = "IfolderRu"
     __type__ = "hoster"
-    __pattern__ = r"http://(?:[^.]*\.)?(?:ifolder\.ru|rusfolder\.(?:com|net|ru))/(?:files/)?(?P<ID>\d+).*"
+    __pattern__ = r"http://(?:[^.]*\.)?(?:ifolder\.ru|metalarea\.org|rusfolder\.(?:com|net|ru))/(?:files/)?(?P<ID>\d+).*"
     __version__ = "0.37"
-    __description__ = """rusfolder.com / ifolder.ru"""
+    __description__ = """metalarea.org / rusfolder.com / ifolder.ru"""
     __author_name__ = ("zoidberg")
     __author_mail__ = ("zoidberg@mujmail.cz")
 


### PR DESCRIPTION
Hi,
I tried to add support for metalarea.org, that use ifolder for file sharing. It would be nice, if it would work in pyload, without manual overwriting every new link form that server. Please include it in pyload.
Didn't tested change yet.
Thanks
