### PR TITLE
share-links.biz (click'n load v2) fix

### DIFF
--- a/module/web/cnl_app.py
+++ b/module/web/cnl_app.py
@@ -18,7 +18,8 @@ except:
 def local_check(function):
     def _view(*args, **kwargs):
         if request.environ.get('REMOTE_ADDR', "0") in ('127.0.0.1', 'localhost') \
-        or request.environ.get('HTTP_HOST','0') == '127.0.0.1:9666':
+        or request.environ.get('HTTP_HOST','0') == '127.0.0.1:9666' \
+        or request.environ.get('HTTP_HOST','0') == 'localhost:9666':
             return function(*args, **kwargs)
         else:
             return HTTPError(403, "Forbidden")


### PR DESCRIPTION
share-links.biz uses the alias 'localhost' for click'n load instead of '127.0.0.1'.
