### PR TITLE
[ClickAndLoad] Update

### DIFF
--- a/module/plugins/hooks/ClickAndLoad.py
+++ b/module/plugins/hooks/ClickAndLoad.py
@@ -8,8 +8,6 @@ try:
 except ImportError:
     pass
 
-from threading import Lock
-
 from module.plugins.internal.Addon import Addon, threaded
 
 
@@ -29,7 +27,7 @@ def forward(source, destination):
 class ClickAndLoad(Addon):
     __name__    = "ClickAndLoad"
     __type__    = "hook"
-    __version__ = "0.47"
+    __version__ = "0.48"
     __status__  = "testing"
 
     __config__ = [("activated", "bool", "Activated"                             , True ),
@@ -55,7 +53,7 @@ class ClickAndLoad(Addon):
 
 
     @threaded
-    def forward(source, destination, queue=False):
+    def forward(self, source, destination, queue=False):
         if queue:
             old_ids = set(pack.id for pack in self.pyload.api.getCollector())
 
@@ -74,10 +72,6 @@ class ClickAndLoad(Addon):
         self.log_info(_("Proxy listening on %s:%s") % (ip or "0.0.0.0", cnlport))
 
         self._server(ip, webport, cnlport)
-
-        lock = Lock()
-        lock.acquire()
-        lock.acquire()
 
 
     @threaded


### PR DESCRIPTION
`forward()` function definition error.
also, a `Lock` is not required because function `_server()` is already `threaded`.

P.S.
what does the new setting `"Add packages to queue"` does exactly?
also, why does the delay `time.sleep(10)` before actually calling `_server()`?