### PR TITLE
[ExternalScripts] Encode unicode characters

### DIFF
--- a/module/plugins/hooks/ExternalScripts.py
+++ b/module/plugins/hooks/ExternalScripts.py
@@ -74,7 +74,8 @@ class ExternalScripts(Hook):
 
     def callScript(self, script, *args):
         try:
-            cmd = [script] + [str(x) if not isinstance(x, basestring) else x for x in args]
+            cmd = [script] + [x.encode("UTF-8") if isinstance(x, unicode) else
+                str(x) if not isinstance(x, basestring) else x for x in args]
 
             self.logDebug("Executing", os.path.abspath(script), " ".join(cmd))
 


### PR DESCRIPTION
Hi,
I don't know if this is the right place to submit patches to pyload, but I would like to submit a small fix:
If a file with unicode characters in the filename is downloaded ExternalScripts.py fails with e.g. this error:

    ExternalScripts: Error in download_finished.sh: 'ascii' codec can't decode byte 0xc3 in position 29: ordinal not in range(128)

This commit makes the ExternalScripts plugin encode unicode characters to UTF-8.