### PR TITLE
Add captcha support to the openload hoster plugin

### DIFF
--- a/module/plugins/hoster/OpenloadIo.py
+++ b/module/plugins/hoster/OpenloadIo.py
@@ -10,7 +10,7 @@ from module.plugins.internal.misc import json
 class OpenloadIo(SimpleHoster):
     __name__    = "OpenloadIo"
     __type__    = "hoster"
-    __version__ = "0.16"
+    __version__ = "0.17"
     __status__  = "testing"
 
     __pattern__ = r'https?://(?:www\.)?openload\.(co|io)/(f|embed)/(?P<ID>[\w\-]+)'

--- a/module/plugins/hoster/OpenloadIo.py
+++ b/module/plugins/hoster/OpenloadIo.py
@@ -29,7 +29,7 @@ class OpenloadIo(SimpleHoster):
     API_URL = 'https://api.openload.co/1'
 
     _DOWNLOAD_TICKET_URI_PATTERN = '/file/dlticket?file=%s'
-    _DOWNLOAD_FILE_URI_PATTERN   = '/file/dl?file=%s&ticket=%s'
+    _DOWNLOAD_FILE_URI_PATTERN   = '/file/dl?file=%s&ticket=%s&captcha_response=%s'
     _FILE_INFO_URI_PATTERN       = '/file/info?file=%s'
 
     OFFLINE_PATTERN = r'>We are sorry'
@@ -59,20 +59,42 @@ class OpenloadIo(SimpleHoster):
         # If the link is being handled here, then it matches the file_id_pattern,
         # therefore, we can call [0] safely.
         file_id     = self.info['pattern']['ID']
-        ticket_json = self._load_json(self._DOWNLOAD_TICKET_URI_PATTERN % file_id)
 
-        if ticket_json['status'] == 404:
-            self.offline(ticket_json['msg'])
+        while True:
+            ticket_json = self._load_json(self._DOWNLOAD_TICKET_URI_PATTERN % file_id)
 
-        elif ticket_json['status'] == 509:
-            self.temp_offline(ticket_json['msg'])
+            if ticket_json['status'] == 404:
+                self.offline(ticket_json['msg'])
 
-        elif ticket_json['status'] != 200:
-            self.fail(ticket_json['msg'])
+            elif ticket_json['status'] == 509:
+                self.temp_offline(ticket_json['msg'])
 
-        self.wait(ticket_json['result']['wait_time'])
+            elif ticket_json['status'] != 200:
+                self.fail(ticket_json['msg'])
 
-        ticket = ticket_json['result']['ticket']
+            self.wait(ticket_json['result']['wait_time'])
 
-        download_json = self._load_json(self._DOWNLOAD_FILE_URI_PATTERN % (file_id, ticket))
+            # check if a captcha is required for this download
+            captchaResponse = ''
+            if 'captcha_url' in ticket_json['result'] and ticket_json['result']['captcha_url'] != False:
+                self.log_debug('This download requires a captcha solution: %s' % (ticket_json['result']['captcha_url']))
+                captchaResponse = self.captcha.decrypt(ticket_json['result']['captcha_url'])
+
+            ticket = ticket_json['result']['ticket']
+
+            download_json = self._load_json(self._DOWNLOAD_FILE_URI_PATTERN % (file_id, ticket, captchaResponse))
+
+            # check download link request result status
+            if download_json['status'] == 403:
+                # wrong captcha, get new captcha and try again
+                self.log_debug('Captcha solution is incorrect')
+                continue
+
+            if download_json['status'] == 200:
+                # start downloading
+                break
+
+            # no status 403 or 200 means getting the download url failed, abort
+            self.fail(download_json['msg'])
+
         self.link = download_json['result']['url']


### PR DESCRIPTION
The hoster openload sometimes requires a captcha to be solved. I followed the api documentation at https://openload.co/api and implemented captcha support for this hoster.