### PR TITLE
Fix wait for UptoBox

### DIFF
--- a/module/plugins/hoster/XFileSharingPro.py
+++ b/module/plugins/hoster/XFileSharingPro.py
@@ -215,7 +215,7 @@ class XFileSharingPro(SimpleHoster):
 
             if 'wait' in self.errmsg:
                 wait_time = sum([int(v) * {"hour": 3600, "minute": 60, "second": 1}[u] for v, u in
-                                 re.findall(r'(\d+)\s*(hour|minute|second)?', self.errmsg)])
+                                 re.findall(r'(\d+)\s*(hour|minute|second)', self.errmsg)])
                 self.wait(wait_time, True)
             elif 'captcha' in self.errmsg:
                 self.invalidCaptcha()


### PR DESCRIPTION
When downloading a file right after having downloaded one on UptoBox, you get this message in the html page :

<center><b>You have to wait 14 minutes, 59 seconds till next download.<br /><br />Download files instantly with <a href='http://uptobox.com/?op=payments' class="blue_link" style="font-size:12px;">Premium-account</a>.</b>

The current result of re.findall(r'(\d+)\s*(hour|minute|second)', self.errmsg) is:
[('14', 'minute'), ('59', 'second'), ('12', '')] and an exception is thrown when computing the wait time because of the third element of the list.

The '?' should be removed from the regexp.
