### PR TITLE
Fixed UploadedTo File not downloadable for free users

### DIFF
--- a/module/plugins/hoster/UploadedTo.py
+++ b/module/plugins/hoster/UploadedTo.py
@@ -16,7 +16,7 @@ from module.plugins.internal.SimpleHoster import SimpleHoster, create_getInfo
 class UploadedTo(SimpleHoster):
     __name__    = "UploadedTo"
     __type__    = "hoster"
-    __version__ = "0.79"
+    __version__ = "0.80"
 
     __pattern__ = r'https?://(?:www\.)?(uploaded\.(to|net)|ul\.to)(/file/|/?\?id=|.*?&id=|/)(?P<ID>\w+)'
 
@@ -77,7 +77,8 @@ class UploadedTo(SimpleHoster):
             if m:
                 self.wait(m.group(1))
             else:
-                self.fail(_("File not downloadable for free users"))
+                if not "type:'download'" in self.html:
+                    self.fail(_("File not downloadable for free users"))
 
         if "limit-size" in self.html:
             self.fail(_("File too big for free download"))


### PR DESCRIPTION
Fixes https://github.com/pyload/pyload/issues/1108

Don't know if it's temporary, but at the moment after Captcha Input there is no more waition time. So Check if download's ready in CheckErrors insert