### PR TITLE
Broken OneFIchierCom plugin

### DIFF
--- a/module/plugins/hoster/OneFichierCom.py
+++ b/module/plugins/hoster/OneFichierCom.py
@@ -9,7 +9,7 @@ from module.plugins.internal.SimpleHoster import SimpleHoster, create_getInfo
 class OneFichierCom(SimpleHoster):
     __name__    = "OneFichierCom"
     __type__    = "hoster"
-    __version__ = "0.89"
+    __version__ = "0.90"
     __status__  = "testing"
 
     __pattern__ = r'https?://(?:www\.)?(?:(?P<ID1>\w+)\.)?(?P<HOST>1fichier\.com|alterupload\.com|cjoint\.net|d(es)?fichiers\.com|dl4free\.com|megadl\.fr|mesfichiers\.org|piecejointe\.net|pjointe\.com|tenvoi\.com)(?:/\?(?P<ID2>\w+))?'
@@ -54,7 +54,7 @@ class OneFichierCom(SimpleHoster):
                 else:
                     if 'content-type' in headers and headers['content-type'] == "application/octet-stream":
                         if "filename=" in headers.get('content-disposition'):
-                            name = dict(_i.split("=") for _i in map(str.strip, headers['content-disposition'].split(";"))[1:]['filename'].strip("\"'")
+                            name = dict(_i.split("=") for _i in map(str.strip, headers['content-disposition'].split(";"))[1:])['filename'].strip("\"'")
                         else:
                             name = url
 


### PR DESCRIPTION
Syntax error in commit [https://github.com/pyload/pyload/commit/10213910fdb5a1c2e7bde50fdd7cdfb99090bf7e] which makes importing OneFichierCom break.
Please test your code before pull requesting.