### PR TITLE
[SharelinksBiz & FilecryptCc] Fixes #1753

### DIFF
--- a/module/plugins/crypter/FilecryptCc.py
+++ b/module/plugins/crypter/FilecryptCc.py
@@ -16,7 +16,7 @@ from module.plugins.captcha.ReCaptcha import ReCaptcha
 class FilecryptCc(Crypter):
     __name__    = "FilecryptCc"
     __type__    = "crypter"
-    __version__ = "0.18"
+    __version__ = "0.19"
     __status__  = "testing"
 
     __pattern__ = r'https?://(?:www\.)?filecrypt\.cc/Container/\w+'
@@ -140,8 +140,9 @@ class FilecryptCc(Crypter):
             for link in weblinks:
                 res   = self.load("%s/Link/%s.html" % (self.base_url, link))
                 link2 = re.search('<iframe noresize src="(.*)"></iframe>', res)
-                res2  = self.load(link2.group(1), just_header=True)
-                self.links.append(res2['location'])
+                if link2:
+                    res2  = self.load(link2.group(1), just_header=True)
+                    self.links.append(res2['location'])
 
         except Exception, e:
             self.log_debug("Error decrypting weblinks: %s" % e)

--- a/module/plugins/crypter/ShareLinksBiz.py
+++ b/module/plugins/crypter/ShareLinksBiz.py
@@ -118,7 +118,10 @@ class ShareLinksBiz(Crypter):
         self.log_debug("Captcha map with [%d] positions" % len(captchaMap.keys()))
 
         #: Request user for captcha coords
-        m = re.search(r'<img src="/captcha.gif\?d=(.*?)&amp;PHPSESSID=(.*?)&amp;legend=1"', self.html)
+        m = re.search(r'<img src="/captcha.gif\?d=(.+?)&PHPSESSID=(.+?)&legend=1"', self.html)
+        if not m:
+            self.log_debug("Captcha url data not found, maybe plugin out of date?")
+            self.fail("Captcha url data not found")
         captchaUrl = self.base_url + '/captcha.gif?d=%s&PHPSESSID=%s' % (m.group(1), m.group(2))
         self.log_debug("Waiting user for correct position")
         coords = self.captcha.decrypt(captchaUrl, input_type="gif", output_type='positional')

--- a/module/plugins/crypter/ShareLinksBiz.py
+++ b/module/plugins/crypter/ShareLinksBiz.py
@@ -68,8 +68,12 @@ class ShareLinksBiz(Crypter):
         url = pyfile.url
         if 's2l.biz' in url:
             url = self.load(url, just_header=True)['location']
-        self.base_url = "http://www.%s.biz" % re.match(self.__pattern__, url).group(1)
-        self.file_id = re.match(self.__pattern__, url).group('ID')
+        if re.match(self.__pattern__, url):
+            self.base_url = "http://www.%s.biz" % re.match(self.__pattern__, url).group(1)
+            self.file_id = re.match(self.__pattern__, url).group('ID')
+        else:
+            self.log_debug("Could not initialize, URL [%s] does not match pattern [%s]" % (url, self.__pattern__))
+            self.fail("Unsupported download link")
         self.package = pyfile.package()
 
 

--- a/module/plugins/crypter/ShareLinksBiz.py
+++ b/module/plugins/crypter/ShareLinksBiz.py
@@ -10,7 +10,7 @@ from module.plugins.internal.Crypter import Crypter
 class ShareLinksBiz(Crypter):
     __name__    = "ShareLinksBiz"
     __type__    = "crypter"
-    __version__ = "1.16"
+    __version__ = "1.17"
     __status__  = "testing"
 
     __pattern__ = r'http://(?:www\.)?(share-links|s2l)\.biz/(?P<ID>_?\w+)'


### PR DESCRIPTION
Fixes the error `'NoneType' object has no attribute 'group'` in the two crypters SharelinksBiz and FilecryptCC which had been reported as #1753.