### PR TITLE
[DownloadScheduler] update timetable on change

### DIFF
--- a/module/plugins/hooks/DownloadScheduler.py
+++ b/module/plugins/hooks/DownloadScheduler.py
@@ -9,7 +9,7 @@ from ..internal.Addon import Addon
 class DownloadScheduler(Addon):
     __name__ = "DownloadScheduler"
     __type__ = "hook"
-    __version__ = "0.27"
+    __version__ = "0.28"
     __status__ = "testing"
 
     __config__ = [("activated", "bool", "Activated", False),
@@ -27,9 +27,22 @@ class DownloadScheduler(Addon):
     def activate(self):
         self.update_schedule()
 
+    def config_changed(self, category, option, value, section):
+        """Listen for config changes, to trigger a schedule update."""
+        # Trigger an update if the timetable has changed
+        if (
+            category == self.__name__ and
+            option == 'timetable' and
+            value != getattr(self, 'last_timetable', None)
+        ):
+            self.update_schedule(schedule=value)
+
     def update_schedule(self, schedule=None):
         if schedule is None:
             schedule = self.config.get('timetable')
+
+        # Save the last timetable for future comparison
+        self.last_timetable = schedule
 
         schedule = re.findall("(\d{1,2}):(\d{2})[\s]*(-?\d+)",
                               schedule.lower().replace("full", "-1").replace("none", "0"))


### PR DESCRIPTION
### Type of request:

- [ ] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [x] Plugin bugfix/enhancement

### Short description:

This triggers a schedule update every time the `timetable` config value is modified, instead of having to deactivate and activate the plugin again.

### Reasons for making this change:

The only way I found to trigger a schedule update when I wanted to edit the `timetable` value, was by turning off and on the plugin, or waiting for it to trigger an update itself, based on the next time it determines to check the timetable again.