### PR TITLE
[master] Change some relative imports to absolute paths

### DIFF
--- a/src/pyload/core/iface.py
+++ b/src/pyload/core/iface.py
@@ -14,8 +14,8 @@ import autoupgrade
 import daemonize
 from pyload.utils.fs import makedirs, remove
 
-from .__about__ import __namespace__, __package_name__, __version__
-from .init import Core, _pmap
+from pyload.core.__about__ import __namespace__, __package_name__, __version__
+from pyload.core.init import Core, _pmap
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/manager/account.py
+++ b/src/pyload/core/manager/account.py
@@ -10,8 +10,8 @@ from future import standard_library
 
 from pyload.utils.struct.lock import lock
 
-from ..datatype.init import AccountInfo
-from .base import BaseManager
+from pyload.core.datatype.init import AccountInfo
+from pyload.core.manager.base import BaseManager
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/manager/addon.py
+++ b/src/pyload/core/manager/addon.py
@@ -16,10 +16,10 @@ from pyload.utils.layer.legacy.collections_ import namedtuple
 from pyload.utils.layer.safethreading import RLock
 from pyload.utils.struct.lock import lock
 
-from ..datatype.init import (AddonInfo, AddonService, ServiceDoesNotExist,
-                             ServiceException)
-from ..thread import AddonThread
-from .base import BaseManager
+from pyload.core.datatype.init import (
+    AddonInfo, AddonService, ServiceDoesNotExist, ServiceException)
+from pyload.core.manager.base import BaseManager
+from pyload.core.thread import AddonThread
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/manager/config.py
+++ b/src/pyload/core/manager/config.py
@@ -10,7 +10,7 @@ from pyload.config import ConfigParser
 # from pyload.config.convert import from_string
 from pyload.utils.layer.legacy.collections_ import OrderedDict
 
-from ..datatype.init import InvalidConfigSection
+from pyload.core.datatype.init import InvalidConfigSection
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/manager/event.py
+++ b/src/pyload/core/manager/event.py
@@ -6,7 +6,7 @@ from builtins import str
 
 from future import standard_library
 
-from .base import BaseManager
+from pyload.core.manager.base import BaseManager
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/manager/exchange.py
+++ b/src/pyload/core/manager/exchange.py
@@ -12,9 +12,9 @@ from pyload.utils.check import bitset
 from pyload.utils.layer.legacy.collections_ import OrderedDict
 from pyload.utils.struct.lock import lock
 
-from ..datatype.init import Input, InputType
-from ..datatype.task import Interaction, InteractionTask
-from .base import BaseManager
+from pyload.core.datatype.init import Input, InputType
+from pyload.core.datatype.task import Interaction, InteractionTask
+from pyload.core.manager.base import BaseManager
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/manager/file.py
+++ b/src/pyload/core/manager/file.py
@@ -11,11 +11,11 @@ from future import standard_library
 
 from pyload.utils.struct.lock import RWLock, lock
 
-from ..datatype.file import File
-from ..datatype.init import DownloadStatus, TreeCollection
-from ..datatype.package import (Package, PackageDoesNotExist, PackageStatus,
-                                RootPackage)
-from .base import BaseManager
+from pyload.core.datatype.file import File
+from pyload.core.datatype.init import DownloadStatus, TreeCollection
+from pyload.core.datatype.package import (
+    Package, PackageDoesNotExist, PackageStatus, RootPackage)
+from pyload.core.manager.base import BaseManager
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/manager/info.py
+++ b/src/pyload/core/manager/info.py
@@ -11,9 +11,9 @@ from pyload.utils.convert import to_list
 from pyload.utils.layer.safethreading import RLock
 from pyload.utils.struct.lock import lock
 
-from ..datatype.check import OnlineCheck
-from ..thread import InfoThread
-from .base import BaseManager
+from pyload.core.datatype.check import OnlineCheck
+from pyload.core.manager.base import BaseManager
+from pyload.core.thread import InfoThread
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/manager/plugin.py
+++ b/src/pyload/core/manager/plugin.py
@@ -12,9 +12,9 @@ from pkg_resources import resource_filename
 
 from pyload.utils.fs import fullpath
 
-from ..__about__ import __package__
-from ..network.loader import LoaderFactory, PluginLoader
-from .base import BaseManager
+from pyload.core.__about__ import __package__
+from pyload.core.manager.base import BaseManager
+from pyload.core.network.loader import LoaderFactory, PluginLoader
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/manager/remote.py
+++ b/src/pyload/core/manager/remote.py
@@ -8,7 +8,7 @@ from traceback import print_exc
 
 from future import standard_library
 
-from .base import BaseManager
+from pyload.core.manager.base import BaseManager
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/manager/transfer.py
+++ b/src/pyload/core/manager/transfer.py
@@ -16,9 +16,9 @@ from pyload.utils.layer.safethreading import Event
 from pyload.utils.struct.lock import RWLock, lock
 from pyload.utils.web.misc import get_ip
 
-from ..datatype.init import DownloadStatus
-from ..thread import DecrypterThread, DownloadThread
-from .base import BaseManager
+from pyload.core.datatype.init import DownloadStatus
+from pyload.core.manager.base import BaseManager
+from pyload.core.thread import DecrypterThread, DownloadThread
 
 standard_library.install_aliases()
 

--- a/src/pyload/core/thread/decrypter.py
+++ b/src/pyload/core/thread/decrypter.py
@@ -10,11 +10,11 @@ from future import standard_library
 from pyload.utils.misc import accumulate
 from pyload.utils.purge import uniqify
 
-from ..datatype.init import (DownloadStatus, LinkStatus, ProgressInfo,
-                             ProgressType)
-from ..network.base import Abort, Retry
-from ..network.crypter import Package
-from .plugin import PluginThread
+from pyload.core.datatype.init import (
+    DownloadStatus, LinkStatus, ProgressInfo, ProgressType)
+from pyload.core.datatype.package import Package
+from pyload.core.network.base import Abort, Retry
+from pyload.core.thread.plugin import PluginThread
 
 standard_library.install_aliases()
 


### PR DESCRIPTION
### Type of request:

> **NOTE:**
> Please, fill with an `x` just one of the checkboxes below, like `[x] Bugfix`.

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

Some relative imports are failing because of the `__init__` imports done in some modules, which make inner modules to mess up when trying to import from parent directories. For example:

```
Traceback (most recent call last):
  File "~/.virtualenvs/pyload2/bin/pyload", line 11, in <module>
    load_entry_point('pyload.core==0.6.2', 'console_scripts', 'pyload')()
  File "~/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 563, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "~/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2651, in load_entry_point
    return ep.load()
  File "~/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2305, in load
    return self.resolve()
  File "~/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2311, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "build/bdist.linux-x86_64/egg/pyload/core/__init__.py", line 39, in <module>
  File "build/bdist.linux-x86_64/egg/pyload/core/manager/__init__.py", line 4, in <module>
  File "build/bdist.linux-x86_64/egg/pyload/core/manager/plugin.py", line 16, in <module>
ImportError: No module named network.loader
```

Changed some (not all) relative imports to absolute. It shouldn't be a
problem (how many times do we move these packages anyway?), and it's
also consistent with the imports from the rest of pyload separate
repositories.