### PR TITLE
[XFileSharingPro] update

### DIFF
--- a/module/plugins/hoster/XFileSharingPro.py
+++ b/module/plugins/hoster/XFileSharingPro.py
@@ -8,7 +8,7 @@ from module.plugins.internal.XFSHoster import XFSHoster, create_getInfo
 class XFileSharingPro(XFSHoster):
     __name__    = "XFileSharingPro"
     __type__    = "hoster"
-    __version__ = "0.54"
+    __version__ = "0.55"
     __status__  = "testing"
 
     __pattern__ = r'https?://(?:www\.)?(?:\w+\.)*?(?P<DOMAIN>(?:[\d.]+|[\w\-^_]{3,}(?:\.[a-zA-Z]{2,}){1,2})(?:\:\d+)?)/(?:embed-)?\w{12}(?:\W|$)'
@@ -37,7 +37,7 @@ class XFileSharingPro(XFSHoster):
 
 
     def _setup(self):
-        account_name     = self.classname if self.account.PLUGIN_DOMAIN is None else self.PLUGIN_NAME
+        account_name     = self.classname if not self.account or self.account.PLUGIN_DOMAIN is None else self.PLUGIN_NAME
         self.chunk_limit = 1
         self.multiDL     = True
 


### PR DESCRIPTION
```
16.10.2015 14:36:04 WARNING   Download failed: L1f31s5tr4n633p3PSN.part01.rar | 'NoneType' object has no attribute 'PLUGIN_DOMAIN'
Traceback (most recent call last):
  File "/usr/share/pyload/module/PluginThread.py", line 191, in run
    pyfile.plugin.preprocessing(self)
  File "/home/user/.pyload-0.4.9/userplugins/internal/Base.py", line 218, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/user/.pyload-0.4.9/userplugins/internal/Hoster.py", line 78, in _process
    self._setup()
  File "/home/user/.pyload-0.4.9/userplugins/hoster/XFileSharingPro.py", line 39, in _setup
    account_name     = self.__name__ if self.account.PLUGIN_DOMAIN is None else self.PLUGIN_NAME
AttributeError: 'NoneType' object has no attribute 'PLUGIN_DOMAIN'
```