### PR TITLE
Fix for zippyshare checksums

### DIFF
--- a/module/plugins/hoster/ZippyshareCom.py
+++ b/module/plugins/hoster/ZippyshareCom.py
@@ -41,12 +41,16 @@ class ZippyshareCom(SimpleHoster):
         """returns the absolute downloadable filepath"""
         url_parts = re.search(r'(addthis:url="(http://www(\d+).zippyshare.com/v/(\d*)/file.html))', self.html)
         number = url_parts.group(4)
-        check = re.search(r'<script type="text/javascript">[^<]*var a = (\d*)%(\d*);', self.html)
-        if check:
+        check_a = re.search(r'<script type="text/javascript">[^<]*var a = (\d*)%(\d*);', self.html)
+        if check_a:
             # Checksum is calculated as (a*b+19), where a and b are the result of modulo calculations
-            a_value = check.groups()
-            b_value = re.search(r'<script type="text/javascript">[^<]*var b = (\d*)%(\d*);', self.html).groups()
-            checksum = int(a_value[0]) % int(a_value[1]) * int(b_value[0]) % int(b_value[1]) + 19
+            check_b = re.search(r'<script type="text/javascript">[^<]*var b = (\d*)%(\d*);', self.html)
+            if check_b:
+                a_value = check_a.groups()
+                b_value = check_b.groups()
+                checksum = int(a_value[0]) % int(a_value[1]) * int(b_value[0]) % int(b_value[1]) + 19
+            else:
+                self.parseError("Unable to extract B values")
         else:
             # This might work but is insecure
             # checksum = eval(re.search("((\d*)\s\%\s(\d*)\s\+\s(\d*)\s\%\s(\d*))", self.html).group(0))


### PR DESCRIPTION
Update ZippyshareCom.py such that it matches the way that Zippyshare currently generate checksums (a*b+19)
