### PR TITLE
Update/Fix ShSt crypter plugin

### DIFF
--- a/module/plugins/crypter/ShSt.py
+++ b/module/plugins/crypter/ShSt.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from module.plugins.internal.SimpleCrypter import SimpleCrypter
+from module.plugins.internal.Crypter import Crypter
 
 import pycurl
 import re
 
 
-class ShSt(SimpleCrypter):
+class ShSt(Crypter):
     __name__    = "ShSt"
     __type__    = "crypter"
-    __version__ = "0.02"
+    __version__ = "0.03"
 
     __pattern__ = r'http://sh\.st/\w+'
 

--- a/module/plugins/crypter/ShSt.py
+++ b/module/plugins/crypter/ShSt.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 
-from module.plugins.internal.Crypter import Crypter
+from module.plugins.internal.SimpleCrypter import SimpleCrypter
 
+import pycurl
 import re
 
 
-class ShSt(Crypter):
+class ShSt(SimpleCrypter):
     __name__    = "ShSt"
     __type__    = "crypter"
-    __version__ = "0.01"
+    __version__ = "0.02"
 
     __pattern__ = r'http://sh\.st/\w+'
 
@@ -21,8 +22,9 @@ class ShSt(Crypter):
 
 
     def decrypt(self, pyfile):
-        package = pyfile.package()
-        package_name = package.name
-        package_folder = package.folder
-        html = self.load("http://deadlockers.com/submit.php", post = { "deadlock" : self.pyfile.url }, decode = True)
-        self.packages.append((package_name, [html], package_folder))
+        # if we use curl as a user agent, we will get a straight redirect (no waiting!)
+        self.req.http.c.setopt(pycurl.USERAGENT, "curl/7.42.1")
+        # fetch the target URL
+        header = self.load(self.pyfile.url, just_header = True, decode = False)
+        target_url = header["location"]
+        self.urls.append(target_url)


### PR DESCRIPTION
The plugin was broken due to a change of the deadlockers.com website.
The new version of the plugin doesn't rely on third party websites anymore and is also much faster. It uses a special user agent which causes the provider (sh.st) to serve an HTTP redirect instead of a waiting page.
Also, self.urls is now used instead of self.packages for the decrypted URL.

To test the new version, you can use the following URL:
http://sh.st/lExcv
This should lead to you the following download:
http://www39.zippyshare.com/v/6kqYhqFA/file.html