### PR TITLE
Update/Fix GamefrontCom hoster plugin

### DIFF
--- a/module/plugins/hoster/GamefrontCom.py
+++ b/module/plugins/hoster/GamefrontCom.py
@@ -6,7 +6,7 @@ from module.plugins.internal.SimpleHoster import SimpleHoster, create_getInfo
 class GamefrontCom(SimpleHoster):
     __name__    = "GamefrontCom"
     __type__    = "hoster"
-    __version__ = "0.07"
+    __version__ = "0.08"
 
     __pattern__ = r'http://(?:www\.)?gamefront\.com/files/(?P<ID>\d+)'
 
@@ -15,7 +15,7 @@ class GamefrontCom(SimpleHoster):
     __authors__     = [("Walter Purcaro", "vuolter@gmail.com")]
 
 
-    NAME_PATTERN    = r'>File Name:</dt>\s*<dd>(?P<N>.+?)<'
+    NAME_PATTERN    = r'<title>(?P<N>.+?) \| Game Front</title>'
     SIZE_PATTERN    = r'>File Size:</dt>\s*<dd>(?P<S>[\d.,]+) (?P<U>[\w^_]+)'
     OFFLINE_PATTERN = r'<p>File not found'
 


### PR DESCRIPTION
GameFront uses a `<span>` tag around long filenames. This caused the
plugin to include the tag in the filename.
Instead of the (possibly abbreviated) filename in the page's content,
the title (HTML `<title>` tag) is now used.
Use this link to see the issue (file is not really a RAR archive, just a file with random content): http://www.gamefront.com/files/25080153/thisisalongfilenameitssolongicantevenseetheendwowanditsstillgoingonahthereistheend.rar