### PR TITLE
[Hook] JustPremium

### DIFF
--- a/module/plugins/hooks/JustPremium.py
+++ b/module/plugins/hooks/JustPremium.py
@@ -22,55 +22,58 @@ from module.plugins.Hoster import Hoster
 
 class JustPremium(Hook):
     __name__ = "JustPremium"
-    __version__ = "0.15"
+    __version__ = "0.16"
     __description__ = "If you add multiple links with at least one premium hoster link, all non premium links get removed"
     __config__ = [("activated", "bool", "Activated", "False"),
-    		  ("freehosters","bool", "Allow all freehosters and other unknown sites", "false"),
+                  ("freehosters","bool", "Allow all freehosters and other unknown sites", "false"),
                   ("nicehoster", "str", "unblock this hosters (comma seperated)", "Zippyshare.com")]
-                  
+
     __author_name__ = ("mazleu")
     __author_mail__ = ("mazleica@gmail.com")
 
     event_list = ["linksAdded"]
-    
-    def coreReady(self) :						         
+
+    def coreReady(self) :
         accs=str(self.core.accountManager.getAccountInfos())
-	global badhosts							         
-	global hosts						
-	hosts = ""							         
-	while "[{" in accs:						          
-	    startid=accs.rfind("[], ", 0, accs.find("[{"))+2
-	    endid=accs.find("}]",startid)+2
-	    hosts=hosts+","+accs[startid+3:accs.find("'",startid+3)]
-	    accs=accs[0:startid]+accs[endid:]
-	badhosts=accs.replace("': [], '",",")[2:-6]   		                
-	hosts=hosts[1:]
-	hosts=hosts+","+self.getConfig("nicehoster")
-	self.logDebug("good hosts:",hosts)	
-        self.logDebug("bad hosts:",badhosts)	
+        global badhosts
+        global hosts
+        hosts = ""
+        while "[{" in accs:
+            startid=accs.rfind("[], ", 0, accs.find("[{"))+2
+            endid=accs.find("}]",startid)+2
+            hosts=hosts+","+accs[startid+3:accs.find("'",startid+3)]
+            accs=accs[0:startid]+accs[endid:]
+        badhosts=accs.replace("': [], '",",")[2:-6]
+        hosts=hosts[1:]
+        hosts=hosts+","+self.getConfig("nicehoster")
+        self.logDebug("good hosts:",hosts)
+        self.logDebug("bad hosts:",badhosts)
 
 
-    def filterLinks(self, t):						        
-        links = self.core.api.checkURLs(t)				
+    def filterLinks(self, t):
+        links = self.core.api.checkURLs(t)
         hosterlist =""
-	bhosters = [x.strip() for x in badhosts.split(",")]
-	ghosters = [x.strip() for x in hosts.split(",")]
-	premhoster = False
-	for hoster in links:
-	    self.logDebug(hoster)
+        bhosters = [x.strip() for x in badhosts.split(",")]
+        ghosters = [x.strip() for x in hosts.split(",")]
+        premhoster = False
+        for hoster in links:
+            self.logDebug(hoster)
             if hoster in ghosters:
                 premhoster = True
-	if premhoster :
-	    for hoster in links:
-		if self.getConfig("freehosters"):
-		    if hoster in bhosters:
-			for link in links[hoster]:
-			    t.remove(link)
-			    self.logDebug("removed link '%s'because hoster was: '%s' " % (link,hoster))     
-		else:	
-		    if not hoster in ghosters:
-		        for link in links[hoster]:
-			    t.remove(link)
-			    self.logDebug("removed link '%s'because hoster was: '%s' " % (link,hoster))
+                self.logDebug ("Found at least one hoster with account")
+        if premhoster :
+            for hoster in links:
+                if self.getConfig("freehosters"):
+                    if hoster in bhosters:
+                        self.logInfo("remove links from hoster '%s' " % (hoster))
+                        for link in links[hoster]:
+                            t.remove(link)
+                            self.logDebug("remove link '%s'because hoster was: '%s' " % (link,hoster))
+                else:
+                    if not hoster in ghosters:
+                        self.logInfo("remove links from hoster '%s' " % (hoster))
+                        for link in links[hoster]:
+                            t.remove(link)
+                            self.logDebug("remove link '%s' because hoster was: '%s' " % (link,hoster))
     def linksAdded(self, links, pid):
         self.filterLinks(links)

