### PR TITLE
[Dereferer] [SimpleCrypter] bugfixes

### DIFF
--- a/module/plugins/crypter/Dereferer.py
+++ b/module/plugins/crypter/Dereferer.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 
+import re
+
 from module.plugins.internal.SimpleCrypter import SimpleCrypter
 
 
 class Dereferer(SimpleCrypter):
     __name__    = "Dereferer"
     __type__    = "crypter"
-    __version__ = "0.13"
+    __version__ = "0.14"
 
     __pattern__ = r'https?://(?:www\.)?(?:\w+\.)*?(?P<DOMAIN>(?:[\d.]+|[\w\-]{3,}(?:\.[a-zA-Z]{2,}){1,2})(?:\:\d+)?)/.*?(?P<LINK>(?:ht|f)tps?://.+)'
     __config__  = [("use_subfolder"     , "bool", "Save package to subfolder"          , True),
@@ -37,4 +39,4 @@ class Dereferer(SimpleCrypter):
 
 
     def getLinks(self):
-        return [re.match(self.__pattern__, pyfile.url).group('LINK').strip()]
+        return [re.match(self.__pattern__, self.pyfile.url).group('LINK').strip()]

--- a/module/plugins/internal/SimpleCrypter.py
+++ b/module/plugins/internal/SimpleCrypter.py
@@ -11,7 +11,7 @@ from module.utils import fixup, html_unescape
 class SimpleCrypter(Crypter, SimpleHoster):
     __name__    = "SimpleCrypter"
     __type__    = "crypter"
-    __version__ = "0.47"
+    __version__ = "0.48"
 
     __pattern__ = r'^unmatchable$'
     __config__  = [("use_subfolder"     , "bool", "Save package to subfolder"          , True),  #: Overrides core.config['general']['folder_per_package']
@@ -101,7 +101,7 @@ class SimpleCrypter(Crypter, SimpleHoster):
 
     def handleDirect(self, pyfile):
         while True:
-            header = self.load(self.link or pyfile.url, just_header=True, decode=True)
+            header = self.load(self.link if hasattr(self, 'link') and self.link else pyfile.url, just_header=True, decode=True)
             if 'location' in header and header['location']:
                 self.link = header['location']
             else:
@@ -114,7 +114,7 @@ class SimpleCrypter(Crypter, SimpleHoster):
         self.logDebug("Looking for link redirect...")
         self.handleDirect(pyfile)
 
-        if self.link:
+        if hasattr(self, 'link') and self.link:
             self.urls = [self.link]
 
         else:


### PR DESCRIPTION
```
  File "/share/pyload/module/PluginThread.py", line 363, in run
    self.active.plugin.preprocessing(self)
  File "/share/pyload/module/plugins/Crypter.py", line 49, in preprocessing
    self.decrypt(self.pyfile)
  File "/etc/pyload/userplugins/internal/SimpleCrypter.py", line 115, in decrypt
    self.handleDirect(pyfile)
  File "/etc/pyload/userplugins/internal/SimpleCrypter.py", line 104, in handleDirect
    header = self.load(self.link or pyfile.url, just_header=True, decode=True)
AttributeError: 'Dereferer' object has no attribute 'link'
```