### PR TITLE
WebInterface : Forms no longer hidden by the section menu

### DIFF
--- a/module/web/media/default/css/default.css
+++ b/module/web/media/default/css/default.css
@@ -1,3 +1,4 @@
+
 .hidden {
 	display:none;
 }
@@ -670,6 +671,13 @@ ul.tabs li a
 {
     display: inline;
 }
+
+#general_form,
+#plugin_form{
+	display: block;
+	padding-left: 250px;
+}
+
 
 #tabsback
 {


### PR DESCRIPTION
Just a small CSS enhancement, to push the forms to the right, in the config tabs. This way they are no longer hidden when hovering the selection menu...

HTH
