### PR TITLE
Fix formatting for large size input

### DIFF
--- a/module/utils.py
+++ b/module/utils.py
@@ -88,8 +88,8 @@ def formatSize(size):
     """formats size of bytes"""
     size = int(size)
     steps = 0
-    sizes = ["B", "KiB", "MiB", "GiB", "TiB"]
-    while size > 1000:
+    sizes = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]
+    while size > 1000 and steps < len(sizes)-1:
         size /= 1024.0
         steps += 1
     return "%.2f %s" % (size, sizes[steps])


### PR DESCRIPTION
Hello,

on my system, Python somehow reports too much available disk space. The raw value returned from `utils.py/freeSpace()` was `2161244370894848`. Since PyLoad checks the value at boot time, this prevented the start up with the following exception:

```
  File ".../pyload/pyLoadCore.py", line 667, in <module>
	main()
  File ".../pyload/pyLoadCore.py", line 658, in main
	pyload_core.start()
  File ".../pyload/pyLoadCore.py", line 412, in start
	self.log.info(_("Free space: %s") % formatSize(spaceLeft))
  File ".../pyload/module/utils.py", line 95, in formatSize
	return "%.2f %s" % (size, sizes[steps])
IndexError: list index out of range
```

Therefore, I suggest this pull request as a fix for similar situations. The master branch should not be affected by this bug, as the bitmath library handles (my) large size input correctly.

Kind regards,
Tobias