### PR TITLE
[ExtractArchive] fixes 'Could not activate UnRar'

### DIFF
--- a/module/plugins/internal/SevenZip.py
+++ b/module/plugins/internal/SevenZip.py
@@ -11,7 +11,7 @@ from module.utils import fs_encode, save_join
 
 class SevenZip(UnRar):
     __name__    = "SevenZip"
-    __version__ = "0.09"
+    __version__ = "0.10"
 
     __description__ = """7-Zip extractor plugin"""
     __license__     = "GPLv3"
@@ -47,7 +47,8 @@ class SevenZip(UnRar):
             p = Popen([cls.CMD], stdout=PIPE, stderr=PIPE)
             out, err = p.communicate()
         
-        cls.VERSION = cls.re_version.search(out).group(1)
+        m = cls.re_version.search(out)
+        cls.VERSION = m.group(1) if m else '(version unknown)'
 
         return True
 

--- a/module/plugins/internal/UnRar.py
+++ b/module/plugins/internal/UnRar.py
@@ -22,7 +22,7 @@ def renice(pid, value):
 
 class UnRar(Extractor):
     __name__    = "UnRar"
-    __version__ = "1.14"
+    __version__ = "1.15"
 
     __description__ = """Rar extractor plugin"""
     __license__     = "GPLv3"
@@ -70,7 +70,8 @@ class UnRar(Extractor):
                 p = Popen([cls.CMD], stdout=PIPE, stderr=PIPE)
                 out, err = p.communicate()
 
-        cls.VERSION = cls.re_version.search(out).group(1)
+        m = cls.re_version.search(out)
+        cls.VERSION = m.group(1) if m else '(version unknown)'
 
         return True
 


### PR DESCRIPTION
fixes http://forum.pyload.org/viewtopic.php?f=10&t=4017 and http://forum.pyload.org/viewtopic.php?f=12&t=4032

But not sure if extraction works for them afterwards, because it seems that they have an untested (possible outdated) unrar version installed...