### PR TITLE
RPC calls via Webinterface

### DIFF
--- a/module/Api.py
+++ b/module/Api.py
@@ -992,11 +992,24 @@ class Api(Iface):
         :return: result
         :raises: ServiceDoesNotExists, when its not available
         :raises: ServiceException, when a exception was raised
+        :raises: KeyError or AttributeError, when a parameter is missing
         """
-        plugin = info.plugin
-        func = info.func
-        args = info.arguments
-        parse = info.parseArguments
+        if type(info) is dict:
+            try:
+                plugin = info['plugin']
+                func = info['func']
+                args = info['arguments']
+                parse = info['parseArguments']
+            except KeyError, e:
+                raise KeyError(e.message)
+        else:
+            try:
+                plugin = info.plugin
+                func = info.func
+                args = info.arguments
+                parse = info.parseArguments
+            except AttributeError, e:
+                raise AttributeError(e.message)
 
         if not self.hasService(plugin, func):
             raise ServiceDoesNotExists(plugin, func)


### PR DESCRIPTION
I could not use the interface "http://PYLOAD.ADDR/api/call".
The reason is, that I cannot supply the type "ServiceCall" for the parameter "info" via URL.

I modified Api.py::call to also accept a dict as input parameter.

Now, I can call exposed API functions with the following URI encoded object:
{"plugin":"PLUGIN", "func":"FUNCTION", "arguments":['arg1','arg2'], "parseArguments":False}

For example:
http://PYLOAD.ADDR/api/call?info=%7B"plugin"%3A"UpdateManager"%2C"func"%3A"autoreloadPlugins"%2C"arguments"%3A[]%2C"parseArguments"%3AFalse%7D

Clear text of URL parameter
`{"plugin":"UpdateManager","func":"autoreloadPlugins","arguments":[],"parseArguments":False}`

Regards!

PS: Sooner or later, I consider adding additional content to the webinterface provided by plugins. Therefore I need to call their functions this way.