### PR TITLE
New Event "packageFinishedUnrar" when there are no more archives to extract in a package

### DIFF
--- a/module/plugins/hooks/ExternalScripts.py
+++ b/module/plugins/hooks/ExternalScripts.py
@@ -28,18 +28,18 @@ from module.utils import save_join
 
 class ExternalScripts(Hook):
     __name__ = "ExternalScripts"
-    __version__ = "0.23"
+    __version__ = "0.24"
     __description__ = """Run external scripts"""
     __config__ = [("activated", "bool", "Activated", True)]
     __author_name__ = ("mkaay", "RaNaN", "spoob")
     __author_mail__ = ("mkaay@mkaay.de", "ranan@pyload.org", "spoob@pyload.org")
 
-    event_list = ["unrarFinished", "allDownloadsFinished", "allDownloadsProcessed"]
+    event_list = ["unrarFinished", "packageFinishedUnrar", "allDownloadsFinished", "allDownloadsProcessed"]
 
     def setup(self):
         self.scripts = {}
 
-        folders = ['download_preparing', 'download_finished', 'package_finished',
+        folders = ['download_preparing', 'download_finished', 'package_finished', 'package_finished_unrar',
                    'before_reconnect', 'after_reconnect', 'unrar_finished',
                    'all_dls_finished', 'all_dls_processed']
 
@@ -91,6 +91,13 @@ class ExternalScripts(Hook):
 
     def packageFinished(self, pypack):
         for script in self.scripts['package_finished']:
+            folder = self.config['general']['download_folder']
+            folder = save_join(folder, pypack.folder)
+
+            self.callScript(script, pypack.name, folder, pypack.password, pypack.id)
+
+    def packageFinishedUnrar(self, pypack):
+        for script in self.scripts['package_finished_unrar']:
             folder = self.config['general']['download_folder']
             folder = save_join(folder, pypack.folder)
 

--- a/module/plugins/hooks/ExtractArchive.py
+++ b/module/plugins/hooks/ExtractArchive.py
@@ -58,7 +58,7 @@ class ExtractArchive(Hook):
     Provides: unrarFinished (folder, filename)
     """
     __name__ = "ExtractArchive"
-    __version__ = "0.16"
+    __version__ = "0.17"
     __description__ = """Extract different kind of archives"""
     __config__ = [("activated", "bool", "Activated", True),
                   ("fullpath", "bool", "Extract full path", True),
@@ -197,6 +197,8 @@ class ExtractArchive(Hook):
 
             if not matched:
                 self.logInfo(_("No files found to extract"))
+
+            self.manager.dispatchEvent("packageFinishedUnrar", p)
 
     def startExtracting(self, plugin, fid, passwords, thread):
         pyfile = self.core.files.getFile(fid)


### PR DESCRIPTION
I am using the ExternalScript Hook to run scripts as soon as unrar_finished is triggered.

When there are rar-archives inside rar-archives, of course pyload triggers unrar_finished multiple times. 
While this is certainly correct, it is sometimes useful to wait for the last archive to be extracted before doing executing scripts. Imagine I want to use a script to work on every extracted file in the package folder. When I use "unrar_finished", the script has to check for other running unrar processes and wait for them to finish and it has to deal with the possibility of having multiple instances of itself running. 

What I would like to have, is an event that triggers when all archives in a package are extracted. Would be easier for external scripts because you don't have to check for race conditions.

ExtractArchive Hook dispatches a new event: "packageFinishedUnrar" 
when there are no more files to extract in a package

ExternalScript Hook listens to the new event "packageFinishedUnrar"
and calls external scripts in folder "package_finished_unrar" with the
arguments "package name", "package folder", "package password", "package id" (same as packageFinished)
