### PR TITLE
Filestube fix

### DIFF
--- a/module/plugins/crypter/FilestubeCom.py
+++ b/module/plugins/crypter/FilestubeCom.py
@@ -37,7 +37,7 @@ class FilestubeCom(SimpleCrypter):
         matches = re.findall('^(.*?)$', linklist)
         return matches
       else:
-        matches = re.findall(self.LINK_PATTERN, self.html)
+        matches = re.findall(self.LINK_PATTERN2, self.html)
         if matches:
           return matches
         else:


### PR DESCRIPTION
Filestube apparently does not always give pages containing the renderGo()-links, I've changed it to take the links inside `<pre>..</pre>` first and, if there are none of them, look for the green "Download Now!" buttons...
