### PR TITLE
Encoding fix: 'ascii' codec can't encode character

### DIFF
--- a/module/plugins/PluginManager.py
+++ b/module/plugins/PluginManager.py
@@ -215,7 +215,8 @@ class PluginManager:
 
             for name, value in chain(self.crypterPlugins.iteritems(), self.hosterPlugins.iteritems(),
                 self.containerPlugins.iteritems()):
-                if value["re"].match(url):
+                re = value.get("re", None)
+                if re != None and re.match(url):
                     res.append((url, name))
                     last = (name, value)
                     found = True

--- a/module/plugins/internal/Plugin.py
+++ b/module/plugins/internal/Plugin.py
@@ -60,7 +60,7 @@ def fixurl(url, unquote=None):
     if unquote is None:
         unquote = newurl == url
 
-    newurl = html_unescape(decode(newurl).decode('unicode-escape'))
+    newurl = html_unescape(newurl.encode('ascii', 'ignore'))
     newurl = re.sub(r'(?<!:)/{2,}', '/', newurl).strip().lstrip('.')
 
     if not unquote:


### PR DESCRIPTION
This fix following errors for me:

> WARNING   Info Fetching for UlozTo failed | 'ascii' codec can't encode character u'\xfd' in position 19: ordinal not in range(128)

I think this should solve also issue https://github.com/pyload/pyload/issues/1737 or https://github.com/pyload/pyload/issues/1949

Treated also other discoved problem which prevents downloading:

>   File ".../pyload/module/plugins/PluginManager.py", line 218, in parseUrls
>     if value["re"].match(url):
> KeyError: 're'
