### PR TITLE
[BasePlugin] Http hoster is not an internal hoster

### DIFF
--- a/module/plugins/hoster/BasePlugin.py
+++ b/module/plugins/hoster/BasePlugin.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from module.plugins.internal.hoster.Http import Http, create_getInfo
+from module.plugins.hoster.Http import Http, create_getInfo
 
 
 class BasePlugin(Http):
     __name__    = "BasePlugin"
     __type__    = "hoster"
-    __version__ = "0.48"
+    __version__ = "0.49"
     __status__  = "testing"
 
     __pattern__ = r'^unmatchable$'


### PR DESCRIPTION
This fixes an import of the [Http hoster](https://github.com/pyload/pyload/blob/aff9388d433847fa7adad7421c4d76bd5bdd4e5a/module/plugins/hoster/Http.py), which is not an internal hoster.
I don't know if it is intended to move `Http.py` to the `internal` directory?