### PR TITLE
Update broken links in README

### DIFF
--- a/README
+++ b/README
@@ -7,12 +7,12 @@ It supports link decryption as well as all important container formats.
 
 pyLoad is written entirely in Python and is currently under heavy development.
 
-For news, downloads, wiki, forum and further information visit http://pyload.org/
+For news, downloads, wiki, forum and further information visit https://pyload.net/
 
 To report bugs, suggest features, ask a question, get the developer version
 or help us out, visit http://github.com/pyload/pyload
 
-Documentation about extending pyLoad can be found at http://docs.pyload.org or join us at #pyload on irc.freenode.net
+Documentation about extending pyLoad can be found at https://github.com/pyload/pyload/wiki or join us at #pyload on irc.freenode.net
 
 Dependencies
 ============
@@ -64,7 +64,7 @@ Configuration
 After finishing the setup assistent pyLoad is ready to use and more configuration can be done via webinterface.
 Additionally you could simply edit the config files located in your pyLoad home dir (defaults to: ~/.pyload)
 with your favorite editor and edit the appropriate options. For a short description of
-the options take a look at http://pyload.org/configuration.
+the options take a look at https://github.com/pyload/pyload/wiki/Configuration.
 
 To restart the configure assistent run::
 
@@ -85,4 +85,4 @@ The webinterface can be accessed when pointing your webbrowser to the ip and con
 
 Notes
 =====
-For more information, see http://pyload.org/
+For more information, see https://pyload.net/


### PR DESCRIPTION
The link: http://pyload.org/ leads to an ads website. Fix to the link provided https://pyload.net/ and the github's wiki links.