### PR TITLE
2 new Crypter plugins: sh.st and pasted.co

### DIFF
--- a/module/plugins/crypter/PastedCo.py
+++ b/module/plugins/crypter/PastedCo.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from module.plugins.internal.Crypter import Crypter
+
+import re
+
+
+class PastedCo(Crypter):
+    __name__    = "PastedCo"
+    __type__    = "crypter"
+    __version__ = "0.01"
+
+    __pattern__ = r'http://pasted\.co/\w+'
+
+    __description__ = """Pasted.co decrypter plugin"""
+    __license__     = "GPLv3"
+    __authors__     = [("Frederik Möllers", "fred-public@posteo.de")]
+
+
+    NAME_PATTERN = r'<title>(?P<N>.+?) - .+</title>'
+    NAME_PATTERN = r"'save_paste' href=\"(http://pasted.co/[0-9a-f]+)/info"
+
+    FS_URL_PREFIX = '<pre id=\'thepaste\' class="prettyprint">'
+    FS_URL_SUFFIX = '</pre>'
+
+    def decrypt(self, pyfile):
+        package = pyfile.package()
+        package_name = package.name
+        package_folder = package.folder
+        html = self.load(pyfile.url, decode = True).splitlines()
+        fs_url = None
+        FS_URL_RE = re.compile('%s/fullscreen\.php\?hash=[0-9a-f]*' % pyfile.url)
+        for line in html:
+            match = FS_URL_RE.search(line)
+            if match:
+                fs_url = match.group()
+                break
+        if not fs_url:
+            raise Exception("Could not find pasted.co fullscreen URL!")
+        urls = self.load(fs_url, decode = True)
+        urls = urls[urls.find(PastedCo.FS_URL_PREFIX) + len(PastedCo.FS_URL_PREFIX):]
+        urls = urls[:urls.find(PastedCo.FS_URL_SUFFIX)].splitlines()
+        self.packages.append((package_name, urls, package_folder))

--- a/module/plugins/crypter/ShSt.py
+++ b/module/plugins/crypter/ShSt.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from module.plugins.internal.Crypter import Crypter
+
+import re
+
+
+class ShSt(Crypter):
+    __name__    = "ShSt"
+    __type__    = "crypter"
+    __version__ = "0.01"
+
+    __pattern__ = r'http://sh\.st/\w+'
+
+    __description__ = """Sh.St decrypter plugin"""
+    __license__     = "GPLv3"
+    __authors__     = [("Frederik Möllers", "fred-public@posteo.de")]
+
+
+    NAME_PATTERN = r'<title>(?P<N>.+?) - .+</title>'
+
+
+    def decrypt(self, pyfile):
+        package = pyfile.package()
+        package_name = package.name
+        package_folder = package.folder
+        html = self.load("http://deadlockers.com/submit.php", post = { "deadlock" : self.pyfile.url }, decode = True)
+        self.packages.append((package_name, [html], package_folder))


### PR DESCRIPTION
I've written 2 new Crypter plugins:
1. sh.st — a URL shortener service much like adf.ly
2. pasted.co — a pastebin website

For testing purposes, here are some URLs:
Random 20MB file hosted on Zippyshare, URL shortened with sh.st: http://sh.st/lExcv
Same file with its URL hosted on pasted.co: http://pasted.co/85f29090
Both services chained (URL on pasted.co, pasted URL shortened with sh.st): http://sh.st/lEb0y

If needed I can also check them vs. the master branch and then create another pull request.

Please note that this is my first pull request on github, so please excuse any major oversights on my part. I'm happy to correct any mistakes I did and I'm grateful for any feedback.