### PR TITLE
Remove obsolete AdYouLike call

### DIFF
--- a/module/plugins/hoster/DlFreeFr.py
+++ b/module/plugins/hoster/DlFreeFr.py
@@ -94,14 +94,15 @@ class DlFreeFr(SimpleHoster):
     def handleFree(self, pyfile):
         action, inputs = self.parseHtmlForm('action="getfile.pl"')
 
-        adyoulike = AdYouLike(self)
-        response, challenge = adyoulike.challenge()
-        inputs.update(response)
+        # old - adyoulike is disabled for now
+        #adyoulike = AdYouLike(self)
+        #response, challenge = adyoulike.challenge()
+        #inputs.update(response)
 
         self.load("http://dl.free.fr/getfile.pl", post=inputs)
         headers = self.getLastHeaders()
         if headers.get("code") == 302 and "set-cookie" in headers and "location" in headers:
-            m = re.search("(.*?)=(.*?); path=(.*?); domain=(.*?)", headers.get("set-cookie"))
+            m = re.search("(.*?)=(.*?); path=(.*?); domain=(.*)", headers.get("set-cookie"))
             cj = CookieJar(__name__)
             if m:
                 cj.setCookie(m.group(4), m.group(1), m.group(2), m.group(3))


### PR DESCRIPTION
@vuolter @tmerle 

AdYouLike is currently not used anymore on the hoster's site. Additionally the regex had to be edited to actually grab the domain value. With these changes I could download again until yesterday's update of the plugin.

Seems like this commit isn't actually working: https://github.com/pyload/pyload/commit/6616c00ba1c40f5d56959bd0e4725f26250e1292#diff-5d57a6bc31e3d4fa2d3010afe37c2d46

The original sample link still works for testing:
http://dl.free.fr/b2ANA3gPp