### PR TITLE
[AntiStandby] fix import error

### DIFF
--- a/module/plugins/hooks/AntiStandby.py
+++ b/module/plugins/hooks/AntiStandby.py
@@ -13,7 +13,7 @@ except ImportError:
     pass
 
 from module.plugins.internal.Addon import Addon, Expose
-from module.utils import save_join as fs_encode, fs_join
+from module.utils import save_join as fs_join, fs_encode
 
 
 class Kernel32(object):
@@ -27,7 +27,7 @@ class Kernel32(object):
 class AntiStandby(Addon):
     __name__    = "AntiStandby"
     __type__    = "hook"
-    __version__ = "0.10"
+    __version__ = "0.11"
     __status__  = "testing"
 
     __config__ = [("activated", "bool", "Activated"                       , True ),


### PR DESCRIPTION
```
03.08.2015 01:06:43 ERROR     Error importing AntiStandby: cannot import name fs_join
Traceback (most recent call last):
  File "/usr/share/pyload/module/plugins/PluginManager.py", line 268, in loadModule
    plugins[name]["name"])
  File "/usr/share/pyload/module/plugins/PluginManager.py", line 317, in load_module
    module = __import__(newname, globals(), locals(), [plugin])
  File "/home/user/.pyload-0.4.9/userplugins/hooks/AntiStandby.py", line 16, in <module>
    from module.utils import save_join as fs_encode, fs_join
ImportError: cannot import name fs_join
```