### PR TITLE
[UptoboxCom] fix "Version mismatch"

### DIFF
--- a/module/plugins/accounts/UptoboxCom.py
+++ b/module/plugins/accounts/UptoboxCom.py
@@ -10,7 +10,7 @@ from module.plugins.internal.XFSAccount import XFSAccount
 class UptoboxCom(XFSAccount):
     __name__    = "UptoboxCom"
     __type__    = "account"
-    __version__ = "0.15"
+    __version__ = "0.17"
     __status__  = "testing"
 
     __description__ = """Uptobox.com account plugin"""


### PR DESCRIPTION
```
13.10.2015 09:57:04 ERROR     HOOK UpdateManager: Error updating plugin: ACCOUNT UptoboxCom | Version mismatch
13.10.2015 09:57:04 ERROR     Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 783, in __bootstrap
    self.__bootstrap_inner()
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/share/pyload/module/PluginThread.py", line 472, in run
    self.f(*self.args, **self.kwargs)
  File "/home/user/.pyload-0.4.9/userplugins/hooks/UpdateManager.py", line 152, in update
    if self._update() is not 2 or not self.get_config('autorestart'):
  File "/home/user/.pyload-0.4.9/userplugins/hooks/UpdateManager.py", line 174, in _update
    exitcode = self.update_plugins()
  File "/home/user/.pyload-0.4.9/userplugins/hooks/UpdateManager.py", line 197, in update_plugins
    updated = self._update_plugins(updates)
  File "/home/user/.pyload-0.4.9/userplugins/hooks/UpdateManager.py", line 318, in _update_plugins
    raise Exception(_("Version mismatch"))
Exception: Version mismatch
13.10.2015 09:57:04 INFO      HOOK UpdateManager: *** No plugin updates available ***
```