### PR TITLE
[Plugin] fix missing import

### DIFF
--- a/module/plugins/internal/Plugin.py
+++ b/module/plugins/internal/Plugin.py
@@ -9,6 +9,7 @@ import re
 import sys
 import traceback
 import urllib
+import urlparse
 
 if os.name != "nt":
     import grp
@@ -172,7 +173,7 @@ def chunks(iterable, size):
 class Plugin(object):
     __name__    = "Plugin"
     __type__    = "plugin"
-    __version__ = "0.35"
+    __version__ = "0.36"
     __status__  = "testing"
 
     __pattern__ = r'^unmatchable$'


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/share/pyload/module/PluginThread.py", line 191, in run
    pyfile.plugin.preprocessing(self)
  File "/home/user/.pyload-0.4.9/userplugins/internal/Hoster.py", line 184, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/user/.pyload-0.4.9/userplugins/internal/Hoster.py", line 179, in _process
    return self.process(self.pyfile)
  File "/home/user/.pyload-0.4.9/userplugins/hoster/MegaCoNz.py", line 218, in process
    self.download(mega['g'])
  File "/home/user/.pyload-0.4.9/userplugins/internal/Hoster.py", line 404, in download
    self.pyfile.name = parse_name(self.pyfile.name)  #: Safe check
  File "/home/user/.pyload-0.4.9/userplugins/internal/Plugin.py", line 58, in parse_name
    url_p = urlparse.urlparse(url.strip().rstrip('/'))
NameError: global name 'urlparse' is not defined
```