### PR TITLE
Broken TRAFFIC_LEFT_PATTERN in RapidfileshareNet and TusfilesNet accounts.

### DIFF
--- a/module/plugins/accounts/RapidfileshareNet.py
+++ b/module/plugins/accounts/RapidfileshareNet.py
@@ -13,6 +13,7 @@ class RapidfileshareNet(XFSPAccount):
     __authors__ = [("guidobelix", "guidobelix@hotmail.it")]
 
 
+    HOSTER_NAME = "rapidfileshare.net"
     HOSTER_URL = "http://www.rapidfileshare.net/"
 
     TRAFFIC_LEFT_PATTERN = r'>Traffic available today:</TD><TD><label for="name">\s*(?P<S>[\d.,]+)\s*(?:(?P<U>[\w^_]+)\s*)?</label></TD></TR>'

--- a/module/plugins/accounts/TusfilesNet.py
+++ b/module/plugins/accounts/TusfilesNet.py
@@ -18,6 +18,7 @@ class TusfilesNet(XFSPAccount):
     __authors__ = [("guidobelix", "guidobelix@hotmail.it")]
 
 
+    HOSTER_NAME = "tusfiles.net"
     HOSTER_URL = "http://www.tusfiles.net/"
 
     VALID_UNTIL_PATTERN = r'<span class="label label-default">([^<]+)</span>'


### PR DESCRIPTION
After the latest commits, remainig traffic is not read correctly anymore in RapidfileshareNet and TusfilesNet accounts; see below screenshot:
![schermata del 2014-10-22 18 47 17](https://cloud.githubusercontent.com/assets/7717069/4742474/4dccfe46-5a1f-11e4-9b9d-c1a80128e044.png)
The proposed changes fix the problem:
![schermata del 2014-10-22 20 44 26](https://cloud.githubusercontent.com/assets/7717069/4742497/7d119b8a-5a1f-11e4-8b63-cb3c89ace998.png)
