### PR TITLE
[Crypter Relink.us] Redirects

### DIFF
--- a/module/plugins/crypter/RelinkUs.py
+++ b/module/plugins/crypter/RelinkUs.py
@@ -16,7 +16,7 @@ from ..internal.misc import fsjoin, replace_patterns
 class RelinkUs(Crypter):
     __name__ = "RelinkUs"
     __type__ = "crypter"
-    __version__ = "3.22"
+    __version__ = "3.23"
     __status__ = "testing"
 
     __pattern__ = r'http://(?:www\.)?relink\.(?:us|to)/(f/|((view|go)\.php\?id=))(?P<ID>.+)'
@@ -106,7 +106,7 @@ class RelinkUs(Crypter):
         self.package = pyfile.package()
 
     def request_package(self):
-        self.data = self.load(self.pyfile.url)
+        self.data = self.load(self.pyfile.url, redirect=2)
 
     def is_online(self):
         if self.OFFLINE_TOKEN in self.data:
@@ -139,6 +139,8 @@ class RelinkUs(Crypter):
                 'password': password,
                 'pw': 'submit'}
             self.data = self.load(passwd_url, post=passwd_data)
+        else:
+            self.fail(_("Wrong password"))
 
     def unlock_captcha_protection(self):
         m = re.search(self.CIRCLE_CAPTCHA_PATTERN, self.data)


### PR DESCRIPTION
I found another link which needs to habe to redirects in the request to get processed:

![requests](https://cloud.githubusercontent.com/assets/6438895/25585105/50cac7da-2e99-11e7-9a9f-6d16fec8c5ed.jpg)

This is the nonworking link:

http://relink.to/f/9ef878e7d070e697e7ead15a28b1d7

Attached the debug file:
[debug_Report.txt](https://github.com/pyload/pyload/files/968234/debug_Report.txt)

(If needed I can provide the password)
