### PR TITLE
[OneFichierCom] fix UpdateManager error: "Version mismatch"

### DIFF
--- a/module/plugins/hoster/OneFichierCom.py
+++ b/module/plugins/hoster/OneFichierCom.py
@@ -8,7 +8,7 @@ from module.plugins.internal.SimpleHoster import SimpleHoster, create_getInfo
 class OneFichierCom(SimpleHoster):
     __name__    = "OneFichierCom"
     __type__    = "hoster"
-    __version__ = "0.87"
+    __version__ = "0.88"
     __status__  = "testing"
 
     __pattern__ = r'https?://(?:www\.)?(?:(?P<ID1>\w+)\.)?(?P<HOST>1fichier\.com|alterupload\.com|cjoint\.net|d(es)?fichiers\.com|dl4free\.com|megadl\.fr|mesfichiers\.org|piecejointe\.net|pjointe\.com|tenvoi\.com)(?:/\?(?P<ID2>\w+))?'


### PR DESCRIPTION
```
19.08.2015 00:40:41 ERROR     HOOK UpdateManager: Error updating plugin: [hoster] OneFichierCom.py | Version mismatch
Traceback (most recent call last):
  File "/pyload/userplugins/hooks/UpdateManager.py", line 270, in _update_plugins
    raise Exception(_("Version mismatch"))
Exception: Version mismatch
```