--- a/module/plugins/hooks/JustPremium.py
+++ b/module/plugins/hooks/JustPremium.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License,
+    or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+    @author: mazleu
+"""
+from module.plugins.Hook import Hook
+from module.plugins.Account import Account
+from module.plugins.Hoster import Hoster
+
+
+class JustPremium(Hook):
+    __name__ = "JustPremium"
+    __version__ = "0.15"
+    __description__ = "If you add multiple links with at least one premium hoster link, all non premium links get removed"
+    __config__ = [("activated", "bool", "Activated", "False"),
+    		  ("freehosters","bool", "Allow all freehosters and other unknown sites", "false"),
+                  ("nicehoster", "str", "unblock this hosters (comma seperated)", "Zippyshare.com")]
+                  
+    __author_name__ = ("mazleu")
+    __author_mail__ = ("mazleica@gmail.com")
+
+    event_list = ["linksAdded"]
+    
+    def coreReady(self) :						         
+        accs=str(self.core.accountManager.getAccountInfos())
+	global badhosts							         
+	global hosts						
+	hosts = ""							         
+	while "[{" in accs:						          
+	    startid=accs.rfind("[], ", 0, accs.find("[{"))+2
+	    endid=accs.find("}]",startid)+2
+	    hosts=hosts+","+accs[startid+3:accs.find("'",startid+3)]
+	    accs=accs[0:startid]+accs[endid:]
+	badhosts=accs.replace("': [], '",",")[2:-6]   		                
+	hosts=hosts[1:]
+	hosts=hosts+","+self.getConfig("nicehoster")
+	self.logDebug("good hosts:",hosts)	
+        self.logDebug("bad hosts:",badhosts)	
+
+
+    def filterLinks(self, t):						        
+        links = self.core.api.checkURLs(t)				
+        hosterlist =""
+	bhosters = [x.strip() for x in badhosts.split(",")]
+	ghosters = [x.strip() for x in hosts.split(",")]
+	premhoster = False
+	for hoster in links:
+	    self.logDebug(hoster)
+            if hoster in ghosters:
+                premhoster = True
+	if premhoster :
+	    for hoster in links:
+		if self.getConfig("freehosters"):
+		    if hoster in bhosters:
+			for link in links[hoster]:
+			    t.remove(link)
+			    self.logDebug("removed link '%s'because hoster was: '%s' " % (link,hoster))     
+		else:	
+		    if not hoster in ghosters:
+		        for link in links[hoster]:
+			    t.remove(link)
+			    self.logDebug("removed link '%s'because hoster was: '%s' " % (link,hoster))
+    def linksAdded(self, links, pid):
+        self.filterLinks(links)


### PR DESCRIPTION
Justpremium V0.16 [hook for pyload]

Update to V0.16 - 8.8.2014

English

Function:
If you add multiple links and one of it is from a registered premium hoster, all links from non-premium hosters will automatically be removed.

Example:
A DLC with links to uploaded.net, shareonline.biz and zippyfiles.com is added. If you have only an account for uploaded.net, then the two other hosters will be removed.

Options:
unblock this hosters (comma separated): all hosters here (pyloadformat) won't be removed. E.g. use it for your favourite freehoster.
Allow all freehosters and other unknown sites: If this option is activated, only links from hosters available in the pyload "Accounts" list but without account will be removed.

Deutsch

Funktion:
Wenn mehrere Links hinzugefügt werden, und sich darunter einer von einem eingetragenem Hoster befindet, dann werden die Links von allen nicht eingetragenen Hostern entfernt.

Beispiel:
Ein DLC mit Links zu uploaded.net, shareonline.biz und zippyfiles.com wird zugefügt. Ist nur bei uploaded.net ein Konto vorhanden, so werden die beiden anderen Links gelöscht.

Optionen:
unblock this hosters (comma separated): Alle hier eingetragenen Hoster (im pyloadformat) werden nie geblockt. Kann zB für einen Lieblings Freehoster genutzt werden.
Allow all freehosters and other unknown sites: Ist diese Option aktiviert, werden nur die Links von Accounts, die unter "Konten" ausgewählt werden können und nicht registriert sind, entfernt, sonnst werden alle bis auf die registrierten entfernt.

Changelog
V0.16: Enhanced logging: Removed Hosters are tracked
V0.15: Rewrite the whole hook
V0.1: First version
