### PR TITLE
[master] Fix pyload.requests dependency

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -5,7 +5,7 @@ daemonize
 future
 pycurl
 pyload.config~=0.6
-pyload.requests~=0.6
+pyload.requests
 pyload.utils2~=0.6
 semver
 setuptools>=0.6.39

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,7 @@ future
 nose
 pycurl
 pyload.config~=0.6
-pyload.requests~=0.6
+pyload.requests
 pyload.utils2~=0.6
 requests>=1.2.2
 setuptools>=0.6.39

--- a/setup.py
+++ b/setup.py
@@ -288,6 +288,11 @@ NAMESPACE_PACKAGES = [_NAMESPACE]
 OBSOLETES = [_NAMESPACE]
 INSTALL_REQUIRES = get_requires('install')
 SETUP_REQUIRES = get_requires('setup')
+DEPENDENCY_LINKS = [
+    # TODO: Remove this dependency when pyload.requests is indexed in PyPI.
+    # Also, specify the correct required version in the requirement txt files
+    'git+git://github.com/pyload/requests.git#egg=pyload.requests',
+]
 TEST_SUITE = 'nose.collector'
 TESTS_REQUIRE = get_requires('test')
 EXTRAS_REQUIRE = get_requires('extra')
@@ -352,6 +357,7 @@ setup(
     namespace_packages=NAMESPACE_PACKAGES,
     obsoletes=OBSOLETES,
     install_requires=INSTALL_REQUIRES,
+    dependency_links=DEPENDENCY_LINKS,
     setup_requires=SETUP_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
     python_requires=PYTHON_REQUIRES,


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

The `pyload.requests` repository is not yet indexed in PyPI. So trying to install the master branch fails with the following error:

```
$ python setup.py install
(...)
Searching for pyload.requests~=0.6
Reading https://pypi.python.org/simple/pyload.requests/
No local packages or working download links found for pyload.requests~=0.6
error: Could not find suitable distribution for Requirement.parse('pyload.requests~=0.6')
```

This is a temporary fix to be able to correctly install the project, until `pyload.requests` is indexed and can be retrieved without a dependency link.

### Reasons for making this change:

Let's make `master` branch installable, so it's easier for people to contribute! :)