### PR TITLE
fixed Keep2Share redirection mess

### DIFF
--- a/module/plugins/hoster/Keep2ShareCc.py
+++ b/module/plugins/hoster/Keep2ShareCc.py
@@ -10,7 +10,7 @@ from module.plugins.internal.SimpleHoster import SimpleHoster, create_getInfo
 class Keep2ShareCc(SimpleHoster):
     __name__    = "Keep2ShareCc"
     __type__    = "hoster"
-    __version__ = "0.28"
+    __version__ = "0.29"
     __status__  = "testing"
 
     __pattern__ = r'https?://(?:www\.)?(keep2share|k2s|keep2s)\.cc/file/(?P<ID>\w+)'
@@ -25,8 +25,6 @@ class Keep2ShareCc(SimpleHoster):
     __authors__     = [("stickell", "l.stickell@yahoo.it"),
                        ("Walter Purcaro", "vuolter@gmail.com")]
 
-
-    URL_REPLACEMENTS = [(__pattern__ + ".*", "http://keep2s.cc/file/\g<ID>")]
 
     NAME_PATTERN = r'File: <span>(?P<N>.+?)</span>'
     SIZE_PATTERN = r'Size: (?P<S>[^<]+)</div>'
@@ -115,7 +113,7 @@ class Keep2ShareCc(SimpleHoster):
         m = re.search(self.CAPTCHA_PATTERN, self.data)
         self.log_debug("CAPTCHA_PATTERN found %s" % m)
         if m is not None:
-            captcha_url = urlparse.urljoin("http://keep2s.cc/", m.group(1))
+            captcha_url = urlparse.urljoin(self.pyfile.url, m.group(1))
             post_data['CaptchaForm[code]'] = self.captcha.decrypt(captcha_url)
         else:
             recaptcha = ReCaptcha(self)

--- a/module/plugins/internal/Base.py
+++ b/module/plugins/internal/Base.py
@@ -36,7 +36,7 @@ def create_getInfo(klass):
 class Base(Plugin):
     __name__    = "Base"
     __type__    = "base"
-    __version__ = "0.19"
+    __version__ = "0.20"
     __status__  = "stable"
 
     __pattern__ = r'^unmatchable$'
@@ -278,6 +278,30 @@ class Base(Plugin):
     #: Deprecated method, use `_process` instead (Remove in 0.4.10)
     def preprocessing(self, *args, **kwargs):
         return self._process(*args, **kwargs)
+
+
+    def follow_redirects_and_get_header(self, redirect=10, update_pyfile=True):
+        maxredirs = 1
+
+        if type(redirect) is int:
+            maxredirs = max(redirect, 1)
+
+        elif redirect:
+            maxredirs = self.get_config("maxredirs", default=maxredirs, plugin="UserAgentSwitcher")
+
+        url = self.pyfile.url
+        for i in xrange(maxredirs):
+            self.log_debug("Redirect #%d to: %s" % (i, url))
+
+            header = self.load(url, just_header=True)
+
+            if header.get('location'):
+                url = self.fixurl(header.get('location'), url)
+                if update_pyfile:
+                    self.pyfile.url = url
+            else:
+                return header
+        return header
 
 
     def process(self, pyfile):


### PR DESCRIPTION
Keep2Share has many names: keep2share.cc, k2s.cc, keep2s.cc and if a link is for the wrong version, they will HTTP-redict to the correct one.

So, If I paste a link for k2s.cc/bla into pyload but the file is at keep2s.cc/bla. Then, k2s.cc will respond with 302, location: keep2s.cc/bla. That's fine as long as we don't want to POST anything, since, by default, libcurl will follow the sequence POST->302 with GET, and what we receive for our captcha submission is the original page, and pyload gets confused because there is no answer to our captcha submission.

Fix 1: one could  add
```
self.c.setopt(pycurl.POSTREDIR, pycurl.REDIR_POST_ALL)
```
to initHandle() in HTTPRequest.py - note that this requires libcurl 7.17.1 (see http://curl.haxx.se/libcurl/c/CURLOPT_POSTREDIR.html)

Fix 2: one could add a method following all redirects at the beginning of a process() and replace pyfile.url with the result of the last redirect.

In fact, the second option is preferable since the different keep2share variants seem to handle their captchas independently meaning, if k2s.cc gives you a captcha & you submit the (correct) solution to keep2s.cc, it will result in a "captcha invalid" response because it's not submitted to the right server.

I figured, Base.py would be the right place to implement this, as following redirects is not hoster specific but might apply to crypers too...