### PR TITLE
[utils.py] Added Petabytes to the formatSize function

### DIFF
--- a/module/utils.py
+++ b/module/utils.py
@@ -88,7 +88,7 @@ def formatSize(size):
     """formats size of bytes"""
     size = int(size)
     steps = 0
-    sizes = ["B", "KiB", "MiB", "GiB", "TiB"]
+    sizes = ["B", "KiB", "MiB", "GiB", "TiB", "Pib"]
     while size > 1000:
         size /= 1024.0
         steps += 1


### PR DESCRIPTION
pyLoad does not start one FreeBSD when having Terabytes of space, adding Petabytes in the list resolves this.