### PR TITLE
Fix ConfigParser file permission issue

### DIFF
--- a/module/ConfigParser.py
+++ b/module/ConfigParser.py
@@ -58,6 +58,7 @@ class ConfigParser:
         try:
             if not exists("pyload.conf"):
                 copy(join(pypath, "module", "config", "default.conf"), "pyload.conf")
+                chmod("pyload.conf", 0600)
 
             if not exists("plugin.conf"):
                 f = open("plugin.conf", "wb")


### PR DESCRIPTION
Fixes an issue which occurs when process owner has no write permission for `join(pypath, "module", "config", "default.conf")`. The later call to `open("pyload.conf", "wb")` then fails. Catched when executing pyLoadCore.py without an existing pyload.conf on a nix derivation (see http://nixos.org/) of pyload.
