### PR TITLE
Shareonline.Biz: Fail on full instead of wait

### DIFF
--- a/module/plugins/hoster/ShareonlineBiz.py
+++ b/module/plugins/hoster/ShareonlineBiz.py
@@ -172,7 +172,7 @@ class ShareonlineBiz(SimpleHoster):
             self.retry(wait=600, msg=errmsg)
 
         elif errmsg == "full":
-            self.retry(10, 600, _("Server is full"))
+            self.fail(_("Server is full"))
 
         elif 'slot' in errmsg:
             self.wait(3600, reconnect=True)


### PR DESCRIPTION
Up to now, if a file cannot be downloaded because of "Server is full", it waits 10 minutes a couple of times. And while waiting, nothing else gets downloaded from Shareonline.biz. After a couple of retries, the download will fail anyway. The "server is full" message usually stays for around one day on a file, but it doesn't necessarily affect other files on same hoster.

Proposed solution: Do not wait on "server is full" but fail instead (as mentioned, the failing download will fail anyway). Then, other files on ShareOnline.biz will continue downloading.