### PR TITLE
Bump version of CaptchaService.py

### DIFF
--- a/module/plugins/internal/CaptchaService.py
+++ b/module/plugins/internal/CaptchaService.py
@@ -6,7 +6,7 @@ from module.plugins.internal.Captcha import Captcha
 class CaptchaService(Captcha):
     __name__    = "CaptchaService"
     __type__    = "captcha"
-    __version__ = "0.34"
+    __version__ = "0.35"
     __status__  = "stable"
 
     __description__ = """Base anti-captcha service plugin"""


### PR DESCRIPTION
The file contains a change, that doesn't make it down to us users ;)

pyLoad 0.4.9 Debug Report of ShareonlineBiz 0.65 

```
TRACEBACK:
 Traceback (most recent call last):
  File "/volume1/web/pyload-git-stable/module/PluginThread.py", line 187, in run
    pyfile.plugin.preprocessing(self)
  File "/volume1/@optware/share/pyload_config/userplugins/internal/Base.py", line 288, in preprocessing
    return self._process(*args, **kwargs)
  File "/volume1/@optware/share/pyload_config/userplugins/internal/Hoster.py", line 118, in _process
    self.process(self.pyfile)
  File "/volume1/@optware/share/pyload_config/userplugins/internal/SimpleHoster.py", line 283, in process
    self.handle_free(pyfile)
  File "/volume1/@optware/share/pyload_config/userplugins/hoster/ShareonlineBiz.py", line 96, in handle_free
    res = self.handle_captcha()
  File "/volume1/@optware/share/pyload_config/userplugins/hoster/ShareonlineBiz.py", line 72, in handle_captcha
    response, challenge = self.captcha.challenge(self.RECAPTCHA_KEY)
  File "/volume1/@optware/share/pyload_config/userplugins/captcha/ReCaptcha.py", line 50, in challenge
    version=2 if re.search(self.KEY_V2_PATTERN, data or self.retrieve_data()) else 1)
  File "/volume1/@optware/share/pyload_config/userplugins/internal/CaptchaService.py", line 30, in retrieve_data
    return self.plugin.data or self.plugin.last_html or ""
AttributeError: 'ReCaptcha' object has no attribute 'plugin'
```