### PR TITLE
change trafficleft to unlimited...

### DIFF
--- a/module/plugins/accounts/ShareonlineBiz.py
+++ b/module/plugins/accounts/ShareonlineBiz.py
@@ -45,8 +45,11 @@ class ShareonlineBiz(Account):
             validuntil = float(api['expire_date'])
 
             traffic     = float(api['traffic_1d'].split(";")[0])
-            maxtraffic  = max(maxtraffic, traffic)
-            trafficleft = maxtraffic - traffic
+
+            if maxtraffic > traffic:
+                trafficleft = maxtraffic - traffic
+            else:
+                trafficleft = -1
 
         maxtraffic  /= 1024  #@TODO: Remove `/ 1024` in 0.4.10
         trafficleft /= 1024  #@TODO: Remove `/ 1024` in 0.4.10


### PR DESCRIPTION
 ...when in Penalty-Premium state to ensure continues Downloads

Otherwise pyload switches to freemode, which interupts the whole Downloadqueue.

Penalty Premium --> means 1 parallel download with decreased bandwith.