### PR TITLE
Fix cookie issues

### DIFF
--- a/pyload/network/CookieJar.py
+++ b/pyload/network/CookieJar.py
@@ -9,11 +9,21 @@ class CookieJar(SimpleCookie):
         return self[name].value
 
     def setCookie(self, domain, name, value, path="/", exp=None, secure="FALSE"):
-        if not exp: exp = time() + 3600 * 24 * 180
-
         self[name] = value
         self[name]["domain"] = domain
         self[name]["path"] = path
-        self[name]["expires"] = exp
+        
+        #Value of expires should be integer if possible
+        # otherwise the cookie won't be used
+        expire=0
+        if not exp:
+	        expires = time() + 3600 * 24 * 180
+        else:
+            try:
+                expires = int(exp)
+            except ValueError:
+                expires = exp
+        
+        self[name]["expires"] = expires
         if secure == "TRUE":
             self[name]["secure"] = secure


### PR DESCRIPTION
The Account-Page didn't show any Values on 'Traffic left' and 'Valid
until' for my Premium Account. Therefore no premium download was
possible. The Problem occured on ArchLinux and FreeBSD, but somehow not
on Ubuntu.
With this fix the cookies will be uses as they should.
