### PR TITLE
Added folder-support for filer.net

### DIFF
--- a/module/plugins/crypter/FilerNetFolder.py
+++ b/module/plugins/crypter/FilerNetFolder.py
@@ -15,5 +15,5 @@ class FilerNetFolder(SimpleCrypter):
   TITLE_PATTERN = r'<h3>(?P<title>.+) - <small'
 
   def getLinks(self):
-    f: lambda url: "http:filer.net/get/" + re.search(r'\w{16}', url).group(0)
-    return uniqify(map(f, re.finall(self.LINK_PATTERN, self.html)))
+    f = lambda url: "http://filer.net/get/" + re.search(r'\w{16}', url).group(0)
+    return uniqify(map(f, re.findall(self.LINK_PATTERN, self.html)))


### PR DESCRIPTION
Simple. Crypter parses urls from filer.net/folder/, creates a new package with the parsed download urls. The hoster-plugin takes care of the rest.
