### PR TITLE
[hoster/ShareonlineBiz] Fix error checking regex

### DIFF
--- a/module/plugins/hoster/ShareonlineBiz.py
+++ b/module/plugins/hoster/ShareonlineBiz.py
@@ -12,7 +12,7 @@ from module.plugins.internal.SimpleHoster import SimpleHoster, create_getInfo
 class ShareonlineBiz(SimpleHoster):
     __name__    = "ShareonlineBiz"
     __type__    = "hoster"
-    __version__ = "0.61"
+    __version__ = "0.62"
     __status__  = "testing"
 
     __pattern__ = r'https?://(?:www\.)?(share-online\.biz|egoshare\.com)/(download\.php\?id=|dl/)(?P<ID>\w+)'
@@ -146,7 +146,7 @@ class ShareonlineBiz(SimpleHoster):
 
 
     def check_errors(self):
-        m = re.search(r"/failure/(.*?)/1", self.req.lastEffectiveURL)
+        m = re.search(r"/failure/(.*?)/", self.req.lastEffectiveURL)
         if m is None:
             self.info.pop('error', None)
             return


### PR DESCRIPTION
In case of a failure, the regex `r"/failure/(.*?)/1"` in `check_errors` may fail, due to the fact that there can be any other number than 1 following the error message itself, e.g.
`dl/TPDSG2RNU70/failure/freelimit/209715200/363232323337313B666F6F`