### PR TITLE
[JsEngine] Support large scripts

### DIFF
--- a/module/common/JsEngine.py
+++ b/module/common/JsEngine.py
@@ -17,9 +17,11 @@
     @author: RaNaN
 """
 
+import os
+import tempfile
+import urllib
+
 from imp import find_module
-from os.path import join, exists
-from urllib import quote
 
 
 ENGINE = ""
@@ -56,12 +58,12 @@ if not ENGINE or DEBUG:
     try:
         path = "" #path where to find rhino
 
-        if exists("/usr/share/java/js.jar"):
+        if os.path.exists("/usr/share/java/js.jar"):
             path = "/usr/share/java/js.jar"
-        elif exists("js.jar"):
+        elif os.path.exists("js.jar"):
             path = "js.jar"
-        elif exists(join(pypath, "js.jar")): #may raises an exception, but js.jar wasnt found anyway
-            path = join(pypath, "js.jar")
+        elif os.path.exists(os.path.join(pypath, "js.jar")): #may raises an exception, but js.jar wasnt found anyway
+            path = os.path.join(pypath, "js.jar")
 
         if not path:
             raise Exception
@@ -133,22 +135,41 @@ class JsEngine():
             return results[0]
 
     def eval_pyv8(self, script):
-        rt = PyV8.JSContext()
-        rt.enter()
-        return rt.eval(script)
+        with PyV8.JSLocker():
+            with PyV8.JSContext() as rt:
+                return rt.eval(script)
 
     def eval_js(self, script):
-        script = "print(eval(unescape('%s')))" % quote(script)
-        p = subprocess.Popen(["js", "-e", script], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=-1)
+        script = "print(eval(unescape('%s')))" % urllib.quote(script)
+        if len(script) <= 2000:
+            script_file = None
+            p = subprocess.Popen(["js", "-e", script], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=-1)
+        else:
+            fd, script_file = tempfile.mkstemp(prefix='pyload_', suffix='.js')
+            os.write(fd, script)
+            os.close(fd)
+            p = subprocess.Popen(["js", "-f", script_file], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=-1)
         out, err = p.communicate()
+        if script_file and os.path.exists(script_file):
+            os.unlink(script_file)
         res = out.strip()
         return res
 
     def eval_rhino(self, script):
-        script = "print(eval(unescape('%s')))" % quote(script)
-        p = subprocess.Popen(["java", "-cp", path, "org.mozilla.javascript.tools.shell.Main", "-e", script],
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=-1)
+        script = "print(eval(unescape('%s')))" % urllib.quote(script)
+        if len(script) <= 1800:
+            script_file = None
+            p = subprocess.Popen(["java", "-cp", path, "org.mozilla.javascript.tools.shell.Main", "-e", script],
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=-1)
+        else:
+            fd, script_file = tempfile.mkstemp(prefix='pyload_', suffix='.js')
+            os.write(fd, script)
+            os.close(fd)
+            p = subprocess.Popen(["java", "-cp", path, "org.mozilla.javascript.tools.shell.Main", "-f", script_file],
+                                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=-1)
         out, err = p.communicate()
+        if script_file and os.path.exists(script_file):
+            os.unlink(script_file)
         res = out.strip()
         return res.decode("utf8").encode("ISO-8859-1")
 


### PR DESCRIPTION
Currently every JS script is sent as a command line parameter.
The length of the command line is limited of-course (especially on windows)

This PR will make `pyLoad` use a temporary file as a script if the script size exceeds some specific length.
I've included #2374 in it also.