### PR TITLE
[ZDF] Encode unicode characters when loading XML

### DIFF
--- a/module/plugins/hoster/ZDF.py
+++ b/module/plugins/hoster/ZDF.py
@@ -42,7 +42,7 @@ class ZDF(Hoster):
 
 
     def process(self, pyfile):
-        xml = etree.fromstring(self.load(self.XML_API % self.get_id(pyfile.url)))
+        xml = etree.fromstring(self.load(self.XML_API % self.get_id(pyfile.url)).encode("UTF-8"))
 
         status = xml.findtext("./status/statuscode")
         if status != "ok":


### PR DESCRIPTION
The XML file from the ZDF website often contains unicode characters, which lead to errors like
`'ascii' codec can't decode byte 0xc3 in position 29: ordinal not in range(128)`. This change makes the plugin encode unicode characters to UTF-8 before parsing the XML data.