### PR TITLE
'super' object has no attribute 'check_download'

### DIFF
--- a/module/plugins/internal/SimpleHoster.py
+++ b/module/plugins/internal/SimpleHoster.py
@@ -290,7 +290,7 @@ class SimpleHoster(Hoster):
 
 
     def check_download(self):
-        super(SimpleHoster, self).check_download()
+        super(SimpleHoster, self)._check_download()
 
         self.log_info(_("Checking file (with built-in rules)..."))
         for r, p in self.FILE_ERRORS:


### PR DESCRIPTION
In earlier versions (before Octobre) there was a check_download in the Hoster.py but now there is only a _check_download.
Not sure what the idea is here, but with this change everything works fine and the download progress bar in queue is updated correctly.