### PR TITLE
Update Captcha9kw.py

### DIFF
--- a/module/plugins/hooks/Captcha9kw.py
+++ b/module/plugins/hooks/Captcha9kw.py
@@ -38,8 +38,8 @@ class Captcha9kw(Hook):
                   ("captchaperhour", "int", "Captcha per hour (max. 9999)", "9999"),
                   ("prio", "int", "Prio 1-10 (Cost +1-10)", "0"),
                   ("selfsolve", "bool",
-                   "If enabled and you have a 9kw client active only you will get your captcha to solve it", "False"),
-                  ("timeout", "int", "Timeout (max. 300)", "220"),
+                   "If enabled and you have a 9kw client active only you will get your captcha to solve it (Selfsolve)", "False"),
+                  ("timeout", "int", "Timeout (max. 300)", "300"),
                   ("passkey", "password", "API key", ""), ]
     __author_name__ = ("RaNaN")
     __author_mail__ = ("RaNaN@pyload.org")


### PR DESCRIPTION
Reason for "Selfsolve" (word) only for say to the users "activate selfsolve (9kw) in the tool pyload".

And for 300 default timeout, from 9kw.eu FAQ, quote:
"What happens when there is no user present?
In that case several possibilities are provided. After a maximum of 60 seconds the alternative system takes over and has another 30 seconds to find a solution in a different way. Optimally that should take 5-30 seconds. Each user has a maximum of 30 seconds to a captcha to solve up to maximum 300 seconds for up to 5 users. Only for captchas with timeout 300 or higher. "
