### PR TITLE
[hooks/Checksum.py] Fix rename error and checksum comparison

### DIFF
--- a/module/plugins/hooks/Checksum.py
+++ b/module/plugins/hooks/Checksum.py
@@ -38,7 +38,7 @@ def compute_checksum(local_file, algorithm):
 class Checksum(Addon):
     __name__    = "Checksum"
     __type__    = "hook"
-    __version__ = "0.19"
+    __version__ = "0.20"
     __status__  = "testing"
 
     __config__ = [("check_checksum", "bool"             , "Check checksum? (If False only size will be verified)", True   ),
@@ -133,7 +133,7 @@ class Checksum(Addon):
                 if key in data:
                     checksum = compute_checksum(local_file, key.replace("-", "").lower())
                     if checksum:
-                        if checksum is data[key].lower():
+                        if checksum == data[key].lower():
                             self.log_info(_('File integrity of "%s" verified by %s checksum (%s)') %
                                         (pyfile.name, key.upper(), checksum))
                             break

--- a/module/plugins/hooks/Checksum.py
+++ b/module/plugins/hooks/Checksum.py
@@ -131,7 +131,7 @@ class Checksum(Addon):
 
             for key in self.algorithms:
                 if key in data:
-                    checksum = computeChecksum(local_file, key.replace("-", "").lower())
+                    checksum = compute_checksum(local_file, key.replace("-", "").lower())
                     if checksum:
                         if checksum is data[key].lower():
                             self.log_info(_('File integrity of "%s" verified by %s checksum (%s)') %
@@ -186,7 +186,7 @@ class Checksum(Addon):
 
                 local_file = fs_encode(fs_join(download_folder, data['NAME']))
                 algorithm = self.methods.get(file_type, file_type)
-                checksum = computeChecksum(local_file, algorithm)
+                checksum = compute_checksum(local_file, algorithm)
                 if checksum is data['HASH']:
                     self.log_info(_('File integrity of "%s" verified by %s checksum (%s)') %
                                 (data['NAME'], algorithm, checksum))

--- a/module/plugins/hooks/Checksum.py
+++ b/module/plugins/hooks/Checksum.py
@@ -139,7 +139,7 @@ class Checksum(Addon):
                             break
                         else:
                             self.log_warning(_("%s checksum for file %s does not match (%s != %s)") %
-                                           (key.upper(), pyfile.name, checksum, data[key]))
+                                           (key.upper(), pyfile.name, checksum, data[key].lower()))
                             self.check_failed(pyfile, local_file, "Checksums do not match")
                     else:
                         self.log_warning(_("Unsupported hashing algorithm"), key.upper())


### PR DESCRIPTION
Replaced all occurences of `computeChecksum()` with `compute_checksum()`. Error was introduced by the recent function name changes without refactoring the source correctly.

Changed the checksum comparison from identity (`is`) to equality (`==`).