### PR TITLE
Hotfix UnicodeDecodeError

### DIFF
--- a/module/plugins/internal/misc.py
+++ b/module/plugins/internal/misc.py
@@ -38,7 +38,7 @@ except ImportError:
 class misc(object):
     __name__    = "misc"
     __type__    = "plugin"
-    __version__ = "0.36"
+    __version__ = "0.37"
     __status__  = "stable"
 
     __pattern__ = r'^unmatchable$'
@@ -367,6 +367,12 @@ def get_console_encoding(enc):
     return enc
 
 
+# Hotfix UnicodeDecodeError: 'ascii' codec can't decode..
+def normalize(value):
+    import unicodedata
+    return unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
+
+
 #@NOTE: Revert to `decode` in Python 3
 def decode(value, encoding=None, errors='strict'):
     """
@@ -380,6 +386,12 @@ def decode(value, encoding=None, errors='strict'):
 
     else:
         res = unicode(value)
+
+    # Hotfix UnicodeDecodeError
+    try:
+        str(res)
+    except UnicodeEncodeError:
+        return normalize(res)
 
     return res
 


### PR DESCRIPTION
If diacritics (Žluťoučký kůň úpěl ďábelské ódy) in filename, pyload return this error:
Maybe this hotfix is best way this time?

Test link: https://uloz.to/!mor9Ans1izOI/zlutoucky-kun-upel-dabelske-ody-txt

`Traceback (most recent call last):
  File "/home/ondrej/programming/pyload/module/PluginThread.py", line 187, in run
    pyfile.plugin.preprocessing(self)
  File "/home/ondrej/programming/pyload/module/plugins/internal/Base.py", line 295, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/ondrej/programming/pyload/module/plugins/internal/Hoster.py", line 106, in _process
    self._setup()
  File "/home/ondrej/programming/pyload/module/plugins/internal/Base.py", line 166, in _setup
    self.grab_info()
  File "/home/ondrej/programming/pyload/module/plugins/internal/Base.py", line 228, in grab_info
    new_info = self.get_info(self.pyfile.url, self.data)
  File "/home/ondrej/programming/pyload/module/plugins/internal/SimpleHoster.py", line 179, in get_info
    info['name'] = parse_name(name)
  File "/home/ondrej/programming/pyload/module/plugins/internal/misc.py", line 534, in parse_name
    path  = fixurl(decode(value), unquote=False)
  File "/home/ondrej/programming/pyload/module/plugins/internal/misc.py", line 471, in fixurl
    url = html_unescape(decode(url).decode('unicode-escape'))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u017d' in position 0: ordinal not in range(128)`
