### PR TITLE
[ExternalScripts] fix: 'PackageData' object has no attribute 'id'

### DIFF
--- a/module/plugins/hooks/ExternalScripts.py
+++ b/module/plugins/hooks/ExternalScripts.py
@@ -10,7 +10,7 @@ from module.plugins.internal.utils import encode, fs_join
 class ExternalScripts(Addon):
     __name__    = "ExternalScripts"
     __type__    = "hook"
-    __version__ = "0.53"
+    __version__ = "0.54"
     __status__  = "testing"
 
     __config__ = [("activated", "bool", "Activated"                   , True ),
@@ -178,7 +178,7 @@ class ExternalScripts(Addon):
         else:
             dl_folder = self.pyload.config.get("general", "download_folder")
 
-        args = [pypack.id, pypack.name, dl_folder, pypack.password]
+        args = [pypack.pid, pypack.name, dl_folder, pypack.password]
         self._call("package_deleted", args)
 
 


### PR DESCRIPTION
[ExternalScripts.py#L174](https://github.com/pyload/pyload/blob/stable/module/plugins/hooks/ExternalScripts.py#L174) :
`getPackageInfo(pid)` returns a `PackageData` object while all other events gets a `PyPackage` object.

```
20.10.2015 14:30:41 WARNING   Error calling event handler packageDeleted: <bound method ExternalScripts.package_deleted of <Hook ExternalScripts>>, (129,), 'PackageData' object has no attribute 'id'
Traceback (most recent call last):
  File "/usr/share/pyload/module/HookManager.py", line 309, in dispatchEvent
    f(*args)
  File "/home/user/.pyload-0.4.9/userplugins/hooks/ExternalScripts.py", line 181, in package_deleted
    args = [pypack.id, pypack.name, dl_folder, pypack.password]
AttributeError: 'PackageData' object has no attribute 'id'
20.10.2015 14:30:43 WARNING   Error calling event handler packageDeleted: <bound method ExternalScripts.package_deleted of <Hook ExternalScripts>>, (130,), 'PackageData' object has no attribute 'id'
Traceback (most recent call last):
  File "/usr/share/pyload/module/HookManager.py", line 309, in dispatchEvent
    f(*args)
  File "/home/user/.pyload-0.4.9/userplugins/hooks/ExternalScripts.py", line 181, in package_deleted
    args = [pypack.id, pypack.name, dl_folder, pypack.password]
AttributeError: 'PackageData' object has no attribute 'id'
```