### PR TITLE
UlozTo hoster and account fixes

### DIFF
--- a/module/plugins/accounts/UlozTo.py
+++ b/module/plugins/accounts/UlozTo.py
@@ -39,7 +39,8 @@ class UlozTo(Account):
 
         html = req.load('http://www.ulozto.net'+action, post={
             "_token_": token,
-            "login": "Submit",
+            "do": "loginForm-submit",
+            "login": u"Přihlásit",
             "password": data['password'],
             "username": user
         }, decode=True)

--- a/module/plugins/hoster/UlozTo.py
+++ b/module/plugins/hoster/UlozTo.py
@@ -37,7 +37,7 @@ class UlozTo(SimpleHoster):
     VIPLINK_PATTERN = r'<a href="[^"]*\?disclaimer=1" class="linkVip">'
     FREE_URL_PATTERN = r'<div class="freeDownloadForm"><form action="([^"]+)"'
     PREMIUM_URL_PATTERN = r'<div class="downloadForm"><form action="([^"]+)"'
-    TOKEN_PATTERN = r'<input type="hidden" name="_token_" id="[^\"]*" value="(?P<token>[^\"]*)" />'
+    TOKEN_PATTERN = r'<input type="hidden" name="_token_" id="[^\"]*" value="(?P<token>[^\"]*)">'
 
 
     def setup(self):

--- a/module/plugins/internal/SimpleHoster.py
+++ b/module/plugins/internal/SimpleHoster.py
@@ -324,7 +324,7 @@ class SimpleHoster(Hoster):
 
 
     def getFileInfo(self):
-        name, size, status, url = parseFileInfo(self)
+        name, size, status, url = parseFileInfo(self, html=self.html)
 
         if name and name != url:
             self.pyfile.name = name


### PR DESCRIPTION
This patch fixes premium account and adult confimation.

I'm not quite sure about SimpleHoster.getFileInfo modification but without this hack parsing file size for adult links doesn't work as pyLoad fetches the URL again and doesn't confirm age.
