### PR TITLE
[XFSHoster] re-fix #1865

### DIFF
--- a/module/plugins/internal/XFSHoster.py
+++ b/module/plugins/internal/XFSHoster.py
@@ -14,7 +14,7 @@ from module.utils import html_unescape
 class XFSHoster(SimpleHoster):
     __name__    = "XFSHoster"
     __type__    = "hoster"
-    __version__ = "0.61"
+    __version__ = "0.62"
     __status__  = "testing"
 
     __pattern__ = r'^unmatchable$'
@@ -244,7 +244,7 @@ class XFSHoster(SimpleHoster):
         try:
             captcha_key = re.search(self.RECAPTCHA_PATTERN, self.html).group(1)
 
-        except (AttributeError, IndexError):
+        except (AttributeError, IndexError, TypeError):
             captcha_key = recaptcha.detect_key()
 
         else:
@@ -258,7 +258,7 @@ class XFSHoster(SimpleHoster):
         try:
             captcha_key = re.search(self.SOLVEMEDIA_PATTERN, self.html).group(1)
 
-        except (AttributeError, IndexError):
+        except (AttributeError, IndexError, TypeError):
             captcha_key = solvemedia.detect_key()
 
         else:


### PR DESCRIPTION
after 0c9e92172f69769f72a2a258f717be4bc4d7a397 #1865 is back:
```
Traceback (most recent call last):
  File "/usr/share/pyload/module/PluginThread.py", line 191, in run
    pyfile.plugin.preprocessing(self)
  File "/home/user/.pyload-0.4.9/userplugins/internal/Hoster.py", line 196, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/user/.pyload-0.4.9/userplugins/internal/Hoster.py", line 191, in _process
    return self.process(self.pyfile)
  File "/home/user/.pyload-0.4.9/userplugins/internal/SimpleHoster.py", line 279, in process
    self.handle_free(pyfile)
  File "/home/user/.pyload-0.4.9/userplugins/internal/XFSHoster.py", line 101, in handle_free
    data = self.get_post_parameters()
  File "/home/user/.pyload-0.4.9/userplugins/internal/XFSHoster.py", line 209, in get_post_parameters
    self.handle_captcha(inputs)
  File "/home/user/.pyload-0.4.9/userplugins/internal/XFSHoster.py", line 245, in handle_captcha
    captcha_key = re.search(self.RECAPTCHA_PATTERN, self.html).group(1)
  File "/usr/lib/python2.7/re.py", line 142, in search
    return _compile(pattern, flags).search(string)
  File "/usr/lib/python2.7/re.py", line 240, in _compile
    raise TypeError, "first argument must be string or compiled pattern"
TypeError: first argument must be string or compiled pattern
01.10.2015 01:09:27 INFO      Debug Report written to debug_HundredEightyUploadCom_01-10-2015_01-09-27.zip
```
