### PR TITLE
Little BugFix in FilecryptCc.py

### DIFF
--- a/module/plugins/crypter/FilecryptCc.py
+++ b/module/plugins/crypter/FilecryptCc.py
@@ -58,7 +58,7 @@ class FilecryptCc(Crypter):
 
         mirror = re.findall(self.MIRROR_PAGE_PATTERN, self.siteWithLinks)
 
-        self.logInfo(_("Found %d mirrors") % len(m))
+        self.logInfo(_("Found %d mirrors") % len(mirror))
 
         for i in mirror[1:]:
             self.siteWithLinks = self.siteWithLinks + self.load(i, cookies=True).decode("utf-8", "replace")


### PR DESCRIPTION
File "/etc/pyload/userplugins/crypter/FilecryptCc.py", line 61, in handleMirrorPages
    self.logInfo(_("Found %d mirrors") % len(m))
NameError: global name 'm' is not defined

Solved: Changed Variable 'm' to 'mirror'.
