### PR TITLE
[XFileSharingProFolder] not able to extract links

### DIFF
--- a/module/plugins/crypter/XFileSharingProFolder.py
+++ b/module/plugins/crypter/XFileSharingProFolder.py
@@ -2,13 +2,15 @@
 
 import re
 
+from urlparse import urljoin, urlparse
+
 from module.plugins.internal.XFSCrypter import XFSCrypter, create_getInfo
 
 
 class XFileSharingProFolder(XFSCrypter):
     __name__    = "XFileSharingProFolder"
     __type__    = "crypter"
-    __version__ = "0.05"
+    __version__ = "0.06"
 
     __pattern__ = r'^unmatchable$'
     __config__  = [("use_subfolder"     , "bool", "Save package to subfolder"          , True),
@@ -47,6 +49,14 @@ class XFileSharingProFolder(XFSCrypter):
         self.user, data = self.account.selectAccount()
         self.req        = self.account.getAccountRequest(self.user)
         self.premium    = self.account.isPremium(self.user)
+
+
+    def getLinks(self):
+        url_p   = urlparse(self.pyfile.url)
+        baseurl = "%s://%s" % (url_p.scheme, url_p.netloc)
+
+        return [urljoin(baseurl, link) if not urlparse(link).scheme else link \
+                for link in re.findall(self.LINK_PATTERN, self.html, re.S)]
 
 
 getInfo = create_getInfo(XFileSharingProFolder)


### PR DESCRIPTION
Fix XFileSharingProFolder unable to extract links when html `<TD>` tag would span multiple lines, eg.:
```html
<td class="title-link">
<img style="margin-top:-3px;" src="/img/file.png"/>
<a href="http://uplea.com/dl/A3B488FFCF93F3F">http://uplea.com/dl/A3B488FFCF93F3F</a>
</td>
```
To avoid Changing `XFSCrypter.py` or `SimpleCrypter.py`, I have added `addLinks` method to `XFileSharingProFolder.py`.
The performance maybe degrades dramatically but I think it worth is (and it changes only for XFileSharingProFolder)

Example URL: http://uplea.com/folder/B3E93A58C71F254

And log:
```
26.04.2015 00:19:40 INFO      Decrypting starts: http://uplea.com/folder/B3E93A58C71F254
26.04.2015 00:19:40 DEBUG     XFileSharingProFolder: File info (BEFORE): {}
26.04.2015 00:19:40 DEBUG     XFileSharingProFolder: File info (AFTER): {'status': 3, 'url': u'http://uplea.com/folder/B3E93A58C71F254?&per_page=10000', 'name': u'B3E93A58C71F254', 'size': 0}
26.04.2015 00:19:40 DEBUG     Finished Info Fetching for XFileSharingProFolder
26.04.2015 00:19:40 DEBUG     XFileSharingProFolder: File name: B3E93A58C71F254 | File folder: B3E93A58C71F254
26.04.2015 00:19:40 DEBUG     XFileSharingProFolder: File info (BEFORE): {'status': 3, 'url': u'http://uplea.com/folder/B3E93A58C71F254?&per_page=10000', 'folder': u'B3E93A58C71F254', 'name': u'B3E93A58C71F254', 'size': 0}
26.04.2015 00:19:40 DEBUG     XFileSharingProFolder: File info (AFTER): {'status': 3, 'name': u'B3E93A58C71F254', 'url': u'http://uplea.com/folder/B3E93A58C71F254?&per_page=10000', 'folder': u'B3E93A58C71F254', 'size': 0}
26.04.2015 00:19:40 DEBUG     XFileSharingProFolder: File name: B3E93A58C71F254 | File folder: B3E93A58C71F254
26.04.2015 00:19:40 DEBUG     XFileSharingProFolder: File status: queued
26.04.2015 00:19:41 DEBUG     XFileSharingProFolder: Package has 0 links
26.04.2015 00:19:41 ERROR     Decrypting failed: B3E93A58C71F254 | No link grabbed
```