### PR TITLE
[ZDF] Encode file name / title

### DIFF
--- a/module/plugins/hoster/ZDF.py
+++ b/module/plugins/hoster/ZDF.py
@@ -51,7 +51,7 @@ class ZDF(Hoster):
         video = xml.find("video")
         title = video.findtext("information/title")
 
-        pyfile.name = title
+        pyfile.name = title.encode("Latin-1")
 
         target_url = sorted((v for v in video.iter("formitaet") if self.video_valid(v)),
                             key=self.video_key)[-1].findtext("url")


### PR DESCRIPTION
The title used as file name is encoded in Latin-1. This commit enables pyload to download those files and display their names in the queue correctly.

URL to test: http://www.zdf.de/ZDFmediathek/beitrag/video/2455326/Toedliche-Versuchung