### PR TITLE
 decryption was failing, with error Decrypting failed:****.dlc | global name 'pyfile' is not defined

### DIFF
--- a/module/plugins/internal/Container.py
+++ b/module/plugins/internal/Container.py
@@ -48,7 +48,7 @@ class Container(Crypter):
 
     def _delete_tmpfile(self):
         if self.pyfile.name.startswith("tmp_"):
-            self.remove(pyfile.url, trash=False)
+            self.remove(self.pyfile.url, trash=False)
 
 
     def _make_tmpfile(self):


### PR DESCRIPTION
dlc decryption was failing, with error Decrypting failed:****.dlc | global name 'pyfile' is not defined
debug mode showed missing self