### PR TITLE
[Keep2shareCC] Added handling of large file error for free users

### DIFF
--- a/module/plugins/hoster/Keep2shareCC.py
+++ b/module/plugins/hoster/Keep2shareCC.py
@@ -11,7 +11,7 @@ from module.plugins.internal.SimpleHoster import SimpleHoster, create_getInfo
 class Keep2shareCC(SimpleHoster):
     __name__ = "Keep2shareCC"
     __type__ = "hoster"
-    __version__ = "0.13"
+    __version__ = "0.14"
 
     __pattern__ = r'https?://(?:www\.)?(keep2share|k2s|keep2s)\.cc/file/(?P<ID>\w+)'
 


### PR DESCRIPTION
If a user attempts to download a file larger than 500mb as a free user the following error will appear:
WARNING Download failed: <filename> | ReCaptcha key not found
