### PR TITLE
Avoiding UnboundLocalError when using method 'type' on method get_info from SimpleHoster.

### DIFF
--- a/module/plugins/internal/SimpleHoster.py
+++ b/module/plugins/internal/SimpleHoster.py
@@ -188,8 +188,8 @@ class SimpleHoster(Hoster):
             info['size'] = parse_size(info['size'], unit)
 
         if 'H' in info['pattern']:
-            type = info['pattern']['H'].strip('-').upper()
-            info['hash'][type] = info['pattern']['D']
+            the_type = info['pattern']['H'].strip('-').upper()
+            info['hash'][the_type] = info['pattern']['D']
 
         return info
 


### PR DESCRIPTION
If someone use "type" method to verify the type of an object on get_info when debugging. They will be a "UnboundLocalError: local variable 'type' referenced before assignment" Error. So I recommend avoiding this name for a temporary variable.