### PR TITLE
[ClickAndLoad] fix bug when webinterface uses SSL

### DIFF
--- a/module/plugins/hooks/ClickAndLoad.py
+++ b/module/plugins/hooks/ClickAndLoad.py
@@ -3,6 +3,11 @@
 import socket
 import time
 
+try:
+    import ssl
+except ImportError:
+    pass
+
 from threading import Lock
 
 from module.plugins.Hook import Hook, threaded
@@ -24,7 +29,7 @@ def forward(source, destination):
 class ClickAndLoad(Hook):
     __name__    = "ClickAndLoad"
     __type__    = "hook"
-    __version__ = "0.41"
+    __version__ = "0.42"
 
     __config__ = [("activated", "bool", "Activated"                             , True),
                   ("port"     , "int" , "Port"                                  , 9666),
@@ -79,6 +84,21 @@ class ClickAndLoad(Hook):
                 self.logDebug("Connection from %s:%s" % client_addr)
 
                 server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+                if self.config['webinterface']['https']:
+                    try:
+                        server_socket = ssl.wrap_socket(server_socket)
+
+                    except NameError:
+                        self.logError(_("pyLoad's webinterface is configured to use HTTPS, Please install python's ssl lib or
+                        client_socket.close()  #: reset the connection.
+                        continue
+
+                    except Exception, e:
+                        self.logError(_("SSL error: %s") % e.message)
+                        client_socket.close()  #: reset the connection.
+                        continue
+
                 server_socket.connect(("127.0.0.1", webport))
 
                 self.manager.startThread(forward, client_socket, server_socket)


### PR DESCRIPTION
fix #1387

The solution requires python's SSL lib which  is officially supported in python 2.6+  but there is an installable version for 2.5 (https://pypi.python.org/pypi/ssl/) 