### PR TITLE
Fix free space calculation

### DIFF
--- a/module/utils.py
+++ b/module/utils.py
@@ -110,7 +110,7 @@ def freeSpace(folder):
         from os import statvfs
 
         s = statvfs(folder)
-        return s.f_bsize * s.f_bavail
+        return s.f_frsize * s.f_bavail
 
 
 def uniqify(seq, idfun=None):


### PR DESCRIPTION
Use fundamental block size to calculate free byte count.
Preferred blocks are not guaranteed to line up with real filesystem blocks.
f_bavail is measured in real filesystem blocks.

(In my case the current calculation is off by a factor of 8, resulting in the free space calculated as being quite a bit larger than the total possible disk space in that directory. However, the off-ness can vary wildly between different hardware and software setups.)
