### PR TITLE
fixed XFileSharing config shadowing

### DIFF
--- a/module/plugins/hooks/XFileSharing.py
+++ b/module/plugins/hooks/XFileSharing.py
@@ -48,19 +48,20 @@ class XFileSharing(Addon):
 
 
     def activate(self):
-        for type, plugin in (("hoster" , "XFileSharing"),
+        for type, plugin in (("hoster" , "XFileSharingHoster"),
                              ("crypter", "XFileSharingFolder")):
             self._load(type, plugin)
 
 
     def deactivate(self):
-        for type, plugin in (("hoster" , "XFileSharing"),
+        for type, plugin in (("hoster" , "XFileSharingHoster"),
                              ("crypter", "XFileSharingFolder")):
             self._unload(type, plugin)
 
 
     def get_pattern(self, type, plugin):
         if self.config.get('use_%s_list' % type):
+            self.log_info(_('handling only listed hosters'))
             plugin_list = self.config.get('%s_list' % type)
             plugin_list = plugin_list.replace(' ', '').replace('\\', '')
             plugin_list = plugin_list.replace('|', ',').replace(';', ',')
@@ -87,6 +88,7 @@ class XFileSharing(Addon):
                            "" if len(plugin_set) == 1 else "s",
                            match_list.replace('\.', '.').replace('|', ', ')))
         else:
+            self.log_info(_('handling all sorts of hosters'))
             plugin_list = []
             isXFS = lambda klass: any(k.__name__.startswith("XFS") for k in inspect.getmro(klass))
 

--- a/module/plugins/hoster/XFileSharingHoster.py
+++ b/module/plugins/hoster/XFileSharingHoster.py
@@ -5,8 +5,8 @@ import re
 from module.plugins.internal.XFSHoster import XFSHoster
 
 
-class XFileSharing(XFSHoster):
-    __name__    = "XFileSharing"
+class XFileSharingHoster(XFSHoster):
+    __name__    = "XFileSharingHoster"
     __type__    = "hoster"
     __version__ = "0.64"
     __status__  = "testing"
@@ -28,7 +28,7 @@ class XFileSharing(XFSHoster):
 
     def _log(self, level, plugintype, pluginname, messages):
         messages = (self.PLUGIN_NAME,) + messages
-        return super(XFileSharing, self)._log(level, plugintype, pluginname, messages)
+        return super(XFileSharingHoster, self)._log(level, plugintype, pluginname, messages)
 
 
     def init(self):
@@ -46,7 +46,7 @@ class XFileSharing(XFSHoster):
 
     #@TODO: Recheck in 0.4.10
     def setup_base(self):
-        super(XFileSharing, self).setup_base()
+        super(XFileSharingHoster, self).setup_base()
 
         if self.account:
             self.req     = self.pyload.requestFactory.getRequest(self.PLUGIN_NAME, self.account.user)
@@ -60,5 +60,5 @@ class XFileSharing(XFSHoster):
     def load_account(self):
         class_name = self.classname
         self.__class__.__name__ = str(self.PLUGIN_NAME)
-        super(XFileSharing, self).load_account()
+        super(XFileSharingHoster, self).load_account()
         self.__class__.__name__ = class_name


### PR DESCRIPTION
This is a patch to fix issue #2324 with implications on issue  #2143
Basically, I've renamed ```hosters/XFileSharing.py``` to ```hosters/XFileSharingHoster.py```