### PR TITLE
 [RestartFailed] Removed clutter message in normal mode

### DIFF
--- a/module/plugins/hooks/RestartFailed.py
+++ b/module/plugins/hooks/RestartFailed.py
@@ -32,7 +32,7 @@ class RestartFailed(Hook):
 
 
     def periodical(self):
-        self.logInfo(_("Restart failed downloads"))
+        self.logDebug(_("Restart failed downloads"))
         self.core.api.restartFailed()
 
 


### PR DESCRIPTION
The hook spams info messages every 15 minutes (default).

e.g.
786 04.11.2014 09:15:00 INFO    RestartFailed: Restart failed downloads
787 04.11.2014 09:30:02 INFO    RestartFailed: Restart failed downloads
788 04.11.2014 09:45:03 INFO    RestartFailed: Restart failed downloads
789 04.11.2014 10:00:05 INFO    RestartFailed: Restart failed downloads
790 04.11.2014 10:15:06 INFO    RestartFailed: Restart failed downloads
791 04.11.2014 10:30:08 INFO    RestartFailed: Restart failed downloads
792 04.11.2014 10:45:09 INFO    RestartFailed: Restart failed downloads
793 04.11.2014 11:00:11 INFO    RestartFailed: Restart failed downloads
794 04.11.2014 11:15:12 INFO    RestartFailed: Restart failed downloads
795 04.11.2014 11:30:14 INFO    RestartFailed: Restart failed downloads
796 04.11.2014 11:45:16 INFO    RestartFailed: Restart failed downloads
797 04.11.2014 12:00:17 INFO    RestartFailed: Restart failed downloads
798 04.11.2014 12:15:19 INFO    RestartFailed: Restart failed downloads 

Very annoying and unnecessary ^^
