### PR TITLE
[Plugin] minor code fixes

### DIFF
--- a/module/plugins/internal/Plugin.py
+++ b/module/plugins/internal/Plugin.py
@@ -173,7 +173,7 @@ def chunks(iterable, size):
 class Plugin(object):
     __name__    = "Plugin"
     __type__    = "plugin"
-    __version__ = "0.37"
+    __version__ = "0.38"
     __status__  = "testing"
 
     __pattern__ = r'^unmatchable$'
@@ -231,8 +231,6 @@ class Plugin(object):
 
     def log_warning(self, *args):
         self._log("warning", self.__type__, self.__name__, args)
-        if self.pyload.debug:
-            traceback.print_exc()
 
 
     def log_error(self, *args):
@@ -347,7 +345,7 @@ class Plugin(object):
         """
         if self.pyload.debug:
             self.log_debug("LOAD URL " + url,
-                           *["%s=%s" % (key, val) for key, val in locals().items() if key not in ("self", "url")])
+                           *["%s=%s" % (key, val) for key, val in locals().items() if key not in ("self", "url", "_[1]")])
 
         if req is None:
             req = self.req or self.pyload.requestFactory.getRequest(self.__name__)


### PR DESCRIPTION
using `print_exc()`  on `log_warning()` make my debug log go crazy with unnecessary and false exception like messages

here is an example:
```
25.09.2015 15:38:54 ERROR     ADDON ExtractArchive: apache-tomcat-6.0.44-deployer.zip | Extract failed
Traceback (most recent call last):
  File "/home/user/.pyload-0.4.9/userplugins/hooks/ExtractArchive.py", line 338, in extract
    new_files = self._extract(pyfile, archive, pypack.password)
  File "/home/user/.pyload-0.4.9/userplugins/hooks/ExtractArchive.py", line 520, in _extract
    raise Exception(_("Extract failed"))
Exception: Extract failed
Exception in thread Thread-11:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/share/pyload/module/PluginThread.py", line 463, in run
    self.f(*self.args, **self.kwargs)
  File "/home/user/.pyload-0.4.9/userplugins/hooks/ExtractArchive.py", line 196, in extract_queued
    if self.extract(packages, thread):  #@NOTE: check only if all gone fine, no failed reporting for now
  File "/home/user/.pyload-0.4.9/userplugins/hooks/ExtractArchive.py", line 308, in extract
    targets = Extractor.get_targets(files_ids)
  File "/home/user/.pyload-0.4.9/userplugins/internal/Extractor.py", line 76, in get_targets
    pname = re.sub(cls.re_multipart, "", fname) if cls.is_multipart(fname) else os.path.splitext(fname)[0]
AttributeError: type object 'UnZip' has no attribute 'is_multipart'
```