### PR TITLE
[ExtractArchive] Some more changes

### DIFF
--- a/module/plugins/internal/Extractor.py
+++ b/module/plugins/internal/Extractor.py
@@ -19,7 +19,7 @@ class PasswordError(Exception):
 
 class Extractor:
     __name__    = "Extractor"
-    __version__ = "0.20"
+    __version__ = "0.21"
 
     __description__ = """Base extractor plugin"""
     __license__     = "GPLv3"
@@ -30,6 +30,7 @@ class Extractor:
 
     EXTENSIONS = []
     VERSION    = ""
+    REPAIR     = False
 
 
     @classmethod
@@ -90,23 +91,24 @@ class Extractor:
 
 
     def check(self):
-        """Check if password if needed. Raise ArchiveError if integrity is
-        questionable.
+        """Quick Check by listing content of archive.
+        Raises error if password is needed, integrity is questionable or else.
 
-        :return: boolean
+        :raises PasswordError
+        :raises CRCError
         :raises ArchiveError
         """
-        raise PasswordError
-
-
-    def isPassword(self, password):
-        """ Check if the given password is/might be correct.
-        If it can not be decided at this point return true.
-
-        :param password:
-        :return: boolean
+        raise NotImplementedError
+        
+    def test(self):
+        """Testing with Extractors buildt-in method
+        Raises error if password is needed, integrity is questionable or else.
+        
+        :raises PasswordError
+        :raises CRCError
+        :raises ArchiveError
         """
-        return None
+        raise NotImplementedError
 
 
     def repair(self):

--- a/module/plugins/internal/UnRar.py
+++ b/module/plugins/internal/UnRar.py
@@ -22,7 +22,7 @@ def renice(pid, value):
 
 class UnRar(Extractor):
     __name__    = "UnRar"
-    __version__ = "1.13"
+    __version__ = "1.14"
 
     __description__ = """Rar extractor plugin"""
     __license__     = "GPLv3"
@@ -33,34 +33,40 @@ class UnRar(Extractor):
 
     CMD = "unrar"
     VERSION = ""
-
     EXTENSIONS = [".rar"]
 
 
-    re_multipart = re.compile(r'\.(part|r)(\d+)(?:\.rar)?',re.I)
+    re_multipart = re.compile(r'\.(part|r)(\d+)(?:\.rar)?(\.rev|\.bad)?',re.I)
 
     re_filefixed = re.compile(r'Building (.+)')
     re_filelist  = re.compile(r'^(.)(\s*[\w\.\-]+)\s+(\d+\s+)+(?:\d+\%\s+)?[\d\-]{8}\s+[\d\:]{5}', re.M|re.I)
 
     re_wrongpwd  = re.compile(r'password', re.I)
-    re_wrongcrc  = re.compile(r'encrypted|damaged|CRC failed|checksum error', re.I)
+    re_wrongcrc  = re.compile(r'encrypted|damaged|CRC failed|checksum error|corrupt', re.I)
 
-    re_version   = re.compile(r'UNRAR\s(\d+\.\d+)', re.I)
+    re_version   = re.compile(r'(?:UN)?RAR\s(\d+\.\d+)', re.I)
 
 
     @classmethod
     def isUsable(cls):
         if os.name == "nt":
-            cls.CMD = os.path.join(pypath, "UnRAR.exe")
-            p = Popen([cls.CMD], stdout=PIPE, stderr=PIPE)
-            out, err = p.communicate()
-        else:
             try:
+                cls.CMD = os.path.join(pypath, "RAR.exe")
                 p = Popen([cls.CMD], stdout=PIPE, stderr=PIPE)
                 out, err = p.communicate()
-
-            except OSError:  #: fallback to rar
-                cls.CMD = "rar"
+                cls.__name__ = "RAR"
+                cls.REPAIR = True
+            except OSError:
+                cls.CMD = os.path.join(pypath, "UnRAR.exe")
+                p = Popen([cls.CMD], stdout=PIPE, stderr=PIPE)
+                out, err = p.communicate()
+        else:
+            try:
+                p = Popen(["rar"], stdout=PIPE, stderr=PIPE)
+                out, err = p.communicate()
+                cls.__name__ = "RAR"
+                cls.REPAIR = True
+            except OSError:  #: fallback to unrar
                 p = Popen([cls.CMD], stdout=PIPE, stderr=PIPE)
                 out, err = p.communicate()
 
