### PR TITLE
[ClickNLoad] Shutdown gracefully + code cleanup

### DIFF
--- a/module/plugins/hooks/ClickNLoad.py
+++ b/module/plugins/hooks/ClickNLoad.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import socket
+import threading
 import time
 
 try:
@@ -16,7 +17,7 @@ from module.plugins.internal.misc import forward, lock
 class ClickNLoad(Addon):
     __name__    = "ClickNLoad"
     __type__    = "hook"
-    __version__ = "0.53"
+    __version__ = "0.54"
     __status__  = "testing"
 
     __config__ = [("activated", "bool"           , "Activated"                      , True       ),
@@ -31,17 +32,42 @@ class ClickNLoad(Addon):
                        ("GammaC0de"     , "nitzo2001[AT]yahoo[DOT]com")]
 
 
+    def init(self):
+        self.cnl_ip    = "" if self.config.get('extern') else "127.0.0.1"
+        self.cnl_port  = self.config.get('port')
+        self.web_ip    = "127.0.0.1" if any(_ip == self.pyload.config.get('webinterface', 'host') for _ip in ("0.0.0.0", "")) \
+            else self.pyload.config.get('webinterface', 'host')
+        self.web_port  = self.pyload.config.get('webinterface', 'port')
+
+        self.do_exit = False
+        self.exit_done = threading.Event()
+
+
     def activate(self):
         if not self.pyload.config.get('webinterface', 'activated'):
+            self.log_warning(_("pyLoad's Web interface is not active, ClickNLoad cannot start"))
             return
 
-        cnlip   = "" if self.config.get('extern') else "127.0.0.1"
-        cnlport = self.config.get('port')
-        webip   = "127.0.0.1" if any(_ip == self.pyload.config.get('webinterface', 'host') for _ip in ("0.0.0.0", "")) \
-            else self.pyload.config.get('webinterface', 'host')
-        webport = self.pyload.config.get('webinterface', 'port')
+        self.pyload.scheduler.addJob(5, self.proxy, threaded=False)
 
-        self.pyload.scheduler.addJob(5, self.proxy, [cnlip, cnlport, webip, webport], threaded=False)
+
+    def exit(self):
+        self.log_info(_("Shutting down proxy..."))
+
+        self.do_exit = True
+
+        try:
+            wakeup_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            wakeup_socket.connect(("127.0.0.1" if any(_ip == self.cnl_ip for _ip in ("0.0.0.0", "")) else self.cnl_ip, self.cnl_port))
+            wakeup_socket.close()
+        except Exception:
+            pass
+
+        success_exit = self.exit_done.wait(10)
+        if success_exit:
+            self.log_debug(_("Server exited successfully"))
+        else:
+            self.log_warning(_("Server was not exited gracefully, shutdown forced"))
 
 
     @lock
@@ -59,48 +85,58 @@ class ClickNLoad(Addon):
 
 
     @threaded
-    def proxy(self, cnlip, cnlport, webip, webport):
-        self.log_info(_("Proxy listening on %s:%s") % (cnlip or "0.0.0.0", cnlport))
-        self._server(cnlip, cnlport, webip, webport)
+    def proxy(self):
+        self.log_info(_("Proxy listening on %s:%s") % (self.cnl_ip or "0.0.0.0", self.cnl_port))
+        self._server()
 
 
     @threaded
-    def _server(self, cnlip, cnlport, webip, webport):
+    def _server(self):
         try:
+            self.exit_done.clear()
+
             dock_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            dock_socket.bind((cnlip, cnlport))
+            dock_socket.bind((self.cnl_ip, self.cnl_port))
             dock_socket.listen(5)
 
             while True:
                 client_socket, client_addr = dock_socket.accept()
-                self.log_debug("Connection from %s:%s" % client_addr)
 
-                server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                if not self.do_exit:
+                    self.log_debug(_("Connection from %s:%s") % client_addr)
 
-                if self.pyload.config.get('webinterface', 'https'):
-                    try:
-                        server_socket = ssl.wrap_socket(server_socket)
+                    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-                    except NameError:
-                        self.log_error(_("Missing SSL lib"), _("Please disable HTTPS in pyLoad settings"))
-                        client_socket.close()
-                        continue
+                    if self.pyload.config.get('webinterface', 'https'):
+                        try:
+                            server_socket = ssl.wrap_socket(server_socket)
 
-                    except Exception, e:
-                        self.log_error(_("SSL error: %s") % e.message)
-                        client_socket.close()
-                        continue
+                        except NameError:
+                            self.log_error(_("Missing SSL lib"), _("Please disable HTTPS in pyLoad settings"))
+                            client_socket.close()
+                            continue
 
-                server_socket.connect((webip, webport))
+                        except Exception, e:
+                            self.log_error(_("SSL error: %s") % e.message)
+                            client_socket.close()
+                            continue
 
-                self.forward(client_socket, server_socket, self.config.get('dest') == "queue")
-                self.forward(server_socket, client_socket)
+                    server_socket.connect((self.web_ip, self.web_port))
+
+                    self.forward(client_socket, server_socket, self.config.get('dest') == "queue")
+                    self.forward(server_socket, client_socket)
+
+                else:
+                    break
+
+            dock_socket.close()
+            self.exit_done.set()
 
         except socket.timeout:
-            self.log_debug("Connection timed out, retrying...")
-            return self._server(cnlip, cnlport, webip, webport)
+            self.log_debug(_("Connection timed out, retrying..."))
+            return self._server()
 
         except socket.error, e:
             self.log_error(e)
             time.sleep(240)
-            return self._server(cnlip, cnlport, webip, webport)
+            return self._server()


### PR DESCRIPTION
As the title says:
`ClickNLoad` will gracefully close the server socket befor exiting - no more "address already in use" errors (hopefully)

One question:
What is the purpose of the startup delay?