### PR TITLE
Update Plugin.py

### DIFF
--- a/module/plugins/internal/Plugin.py
+++ b/module/plugins/internal/Plugin.py
@@ -334,7 +334,7 @@ class Plugin(object):
             req = self.req or self.pyload.requestFactory.getRequest(self.__name__)
 
         #@TODO: Move to network in 0.4.10
-        if isinstance(self.COOKIES, list):
+        if hasattr(self, 'COOKIES') and isinstance(self.COOKIES, list):
             set_cookies(req.cj, cookies)
 
         res = req.load(url, get, post, ref, bool(cookies), just_header, multipart, decode is True)  #@TODO: Fix network multipart in 0.4.10

--- a/module/plugins/internal/Plugin.py
+++ b/module/plugins/internal/Plugin.py
@@ -335,7 +335,7 @@ class Plugin(object):
 
         #@TODO: Move to network in 0.4.10
         if hasattr(self, 'COOKIES') and isinstance(self.COOKIES, list):
-            set_cookies(req.cj, cookies)
+            set_cookies(req.cj, self.COOKIES)
 
         res = req.load(url, get, post, ref, bool(cookies), just_header, multipart, decode is True)  #@TODO: Fix network multipart in 0.4.10
 


### PR DESCRIPTION
Hi,
With commit e5ce0acf056dc96c40d5616ab6d2b82f998eefbe titled "Use set_cookie instead cj.setCookie", COOKIES attribute in Plugin class does not necessarily exist anymore, unfortunately it is used in module/plugins/internal/Plugin.py#337.
Therefore it breaks loading many plugins like UpdateManager, Mega.Co.Nz...