### PR TITLE
Add LinkFilter plugin

### DIFF
--- a/module/plugins/hooks/LinkFilter.py
+++ b/module/plugins/hooks/LinkFilter.py
@@ -1,0 +1,33 @@
+
+from module.plugins.internal.Addon import Addon
+
+class LinkFilter(Addon):
+        __name__ = "LinkFilter"
+        __type__ = "hook"
+        __version__ = "0.1"
+        __status__ = "testing"
+        __config__ = [("activated"     , "bool" , "Activated"                                   , False ),
+                      ("filter"        , "str"  , "Filter links containing (seperate by comma)" , "ul.to,share-online.biz" )]
+        __description__ = "Filters all added links"
+        __authors__ = "segelkma"
+
+
+        def deactivate(self):
+            self.manager.removeEvent('linksAdded', self.filter_links)
+
+
+        def activate(self):
+            self.manager.addEvent('linksAdded', self.filter_links)
+
+
+        def filter_links(self, links, pid):
+            filter_entries = self.config.get('filter').split(',')
+
+            for filter in filter_entries:
+                linkcount = len(links)
+                links[:] = [link for link in links if link.find(filter) == -1]
+                linkcount -= len(links)
+
+                if linkcount > 0:
+                    linkstring = 'links' if linkcount > 1 else 'link'
+                    self.log_info("Removed %s %s containing %s" % (linkcount, linkstring, filter))

--- a/module/plugins/hooks/LinkFilter.py
+++ b/module/plugins/hooks/LinkFilter.py
@@ -24,6 +24,8 @@ class LinkFilter(Addon):
             filter_entries = self.config.get('filter').split(',')
 
             for filter in filter_entries:
+                if filter == "": break
+
                 linkcount = len(links)
                 links[:] = [link for link in links if link.find(filter) == -1]
                 linkcount -= len(links)


### PR DESCRIPTION
- LinkFilter

This simple plugin allows to filter all added links.

Example: The filter "random-url.com" will remove all links from queue containing it such as http://random-url.com/fileabc.rar
Multiple filters can be set by seprerating them by comma: "filter1.com,filter2.com"

Example usage: Sort out hosters when a dlc contains multiple hosters.

Future versions: Reverse filter (only allow given filter + option not to filter containers (dlc's))

References: #2519 #182