### PR TITLE
Fix ClickAndLoad for action 'add'

### DIFF
--- a/module/web/cnl_app.py
+++ b/module/web/cnl_app.py
@@ -35,7 +35,7 @@ def flash(id="0"):
 
 @route("/flash/add", method="POST")
 @local_check
-def add(request):
+def add():
     package = request.POST.get('referer', None)
     urls = filter(lambda x: x != "", request.POST['urls'].split("\n"))
 


### PR DESCRIPTION
The variable 'request' is not handed to the add function.
If this action was triggered the following error sowed up:

Traceback (most recent call last):
  File "/home/pyload/pyload/module/lib/bottle.py", line 733, in _handle
    return route.call(**args)
  File "/home/pyload/pyload/module/lib/bottle.py", line 1448, in wrapper
    rv = callback(*a, **ka)
  File "/home/pyload/pyload/module/web/cnl_app.py", line 22, in _view
    return function(*args, **kwargs)
TypeError: add() takes exactly 1 argument (0 given)
An error occured while processing the request.
Traceback (most recent call last):
  File "/home/pyload/pyload/module/lib/bottle.py", line 733, in _handle
    return route.call(**args)
  File "/home/pyload/pyload/module/lib/bottle.py", line 1448, in wrapper
    rv = callback(*a, **ka)
  File "/home/pyload/pyload/module/web/cnl_app.py", line 22, in _view
    return function(*args, **kwargs)
TypeError: add() takes exactly 1 argument (0 given)