### PR TITLE
To solve a slashes in filename (slash is usually a directory separator, but in some case).

### DIFF
--- a/module/network/HTTPChunk.py
+++ b/module/network/HTTPChunk.py
@@ -258,7 +258,7 @@ class HTTPChunk(HTTPRequest):
 
             if line.startswith("content-disposition") and "filename=" in line:
                 name = orgline.partition("filename=")[2]
-                name = name.replace('"', "").replace("'", "").replace(";", "").strip()
+                name = name.replace('"', "").replace("'", "").replace(";", "").replace("/", "_").strip()
                 self.p.nameDisposition = name
                 self.log.debug("Content-Disposition: %s" % name)
 


### PR DESCRIPTION
Some servers offers a filename with slashes which is against unix/linux filesystems. Added substitution to change all slashes to underscores in filename.
