### PR TITLE
[master] Fix config default for cache section

### DIFF
--- a/src/pyload/core/config/default.py
+++ b/src/pyload/core/config/default.py
@@ -16,27 +16,27 @@ def _gen_session_defaults():
     profile_section = (
         ('path', ('option', None, 'Path', None, None, InputType.Folder)),
         ('pid', ('option', None, 'PID', None, None, InputType.Int)),
-        ('ctime', ('option', None, 'CTime', None, None, InputType.Float))
+        ('ctime', ('option', None, 'CTime', None, None, InputType.Float)),
     )
     cache_section = (
-        ('path', ('option', None, 'Path', None, None, InputType.Folder))
+        ('path', ('option', None, 'Path', None, None, InputType.Folder)),
     )
     log_section = (
         ('path', ('option', None, 'Path', None, None, InputType.Folder)),
-        ('name', ('option', None, 'Name', None, None, InputType.Str))
+        ('name', ('option', None, 'Name', None, None, InputType.Str)),
     )
 
     current_config = (
         ('id', ('option', None, 'ID', None, None, InputType.Float)),
         ('profile', ('section', profile_section, 'Profile', None)),
         ('cache', ('section', cache_section, 'Cache', None)),
-        ('log', ('section', log_section, 'Logging', None))
+        ('log', ('section', log_section, 'Logging', None)),
     )
     previous_config = deepcopy(current_config)
 
     defaults = (
         ('current', ('section', current_config, 'Current', None)),
-        ('previous', ('section', previous_config, 'Previous', None))
+        ('previous', ('section', previous_config, 'Previous', None)),
     )
     return defaults
 


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

Added trailing commas to all config sections. This is a bugfix because the `cache_section` variable wasn't a tuple because it had only one element but lacked a trailing comma, so config initialization failed when trying to iterate over it.

Trailing commas are our friends :)