### PR TITLE
[DeadHoster] StahnuTo

### DIFF
--- a/module/plugins/hoster/StahnuTo.py
+++ b/module/plugins/hoster/StahnuTo.py
@@ -1,0 +1,16 @@
+from module.plugins.internal.DeadHoster import DeadHoster, create_getInfo
+
+class StahnuTo(DeadHoster):
+    __name__ = "StahnuTo"
+    __type__ = "hoster"
+    __version__ = "0.13"
+    __status__  = "stable"
+
+    __pattern__ = r"http://(\w*\.)?stahnu.to/(files/get/|.*\?file=)([^/]+).*"
+    __config__  = []  #@TODO: Remove in 0.4.10
+
+    __description__ = """stahnu.to"""
+    __license__     = "GPLv3"
+    __author_name__ = ("zoidberg")
+
+getInfo = create_getInfo(StahnuTo)


### PR DESCRIPTION
```
24.10.2015 01:07:11 ERROR     Error importing StahnuTo: cannot import name parseFileInfo
Traceback (most recent call last):
  File "/usr/share/pyload/module/plugins/PluginManager.py", line 270, in loadModule
    plugins[name]["name"])
  File "/usr/share/pyload/module/plugins/hoster/StahnuTo.py", line 20, in <module>
    from module.plugins.internal.SimpleHoster import SimpleHoster, parseFileInfo
ImportError: cannot import name parseFileInfo
```