### PR TITLE
[ExtractArchive] Send2Trash Integration

### DIFF
--- a/module/plugins/hooks/ExtractArchive.py
+++ b/module/plugins/hooks/ExtractArchive.py
@@ -106,24 +106,24 @@ class ArchiveQueue(object):
 class ExtractArchive(Hook):
     __name__    = "ExtractArchive"
     __type__    = "hook"
-    __version__ = "1.35"
+    __version__ = "1.36"
 
-    __config__ = [("activated"      , "bool"  , "Activated"                             , True                                                                     ),
-                  ("fullpath"       , "bool"  , "Extract with full paths"               , True                                                                     ),
-                  ("overwrite"      , "bool"  , "Overwrite files"                       , False                                                                    ),
-                  ("keepbroken"     , "bool"  , "Try to extract broken archives"        , False                                                                    ),
-                  ("repair"         , "bool"  , "Repair broken archives (RAR required)" , False                                                                    ),
-                  ("test"           , "bool"  , "Test archive before extracting"        , False                                                                    ),
-                  ("usepasswordfile", "bool"  , "Use password file"                     , True                                                                     ),
-                  ("passwordfile"   , "file"  , "Password file"                         , "archive_password.txt"                                                   ),
-                  ("delete"         , "bool"  , "Delete archive after extraction"       , False                                                                    ),
-                  ("subfolder"      , "bool"  , "Create subfolder for each package"     , False                                                                    ),
-                  ("destination"    , "folder", "Extract files to folder"               , ""                                                                       ),
-                  ("extensions"     , "str"   , "Extract archives ending with extension", "7z,bz2,bzip2,gz,gzip,lha,lzh,lzma,rar,tar,taz,tbz,tbz2,tgz,xar,xz,z,zip"),
-                  ("excludefiles"   , "str"   , "Don't extract the following files"     , "*.nfo,*.DS_Store,index.dat,thumb.db"                                    ),
-                  ("recursive"      , "bool"  , "Extract archives in archives"          , True                                                                     ),
-                  ("waitall"        , "bool"  , "Run after all downloads was processed" , False                                                                    ),
-                  ("renice"         , "int"   , "CPU priority"                          , 0                                                                        )]
+    __config__ = [("activated"      , "bool"                , "Activated"                             , True                                                                     ),
+                  ("fullpath"       , "bool"                , "Extract with full paths"               , True                                                                     ),
+                  ("overwrite"      , "bool"                , "Overwrite files"                       , False                                                                    ),
+                  ("keepbroken"     , "bool"                , "Try to extract broken archives"        , False                                                                    ),
+                  ("repair"         , "bool"                , "Repair broken archives (RAR required)" , False                                                                    ),
+                  ("test"           , "bool"                , "Test archive before extracting"        , False                                                                    ),
+                  ("usepasswordfile", "bool"                , "Use password file"                     , True                                                                     ),
+                  ("passwordfile"   , "file"                , "Password file"                         , "archive_password.txt"                                                   ),
+                  ("delete"         , "No;Permanent;Trash"  , "Delete archive after extraction"       , "No"                                                                     ),
+                  ("subfolder"      , "bool"                , "Create subfolder for each package"     , False                                                                    ),
+                  ("destination"    , "folder"              , "Extract files to folder"               , ""                                                                       ),
+                  ("extensions"     , "str"                 , "Extract archives ending with extension", "7z,bz2,bzip2,gz,gzip,lha,lzh,lzma,rar,tar,taz,tbz,tbz2,tgz,xar,xz,z,zip"),
+                  ("excludefiles"   , "str"                 , "Don't extract the following files"     , "*.nfo,*.DS_Store,index.dat,thumb.db"                                    ),
+                  ("recursive"      , "bool"                , "Extract archives in archives"          , True                                                                     ),
+                  ("waitall"        , "bool"                , "Run after all downloads was processed" , False                                                                    ),
+                  ("renice"         , "int"                 , "CPU priority"                          , 0                                                                        )]
 
     __description__ = """Extract different kind of archives"""
     __license__     = "GPLv3"
@@ -148,6 +148,7 @@ class ExtractArchive(Hook):
         self.extractors  = []
         self.passwords   = []
         self.repair      = False
+        self.trash       = False
 
 
     def coreReady(self):
@@ -448,15 +449,29 @@ class ExtractArchive(Hook):
             pyfile.setProgress(100)
             pyfile.setStatus("processing")
 
+            delfiles = archive.getDeleteFiles()
             if self.core.debug:
-                self.logDebug("Would delete: %s" % ", ".join(archive.getDeleteFiles()))
+                self.logDebug("Would delete: %s" % ", ".join(delfiles))
 
-            if self.getConfig('delete'):
-                files = archive.getDeleteFiles()
-                self.logInfo(_("Deleting %s files") % len(files))
-                for f in files:
+            if self.getConfig('delete') != 'No':
+                try:
+                    from send2trash import send2trash
+                    if self.getConfig('delete') == "Trash":
+                        self.trash = True
+                        self.logInfo(_("Sending %s files to trash") % len(delfiles))
+                except ImportError:
+                    self.logError(name, _("Send2Trash not installed, no files deleted"))
+                    self.trash = False
+
+                if self.getConfig('delete') == "Permanent":
+                    self.trash = False
+                    self.logInfo(_("Deleting %s files") % len(delfiles))
+
+                for f in delfiles:
                     file = fs_encode(f)
-                    if os.path.exists(file):
+                    if os.path.exists(file) and self.trash:
+                        send2trash(file)
+                    elif os.path.exists:
                         os.remove(file)
                     else:
                         self.logDebug("%s does not exists" % f)

--- a/module/plugins/internal/Extractor.py
+++ b/module/plugins/internal/Extractor.py
@@ -20,7 +20,7 @@ class PasswordError(Exception):
 
 class Extractor:
     __name__    = "Extractor"
-    __version__ = "0.22"
+    __version__ = "0.23"
 
     __description__ = """Base extractor plugin"""
     __license__     = "GPLv3"
@@ -75,7 +75,7 @@ class Extractor:
                  overwrite=False,
                  excludefiles=[],
                  renice=0,
-                 delete=False,
+                 delete='No',
                  keepbroken=False,
                  fid=None):
         """ Initialize extractor for specific file """

--- a/module/plugins/internal/UnRar.py
+++ b/module/plugins/internal/UnRar.py
@@ -22,7 +22,7 @@ def renice(pid, value):
 
 class UnRar(Extractor):
     __name__    = "UnRar"
-    __version__ = "1.18"
+    __version__ = "1.19"
 
     __description__ = """Rar extractor plugin"""
     __license__     = "GPLv3"
@@ -216,7 +216,7 @@ class UnRar(Extractor):
             args.append("-o+")
         else:
             args.append("-o-")
-            if self.delete:
+            if self.delete != 'No':
                 args.append("-or")
 
         for word in self.excludefiles:


### PR DESCRIPTION
https://github.com/pyload/pyload/issues/1230

Integrated https://github.com/hsoft/send2trash

With this you don't have to make s2t a dependency for pyload. Maybe you want to do that, but this is just a quick'n'dirty solution.

install using pip: 

    pip install send2trash


Tested on windows. Did not effect systems where send2trash isn't installed, except an Errormessage in Log if it isn't installed but selected in config