### PR TITLE
Fix: Nitroflare cannot be handled as Direct Download

### DIFF
--- a/module/plugins/hoster/NitroflareCom.py
+++ b/module/plugins/hoster/NitroflareCom.py
@@ -29,6 +29,7 @@ class NitroflareCom(SimpleHoster):
     OFFLINE_PATTERN = r'>File doesn\'t exist'
 
     LINK_PREMIUM_PATTERN = LINK_FREE_PATTERN = r'(https?://[\w\-]+\.nitroflare\.com/.+?)"'
+    DIRECT_LINK = False
 
     RECAPTCHA_KEY        = "6Lenx_USAAAAAF5L1pmTWvWcH73dipAEzNnmNLgy"
     PREMIUM_ONLY_PATTERN = r'This file is available with Premium only'


### PR DESCRIPTION
Alternatively, you could not declare all Hosters to be DIRECT_LINK = True in SimpleHoster.py