### PR TITLE
[DailymotionCom] Fix video qualities parsing fail in special represen…

### DIFF
--- a/module/plugins/hoster/DailymotionCom.py
+++ b/module/plugins/hoster/DailymotionCom.py
@@ -45,7 +45,7 @@ def get_info(urls):
 class DailymotionCom(Hoster):
     __name__ = "DailymotionCom"
     __type__ = "hoster"
-    __version__ = "0.27"
+    __version__ = "0.28"
     __status__ = "testing"
 
     __pattern__ = r'https?://(?:www\.)?dailymotion\.com/.*video/(?P<ID>[\w^_]+)'

--- a/module/plugins/hoster/DailymotionCom.py
+++ b/module/plugins/hoster/DailymotionCom.py
@@ -63,13 +63,14 @@ class DailymotionCom(Hoster):
     def get_streams(self):
         streams = []
 
-        for result in re.finditer(r'\"(?P<URL>http:\\/\\/www.dailymotion.com\\/cdn\\/H264-(?P<QF>.*?)\\.*?)\"',
+        for result in re.finditer(r'\"(?P<URL>http:\\/\\/www.dailymotion.com\\/cdn\\/H264-(?P<QF_WIDTH>\d+)x(?P<QF_HEIGHT>\d+).*?)\"',
                                   self.data):
             url = result.group('URL')
-            qf = result.group('QF')
+            qf_width = result.group('QF_WIDTH')
+            qf_height = result.group('QF_HEIGHT')
 
             link = url.replace("\\", "")
-            quality = tuple(int(x) for x in qf.split("x"))
+            quality = (int(qf_width), int(qf_height))
 
             streams.append((quality, link))
 


### PR DESCRIPTION
…tation.

### Type of request:

> **NOTE:**
> Please, fill with an `x` just one of the checkboxes below.

- [x ] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin enhancement

### Short description:

Fix video qualities parsing fail in special representation.

### Additional info:

1. **Related pull requests**: _OPTIONAL_
2. **Related issues**: _OPTIONAL_
3. If this is a **New plugin**, please provide too:
  - **Link to the plugin's homepage**: _OPTIONAL_
  - **Link to a sample plugin's resource page**: _OPTIONAL_

### Reasons for making this change:

Dailymotion server may response URL such as "http:\/\/www.dailymotion.com\/cdn\/H264-176x144-2\/video\/x47syj7.mp4?auth=1496652791-2688-jnnyiz9a-291260fbb3a6dc61f883888c26ae073f". The previous version can't handle such URLs, will failing to download.

### References supporting this change:

_OPTIONAL_
