### PR TITLE
[Hoster] Python 2.5 compatibility hack for property.setter

### DIFF
--- a/module/plugins/internal/Hoster.py
+++ b/module/plugins/internal/Hoster.py
@@ -13,10 +13,28 @@ from module.plugins.internal.Plugin import Fail, Retry
 from module.plugins.internal.misc import compute_checksum, encode, exists, fixurl, fsjoin, parse_name, safejoin
 
 
+# Python 2.5 compatibility hack for property.setter, property.deleter
+import __builtin__
+if not hasattr(__builtin__.property, "setter"):
+    class property(__builtin__.property):
+        __metaclass__ = type
+
+        def setter(self, method):
+            return property(self.fget, method, self.fdel)
+
+        def deleter(self, method):
+            return property(self.fget, self.fset, method)
+
+        @__builtin__.property
+        def __doc__(self):
+            """Doc seems not to be set correctly when subclassing"""
+            return self.fget.__doc__
+
+
 class Hoster(Base):
     __name__    = "Hoster"
     __type__    = "hoster"
-    __version__ = "0.47"
+    __version__ = "0.48"
     __status__  = "stable"
 
     __pattern__ = r'^unmatchable$'


### PR DESCRIPTION
Python 2.5 does not support `@property.setter`