### PR TITLE
Update XFileSharingPro.py

### DIFF
--- a/module/plugins/hoster/XFileSharingPro.py
+++ b/module/plugins/hoster/XFileSharingPro.py
@@ -52,7 +52,7 @@ class XFileSharingPro(SimpleHoster):
     OVR_KILL_LINK_PATTERN = r'<h2>Delete Link</h2>\s*<textarea[^>]*>([^<]+)'
     CAPTCHA_URL_PATTERN = r'(http://[^"\']+?/captchas?/[^"\']+)'
     RECAPTCHA_URL_PATTERN = r'http://[^"\']+?recaptcha[^"\']+?\?k=([^"\']+)"'
-    CAPTCHA_DIV_PATTERN = r'Enter code.*?<div.*?>(.*?)</div>'
+    CAPTCHA_DIV_PATTERN = r'>Enter code.*?<div.*?>(.*?)</div>'
     SOLVEMEDIA_PATTERN = r'http:\/\/api\.solvemedia\.com\/papi\/challenge\.script\?k=(.*?)"'
     ERROR_PATTERN = r'class=["\']err["\'][^>]*>(.*?)</'
 


### PR DESCRIPTION
fixed XFileSharingPro to work with xvidstage.com

I changed re.S into re.DOTALL for readability and, if I understand correctly, then DOTALL doesn't have any effect at all without MULTILINE. 
Second, it seemed kind of arbitrary to require "Enter code" to be in bold.
In any case, both changes are necessary for xvidstage to work.
