### PR TITLE
Download deleted because of file size mismatch

### DIFF
--- a/module/plugins/internal/SimpleHoster.py
+++ b/module/plugins/internal/SimpleHoster.py
@@ -310,8 +310,8 @@ class SimpleHoster(Hoster):
             self.captcha.invalid()
             self.retry(10, reason=_("Wrong captcha"))
 
-        # 10485760 is 10MB, tolerance is used when comparing displayed size to real size
-        # For example displayed size can be 1.46GB for example, but real size can be 1.4649853
+        # 10485760 is 10MB, tolerance is used when comparing displayed size on the hoster website to real size
+        # For example displayed size can be 1.46GB for example, but real size can be 1.4649853GB
         elif self.check_download({'Empty file': re.compile(r'\A((.|)(\2|\s)*)\Z')},
                                  file_size=self.info['size'] if 'size' in self.info else 0,
                                  size_tolerance=10485760,

--- a/module/plugins/internal/SimpleHoster.py
+++ b/module/plugins/internal/SimpleHoster.py
@@ -310,9 +310,11 @@ class SimpleHoster(Hoster):
             self.captcha.invalid()
             self.retry(10, reason=_("Wrong captcha"))
 
+        # 10485760 is 10MB, tolerance is used when comparing displayed size to real size
+        # For example displayed size can be 1.46GB for example, but real size can be 1.4649853
         elif self.check_download({'Empty file': re.compile(r'\A((.|)(\2|\s)*)\Z')},
                                  file_size=self.info['size'] if 'size' in self.info else 0,
-                                 size_tolerance=1048576,
+                                 size_tolerance=10485760,
                                  delete=True):
             self.error(_("Empty file"))
 


### PR DESCRIPTION
One some hosters like OneFichier for example, the webpage displays a file size of 1.46GB.
However the real file size can be 1.4649853GB, which makes a difference between the downloaded file size and the expected file size.

size_tolerance is meant for that, but its value is currently set to 1MB. This is an issue in the above case where the difference between expected size and downloaded size is almost 10MB. In many cases, this causes the downloaded file to simply be deleted, even though it has been downloaded without any issue.

The biggest possible size difference is 10MB, at least if the website displays 2 decimals and that the biggest unit is GB. Therefore I propose to change the max tolerance from 1MB to 10MB.

FYI the error message in the log looks like that:
`Fail: File size mismatch | Expected file size: 1492501135.36 | Downloaded file size: 1488025852`