### PR TITLE
[zippyshare] fix bug #1311

### DIFF
--- a/module/plugins/hoster/ZippyshareCom.py
+++ b/module/plugins/hoster/ZippyshareCom.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import re
+from urllib import unquote
 
 from BeautifulSoup import BeautifulSoup
 
@@ -51,6 +52,9 @@ class ZippyshareCom(SimpleHoster):
 
         else:
             self.link = self.get_link()
+
+        if  pyfile.name == 'file.html' and self.link:
+            pyfile.name = unquote(self.link.split('/')[-1])
 
 
     def get_link(self):


### PR DESCRIPTION
Zippyshare sometimes encode the file name with an image.
In this case, use the file link to get the file name.
(it's probably a bad hack. I don't know nothing about pyload Core).