### PR TITLE
socket.create_connection is unavailable in Python25

### DIFF
--- a/module/plugins/hooks/ClickAndLoad.py
+++ b/module/plugins/hooks/ClickAndLoad.py
@@ -17,11 +17,40 @@ def forward(source, destination):
         else:
             destination.shutdown(socket.SHUT_WR)
 
+_GLOBAL_DEFAULT_TIMEOUT = object()
+def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT):
+    """Connect to *address* and return the socket object.
 
+    Convenience function.  Connect to *address* (a 2-tuple ``(host,
+    port)``) and return the socket object.  Passing the optional
+    *timeout* parameter will set the timeout on the socket instance
+    before attempting to connect.  If no *timeout* is supplied, the
+    global default timeout setting returned by :func:`getdefaulttimeout`
+    is used.
+    """
+
+    msg = "getaddrinfo returns an empty list"
+    host, port = address
+    for res in getaddrinfo(host, port, 0, socket.SOCK_STREAM):
+        af, socktype, proto, canonname, sa = res
+        sock = None
+        try:
+            sock = socket(af, socktype, proto)
+            if timeout is not _GLOBAL_DEFAULT_TIMEOUT:
+                sock.settimeout(timeout)
+            sock.connect(sa)
+            return sock
+
+        except error, msg:
+            if sock is not None:
+                sock.close()
+
+    raise error, msg
+    
 class ClickAndLoad(Hook):
     __name__    = "ClickAndLoad"
     __type__    = "hook"
-    __version__ = "0.26"
+    __version__ = "0.27"
 
     __config__ = [("activated", "bool", "Activated"                                     , True ),
                   ("port"     , "int" , "Port"                                          , 9666 ),
@@ -62,7 +91,7 @@ class ClickAndLoad(Hook):
 
             while True:
                 server_socket = dock_socket.accept()[0]
-                client_socket = socket.create_connection(("127.0.0.1", webport))
+                client_socket = create_connection(("127.0.0.1", webport))
 
                 hookManager.startThread(forward, server_socket, client_socket)
                 hookManager.startThread(forward, client_socket, server_socket)


### PR DESCRIPTION
socket.create_connection doesn't exist in Python 2.5.
But it can be modeled with above function taken from:
https://hg.python.org/cpython/file/2.6/Lib/socket.py#l534
So, it is how 2.6 does it :)