### PR TITLE
Bugfix Reconnect Failed: 'ip'

### DIFF
--- a/module/plugins/hooks/UpdateManager.py
+++ b/module/plugins/hooks/UpdateManager.py
@@ -15,7 +15,7 @@ from ..internal.misc import Expose, encode, exists, fsjoin, threaded
 class UpdateManager(Addon):
     __name__ = "UpdateManager"
     __type__ = "hook"
-    __version__ = "1.17"
+    __version__ = "1.18"
     __status__ = "testing"
 
     __config__ = [("activated", "bool", "Activated", True),
@@ -48,10 +48,10 @@ class UpdateManager(Addon):
         self.periodical.start(10)
 
     def init(self):
-        self.info = {
+        self.info.update({
             'pyload': False,
             'plugins': False,
-            'last_check': time.time()}
+            'last_check': time.time()})
         self.mtimes = {}  #: Store modification time for each plugin
         self.event_map = {'allDownloadsProcessed': "all_downloads_processed"}
 


### PR DESCRIPTION
After reconnect I always get an error message, see following log excerpt:

INFO      HOSTER UploadedTo[434]: Checking for link errors...
WARNING   HOSTER UploadedTo[434]: You have reached the max. number of possible free downloads for this hour
DEBUG     HOSTER UploadedTo[434]: WAIT set to timestamp 1495373762.010000 | Previous waitUntil: 0.000000
DEBUG     HOSTER UploadedTo[434]: RECONNECT  required | Previous wantReconnect: False
INFO      HOSTER UploadedTo[434]: Waiting 1 hours...
INFO      HOSTER UploadedTo[434]: Requiring reconnection...
INFO      Starting reconnect
DEBUG     ADDON ExternalScripts: No script found under folder `download_processed`
DEBUG     ADDON ExternalScripts: No script found under folder `package_processed`
DEBUG     ADDON ExternalScripts: No script found under folder `before_reconnect`
DEBUG     Old IP: 217.254.116.104
**ERROR     Reconnect Failed: 'ip'**
DEBUG     ADDON ExternalScripts: No script found under folder `all_downloads_processed`
DEBUG     All downloads processed

Reason: In UpdateManager.py the dict "self.info['ip']" which is created in __ init__ function of Addon.py is overwritten. 
