### PR TITLE
[misc] Fix "'ascii' codec can't encode character" when url containing unicode character.

### DIFF
--- a/module/plugins/internal/misc.py
+++ b/module/plugins/internal/misc.py
@@ -469,8 +469,9 @@ def fixurl(url, unquote=None):
     if unquote is None:
         unquote = url is old
 
-    url = html_unescape(decode(url).decode('unicode-escape'))
+    url = html_unescape(decode(url))
     url = re.sub(r'(?<!:)/{2,}', '/', url).strip().lstrip('.')
+    url = encode(url)
 
     if not unquote:
         url = urllib.quote(url)
@@ -539,6 +540,7 @@ def parse_name(value, safechar=True):
              url_p.netloc.split('.', 1)[0])
 
     name = urllib.unquote(name)
+    name = decode(name)
     return safename(name) if safechar else name
 
 


### PR DESCRIPTION
I met the Unicode problem as issue #2286 mentioned. And this fixing will keep all Unicode characters.

I can't tell the reason to decode a decoded string, so I removed it directly. 
I did encoding before the quote line, so that quote will always get a byte string. And this keeps fixurl always return a byte string.
Finally, I made parse_name decode the byte string after unquoted, so that parse_name always return a Unicode string.

I hope this fixing helps.
