### PR TITLE
[Plugin] censor ACCOUNT request data

### DIFF
--- a/module/plugins/internal/Account.py
+++ b/module/plugins/internal/Account.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import copy
 import random
 import re
 import threading
@@ -12,7 +13,7 @@ from module.plugins.internal.utils import compare_time, isiterable, lock, parse_
 class Account(Plugin):
     __name__    = "Account"
     __type__    = "account"
-    __version__ = "0.65"
+    __version__ = "0.66"
     __status__  = "stable"
 
     __description__ = """Base account plugin"""
@@ -237,7 +238,9 @@ class Account(Plugin):
 
             self.syncback()
 
-            self.log_debug("Account info for user `%s`: %s" % (self.user, self.info))
+            safe_info = copy.deepcopy(self.info)
+            safe_info['login']['password'] = "**********"
+            self.log_debug("Account info for user `%s`: %s" % (self.user, safe_info))
 
         return self.info
 

--- a/module/plugins/internal/Plugin.py
+++ b/module/plugins/internal/Plugin.py
@@ -20,7 +20,7 @@ from module.plugins.internal.utils import *
 class Plugin(object):
     __name__    = "Plugin"
     __type__    = "plugin"
-    __version__ = "0.59"
+    __version__ = "0.60"
     __status__  = "stable"
 
     __config__  = []  #: [("name", "type", "desc", "default")]
@@ -214,7 +214,7 @@ class Plugin(object):
         """
         if self.pyload.debug:
             self.log_debug("LOAD URL " + url,
-                           *["%s=%s" % (key, val) for key, val in locals().items() if key not in ("self", "url", "_[1]")])
+                           *["%s=%s" % (key, "{********}" if self.__type__ == "account" and key in ("get", "post") else val) for key, val in locals().items() if key not in ("self", "url", "_[1]")])
 
         url = fixurl(url, unquote=True)  #: Recheck in 0.4.10
 


### PR DESCRIPTION
HI,
After the third time I see someone post a log that reveals his user and password, I think that @joberreiter was right in #2061
To overcome the request logging issue discussed in #2061, this PR will mask the requests of all account plugins.

Now you can reimplement `safe_info`.