### PR TITLE
Update RealdebridCom.py

### DIFF
--- a/module/plugins/hoster/RealdebridCom.py
+++ b/module/plugins/hoster/RealdebridCom.py
@@ -14,7 +14,7 @@ class RealdebridCom(MultiHoster):
     __version__ = "0.75"
     __status__ = "testing"
 
-    __pattern__ = r'https?://((?:www\.|s\d+\.)?real-debrid\.com/dl/|[\w^_]\.rdb\.so/d/)[\w^_]+'
+    __pattern__ = r'https?://((?:www\.|s\d+\.)?real-debrid\.com/dl?/|[\w^_]\.rdb\.so/d/)[\w^_]+'
     __config__ = [("use_premium", "bool", "Use premium account if available", True),
                   ("fallback",
                    "bool",


### PR DESCRIPTION
It seems that realdebrid links generated with the torrent service are of type : "https://real-debrid.com/d/{id}"
So the "**l**" in https://real-debrid.com/dl/" is not mandatory.
I rendered the **l** optional by replacing /**dl**/ with /**dl?**/ in order to match torrent service links.