### PR TITLE
Update MediafireCom.py

### DIFF
--- a/module/plugins/hoster/MediafireCom.py
+++ b/module/plugins/hoster/MediafireCom.py
@@ -11,7 +11,7 @@ class MediafireCom(SimpleHoster):
     __version__ = "0.90"
     __status__  = "testing"
 
-    __pattern__ = r'https?://(?:www\.)?mediafire\.com/(file/|view/\??|download(\.php\?|/)|\?)(?P<ID>\w{15})'
+    __pattern__ = r'https?://(?:www\.)?mediafire\.com/(file/|view/\??|download(\.php\?|/)|\?)(?P<ID>\w*)'
     __config__  = [("use_premium", "bool", "Use premium account if available", True)]
 
     __description__ = """Mediafire.com hoster plugin"""


### PR DESCRIPTION
Mediafire links aren't matched correctly against Regexp because ID expects 15 characters.
Links within the hoster don't seem to have that number of characters in the ID. For instance : http://www.mediafire.com/?bymzjtndprr (11 char)
==> I replaced {15} with * in the pattern in MediafireCom.py
Tested, seems to be working, my downloads finally start