### PR TITLE
Fix accounts trafficleft

### DIFF
--- a/pyload/web/app/scripts/helpers/formatSize.js
+++ b/pyload/web/app/scripts/helpers/formatSize.js
@@ -3,7 +3,11 @@ define('helpers/formatSize', ['handlebars', 'utils/i18n'], function(Handlebars, 
     'use strict';
 
     var sizes = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB'];
-    function formatSize(bytes, options) {
+    function formatSize(bytes, options, multiplier) {
+        //multiplier 1024 is used for trafficleft because trafficleft is in KiB
+        if (typeof multiplier === 'number')
+           bytes = bytes * multiplier;
+        
         if (!bytes || bytes === 0) return '0 B';
         if (bytes === -1)
             return i18n.gettext('not available');

--- a/pyload/web/app/templates/default/accounts/account.html
+++ b/pyload/web/app/templates/default/accounts/account.html
@@ -22,7 +22,7 @@
 </div>
 <div class="span2 account-data">
     {{_ "Traffic left:"}}<br>
-    {{ formatSize trafficleft }}
+    {{ formatSize trafficleft 0 1024 }}
 </div>
 <div class="span2 account-data">
     {{_ "Valid until:"}}<br>


### PR DESCRIPTION
The Accounts Page shows the value for 'Traffic Left' as 'MiB' instead of 'GiB'.
Afaik this is because the traffic is internally everywhere in KiB, so i multiply it by 1024.
(Problem occured with Hoster UploadedTo)
