### PR TITLE
[Plugin.py] cannot log unicode chars

### DIFF
--- a/module/plugins/internal/Plugin.py
+++ b/module/plugins/internal/Plugin.py
@@ -146,7 +146,7 @@ def chunks(iterable, size):
 class Plugin(object):
     __name__    = "Plugin"
     __type__    = "hoster"
-    __version__ = "0.30"
+    __version__ = "0.31"
     __status__  = "testing"
 
     __pattern__ = r'^unmatchable$'
@@ -180,7 +180,7 @@ class Plugin(object):
 
     def _log(self, level, plugintype, pluginname, messages):
         log = getattr(self.pyload.log, level)
-        msg = encode(" | ".join((a if isinstance(a, basestring) else str(a)).strip() for a in messages if a))
+        msg = " | ".join((a if isinstance(a, basestring) else str(a)).strip() for a in messages if a)
         log("%(plugintype)s %(pluginname)s%(id)s: %(msg)s"
             % {'plugintype': plugintype.upper(),
                'pluginname': pluginname,


### PR DESCRIPTION
if you try, for example, `self.log_debug(u"\u2022")` you get:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 874, in emit
    stream.write(fs % msg.encode("UTF-8"))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 53: ordinal not in range(128)
Logged from file Plugin.py, line 188
```