### PR TITLE
[ExternalScripts] Prepend directory to filenames

### DIFF
--- a/module/plugins/hooks/ExternalScripts.py
+++ b/module/plugins/hooks/ExternalScripts.py
@@ -71,7 +71,7 @@ class ExternalScripts(Addon):
             if not os.path.isfile(file):
                 continue
 
-            if file[0] in ("#", "_") or file.endswith("~") or file.endswith(".swp"):
+            if filebase[0] in ("#", "_") or file.endswith("~") or file.endswith(".swp"):
                 continue
 
             if not os.access(file, os.X_OK):

--- a/module/plugins/hooks/ExternalScripts.py
+++ b/module/plugins/hooks/ExternalScripts.py
@@ -10,7 +10,7 @@ from module.utils import fs_encode, save_join as fs_join
 class ExternalScripts(Addon):
     __name__    = "ExternalScripts"
     __type__    = "hook"
-    __version__ = "0.46"
+    __version__ = "0.47"
     __status__  = "testing"
 
     __config__ = [("activated", "bool", "Activated"         , True ),
@@ -66,7 +66,8 @@ class ExternalScripts(Addon):
                 self.log_debug(e)
                 return
 
-        for file in os.listdir(path):
+        for filebase in os.listdir(path):
+            file = os.path.join(path, filebase)
             if not os.path.isfile(file):
                 continue
 


### PR DESCRIPTION
As `os.path.join()` returns the basename of the files, the directory has to be prepended.