### PR TITLE
[ExtractArchive] [bug] `extractQueued` was called twice

### DIFF
--- a/module/plugins/hooks/ExtractArchive.py
+++ b/module/plugins/hooks/ExtractArchive.py
@@ -187,6 +187,11 @@ class ExtractArchive(Hook):
 
     @threaded
     def extractQueued(self, thread):
+        if self.extracting:  #@NOTE: doing the check here for safty (called by coreReady)
+            return
+
+        self.extracting = True
+
         packages = self.queue.get()
         while packages:
             if self.lastPackage:  #: called from allDownloadsProcessed
@@ -199,6 +204,8 @@ class ExtractArchive(Hook):
                     pass
 
             packages = self.queue.get()  #: check for packages added during extraction
+
+        self.extracting = False
 
 
     @Expose
@@ -222,7 +229,7 @@ class ExtractArchive(Hook):
 
     def allDownloadsProcessed(self):
         self.lastPackage = True
-        if not self.extracting:
+        if self.getConfig('waitall') and not self.extracting:
             self.extractQueued()
 
 
@@ -230,8 +237,6 @@ class ExtractArchive(Hook):
     def extract(self, ids, thread=None):  #@TODO: Use pypack, not pid to improve method usability
         if not ids:
             return False
-
-        self.extracting = True
 
         processed = []
         extracted = []
@@ -374,7 +379,6 @@ class ExtractArchive(Hook):
 
             self.queue.remove(pid)
 
-        self.extracting = False
         return True if not failed else False
 
 

--- a/module/plugins/hooks/ExtractArchive.py
+++ b/module/plugins/hooks/ExtractArchive.py
@@ -110,7 +110,7 @@ class ArchiveQueue(object):
 class ExtractArchive(Hook):
     __name__    = "ExtractArchive"
     __type__    = "hook"
-    __version__ = "1.42"
+    __version__ = "1.43"
 
     __config__ = [("activated"      , "bool"              , "Activated"                                 , True                                                                     ),
                   ("fullpath"       , "bool"              , "Extract with full paths"                   , True                                                                     ),


### PR DESCRIPTION
fix #1371 and #1344

This one was nasty.
Apparently extractQueued was called twice by `packageFinished` and `allDownloadsProcessed` causing two threads to try extract and delete the same file which cause things like:
```
11.04.2015 02:21:15 ERROR     ExtractArchive: file01.part40.rar | Archive error | Cannot open file
```
and
```
04.05.2015 22:03:22 DEBUG     ExtractArchive: Successfully moved hg-l10n-201104080000.zip to trash
04.05.2015 22:03:22 INFO      ExtractArchive: hg-l10n-201104080000.zip | Extracting finished
04.05.2015 22:03:22 DEBUG     ExtractArchive: Extracted files: [u'installer/', u'installer]/components/]
04.05.2015 22:03:22 DEBUG     ExtractArchive: setPermissions
    self.extract(zipinfo, path, pwd)
  File "/usr/lib/python2.7/zipfile.py", line 1028, in extract
    return self._extract_member(member, path, pwd)
  File "/usr/lib/python2.7/zipfile.py", line 1082, in _extract_member
    with self.open(member, pwd=pwd) as source, \
  File "/usr/lib/python2.7/zipfile.py", line 951, in open
    zef_file = open(self.filename, 'rb')
IOError: [Errno 2] No such file or directory: u'/tmp/Downloads/Extract/hg-l10n-201104080000.zip'
04.05.2015 22:03:22 ERROR     ExtractArchive: hg-l10n-201104080000.zip | Extract failed
```

I think we can say that finally ExtractArchive is working ok.