### PR TITLE
Unrar 5.x Support

### DIFF
--- a/module/plugins/internal/UnRar.py
+++ b/module/plugins/internal/UnRar.py
@@ -33,9 +33,11 @@ class UnRar(AbtractExtractor):
     __version__ = "0.14"
 
     # there are some more uncovered rar formats
+    re_version = re.compile(r"(UNRAR 5[\.\d]+ freeware)")
     re_splitfile = re.compile(r"(.*)\.part(\d+)\.rar$", re.I)
     re_partfiles = re.compile(r".*\.(rar|r[0-9]+)", re.I)
     re_filelist = re.compile(r"(.+)\s+(\d+)\s+(\d+)\s+")
+    re_filelist5 = re.compile(r"(.+)\s+(\d+)\s+\d\d-\d\d-\d\d\s+\d\d:\d\d\s+(.+)")
     re_wrongpwd = re.compile("(Corrupt file or wrong password|password incorrect)", re.I)
     CMD = "unrar"
 
@@ -91,10 +93,16 @@ class UnRar(AbtractExtractor):
             return True
 
         # output only used to check if passworded files are present
-        for name, size, packed in  self.re_filelist.findall(out):
-            if name.startswith("*"):
-                self.passwordProtected = True
-                return True
+        if self.re_version.search(out):
+            for attr, size, name in  self.re_filelist5.findall(out):
+                if attr.startswith("*"):
+                    self.passwordProtected = True
+                    return True
+        else:
+            for name, size, packed in  self.re_filelist.findall(out):
+                if name.startswith("*"):
+                    self.passwordProtected = True
+                    return True
 
         self.listContent()
         if not self.files:


### PR DESCRIPTION
With Unrar 5.x the ExtractArchive plugin doesn't work for password protected archives. The reason for this is that the output of Unrar has changed. Therefore, the script must use a different regex pattern to parse the received data.

This new version of the plugin does essentially that after determining whether Unrar 5.x is used.

Take a look at http://forum.pyload.org/viewtopic.php?f=12&t=3308 for further readings.
