### PR TITLE
UptoboxCom fix to manage wait time correctly

### DIFF
--- a/module/plugins/hoster/TurbobitNet.py
+++ b/module/plugins/hoster/TurbobitNet.py
@@ -17,7 +17,7 @@ from module.plugins.internal.SimpleHoster import SimpleHoster, create_getInfo, t
 class TurbobitNet(SimpleHoster):
     __name__    = "TurbobitNet"
     __type__    = "hoster"
-    __version__ = "0.15"
+    __version__ = "0.14"
 
     __pattern__ = r'http://(?:www\.)?turbobit\.net/(?:download/free/)?(?P<ID>\w+)'
 


### PR DESCRIPTION
I noticed that the UptoboxCom plugin was not catching the "wait" pattern but was waiting for a default 1 minute delay.
It caused plugin retries and in the end a download failure.