@@ -74,13 +80,25 @@ class UnRar(Extractor):
         multipart = cls.re_multipart.search(filename)
         if multipart:
             # First Multipart file (part1.rar for *.part1-9.rar format or *.rar for .r1-9 format) handled as normal Archive
-            return False if (multipart.group(1) == "part" and int(multipart.group(2)) == 1) else True
+            return False if (multipart.group(1) == "part" and int(multipart.group(2)) == 1 and not multipart.group(3)) else True
 
         return False
 
 
-    def check(self):
-        p = self.call_cmd("l", "-v", fs_encode(self.filename))
+    def test(self, password):
+        p = self.call_cmd("t", "-v", fs_encode(self.filename), password=password)
+        self._progress(p)
+        err = p.stderr.read().strip()
+        
+        if self.re_wrongpwd.search(err):
+            raise PasswordError
+
+        if self.re_wrongcrc.search(err):
+            raise CRCError(err)
+
+
+    def check(self, password):
+        p = self.call_cmd("l", "-v", fs_encode(self.filename), password=password)
         out, err = p.communicate()
 
         if self.re_wrongpwd.search(err):
@@ -95,35 +113,14 @@ class UnRar(Extractor):
                 raise PasswordError
 
 
-    def isPassword(self, password):
-        # at this point we can only verify header protected files
-        p = self.call_cmd("l", "-v", fs_encode(self.filename), password=password)
-        out, err = p.communicate()
-        return False if self.re_wrongpwd.search(err) else True
-
-
     def repair(self):
         p = self.call_cmd("rc", fs_encode(self.filename))
 
         # communicate and retrieve stderr
         self._progress(p)
         err = p.stderr.read().strip()
-
         if err or p.returncode:
-            p = self.call_cmd("r", fs_encode(self.filename))
-
-            # communicate and retrieve stderr
-            self._progress(p)
-            err = p.stderr.read().strip()
-
-            if err or p.returncode:
-                return False
-            else:
-                dir  = os.path.dirname(filename)
-                name = re_filefixed.search(out).group(1)
-
-                self.filename = os.path.join(dir, name)
-
+            return False
         return True
 
 

--- a/module/plugins/internal/UnZip.py
+++ b/module/plugins/internal/UnZip.py
@@ -12,7 +12,7 @@ from module.utils import fs_encode
 
 class UnZip(Extractor):
     __name__    = "UnZip"
-    __version__ = "1.10"
+    __version__ = "1.11"
 
     __description__ = """Zip extractor plugin"""
     __license__     = "GPLv3"
@@ -34,7 +34,11 @@ class UnZip(Extractor):
             return z.namelist()
 
 
-    def check(self):
+    def check(self, password):
+        pass
+
+
+    def test(self):
         with zipfile.ZipFile(fs_encode(self.filename), 'r', allowZip64=True) as z:
             badfile = z.testzip()
 


### PR DESCRIPTION
- repair function only with rar
- added testing option (testing is a litte faster than extracting, so it can be detected if a file is pw protected or has CRC Error a little faster) When testing, extracting is a little faster afterwards (think through caching or something)
- removed periodical run for extract package, because when enabled pyload is always "busy" and therefore my NAS system isn't going to sleep when nothing to do. Furthermore when still extracting when allDownloadsprocessed event is dispatched, double extractions could occur.
- remove deleted packages from extract queue
- event "archive_extracted" moved after check whether extracted files exists, because other hooks could move/delete them before check is done
- deleting rev files and other files created by repairing 

all tested on windows (there are some errors when trying to write error or debug logs when packed files failes and contains special characters -> encoding errors)

TODO: 
sevenzip and unzip
Sevenzip is a little bit harder. First it can't distinguish between crc error and password error in Test mode, second even with little crc errors it extracts a good file (at the moment although it fires error extraction is seen completed)