### PR TITLE
Download file size fix

### DIFF
--- a/module/plugins/internal/misc.py
+++ b/module/plugins/internal/misc.py
@@ -559,7 +559,12 @@ def parse_size(value, unit=""):  #: returns bytes
     if m is None:
         return 0
 
-    size = float(m.group(1).replace(',', '.'))
+    # fix for size vales like 1,000.00
+    if re.match(r'\d+,\d+\.\d+$', m.group(1)) is not None:
+        size = float(m.group(1).replace(',', ''))
+    else:
+        size = float(m.group(1).replace(',', '.'))
+
     unit = (unit.strip().lower() or m.group(2) or "byte")[0]
 
     if unit == "b":

--- a/module/plugins/internal/misc.py
+++ b/module/plugins/internal/misc.py
@@ -38,7 +38,7 @@ except ImportError:
 class misc(object):
     __name__    = "misc"
     __type__    = "plugin"
-    __version__ = "0.37"
+    __version__ = "0.38"
     __status__  = "stable"
 
     __pattern__ = r'^unmatchable$'


### PR DESCRIPTION
I had a download report 1,000.00 as file size (I think it was filefactory) which was changed to 1.000.00 in misc.py causing an error when casted to float.
This patch checks if the size string contains a comma and a decimal point in that order and if so, the comma will be removed allowing the float cast to succeed.
The patched code will work as before if the string does not contain comma and decimal point.