### PR TITLE
[SimpleHoster] update

### DIFF
--- a/module/plugins/internal/SimpleHoster.py
+++ b/module/plugins/internal/SimpleHoster.py
@@ -17,7 +17,7 @@ from module.plugins.internal.utils import (encode, parse_name, parse_size,
 class SimpleHoster(Hoster):
     __name__    = "SimpleHoster"
     __type__    = "hoster"
-    __version__ = "2.06"
+    __version__ = "2.07"
     __status__  = "stable"
 
     __pattern__ = r'^unmatchable$'
@@ -420,7 +420,7 @@ class SimpleHoster(Hoster):
 
 
     def handle_direct(self, pyfile):
-        self.link = self.isdownload(pyfile.url)
+        self.link = pyfile.url if self.isdownload(pyfile.url) else None
 
 
     def handle_multi(self, pyfile):  #: Multi-hoster handler


### PR DESCRIPTION
Hi,
`http://1fichier.com/?86zu29oou8` is a direct link and is resumable.

Passing `http://1fichier.com/?86zu29oou8` to `isdownload` returns `https://a-9.1fichier.com/s29174186` as a download link, but if you try to download directly from `https://a-9.1fichier.com/s29174186` you get an error.

Also, if a link is a direct link, I don't  see the reason why not use the original link.
