### PR TITLE
fixes error on adding container

### DIFF
--- a/pyload/plugin/Container.py
+++ b/pyload/plugin/Container.py
@@ -7,7 +7,7 @@ import re
 from os import remove
 from os.path import basename, exists
 
-from pyload.plugin.internal.Crypter import Crypter
+from pyload.plugin.Crypter import Crypter
 from pyload.utils import fs_join
 
 


### PR DESCRIPTION
2015-05-10 10:34:17  ERROR     Error importing plugin: [container] DLC (v0.24) | No module named Crypter
Traceback (most recent call last):
  File "/opt/pyload/pyload/manager/Plugin.py", line 284, in loadModule
    plugins[name]['name'])
  File "/opt/pyload/pyload/plugin/container/DLC.py", line 10, in <module>
    from pyload.plugin.Container import Container
  File "/opt/pyload/pyload/plugin/Container.py", line 10, in <module>
    from pyload.plugin.internal.Crypter import Crypter
ImportError: No module named Crypter
2015-05-10 10:34:17  CRITICAL  'NoneType' object has no attribute 'DLC'
Traceback (most recent call last):
  File "/opt/pyload/pyload/manager/Thread.py", line 275, in assignJob
    job.initPlugin()
  File "/opt/pyload/pyload/utils/__init__.py", line 214, in new
    return func(*args)
  File "/opt/pyload/pyload/datatype/File.py", line 91, in initPlugin
    self.pluginclass  = getattr(self.pluginmodule, self.m.core.pluginManager.getPluginName(self.plugintype, self.pluginname))
AttributeError: 'NoneType' object has no attribute 'DLC'