### PR TITLE
Initial XupPl decrypter

### DIFF
--- a/module/plugins/crypter/XupPl.py
+++ b/module/plugins/crypter/XupPl.py
@@ -4,7 +4,7 @@ from module.plugins.Crypter import Crypter
 class XupPl(Crypter):
     __name__ = "XupPl"
     __type__ = "crypter"
-    __pattern__ = r"http(?:s)?://.*\.xup\.pl/.*"
+    __pattern__ = r"https?://.*\.xup\.pl/.*"
     __version__ = "0.1"
     __description__ = """Xup.pl Crypter Plugin"""
     __author_name__ = ("z00nx")


### PR DESCRIPTION
I've written a crypter plugin which is able to decrypt xup.pl links as requested in issue #100
I've tested the plugin with a few links and it works fine.
This plugin can be extended to work with other shortening services which use HTTP 301/302 redirections by extending the URL regex.
