### PR TITLE
[master] Remove usages of chunks util

### DIFF
--- a/src/pyload/core/network/crypter.py
+++ b/src/pyload/core/network/crypter.py
@@ -10,7 +10,6 @@ from future import standard_library
 
 from pyload.requests.curl.download import CurlDownload
 from pyload.requests.curl.request import CurlRequest
-from pyload.utils.convert import chunks as _chunks
 from pyload.utils.fs import lopen, makedirs, remove
 
 from .base import Base, Fail, Retry
@@ -21,10 +20,6 @@ standard_library.install_aliases()
 if os.name != 'nt':
     import grp
     import pwd
-
-
-# Import for Hoster Plugins
-chunks = _chunks
 
 
 class Reconnect(Exception):

--- a/src/pyload/core/network/hoster.py
+++ b/src/pyload/core/network/hoster.py
@@ -10,7 +10,6 @@ from future import standard_library
 
 from pyload.requests.curl.download import CurlDownload
 from pyload.requests.curl.request import CurlRequest
-from pyload.utils.convert import chunks as _chunks
 from pyload.utils.fs import lopen, makedirs, remove
 
 from .base import Base, Fail, Retry
@@ -21,10 +20,6 @@ standard_library.install_aliases()
 if os.name != 'nt':
     import grp
     import pwd
-
-
-# Import for Hoster Plugins
-chunks = _chunks
 
 
 class Reconnect(Exception):


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

`chunks` was completely removed from the `utils` repository (see commit https://github.com/pyload/utils/commit/48da11e8fc8caa391131fdcea12044aecbcc4509), and it seems it's not needed anymore in this code.

### Additional info:

Relevant stacktrace:
```
Traceback (most recent call last):
  File "$HOME/.virtualenvs/pyload2/bin/pyload", line 11, in <module>
    load_entry_point('pyload.core==0.6.2', 'console_scripts', 'pyload')()
  File "/home/mike/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 563, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2651, in load_entry_point
    return ep.load()
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2305, in load
    return self.resolve()
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2311, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "build/bdist.linux-x86_64/egg/pyload/core/__init__.py", line 39, in <module>
  File "build/bdist.linux-x86_64/egg/pyload/core/manager/__init__.py", line 6, in <module>
  File "build/bdist.linux-x86_64/egg/pyload/core/manager/addon.py", line 22, in <module>
  File "build/bdist.linux-x86_64/egg/pyload/core/thread/__init__.py", line 7, in <module>
  File "build/bdist.linux-x86_64/egg/pyload/core/thread/download.py", line 19, in <module>
  File "build/bdist.linux-x86_64/egg/pyload/core/network/hoster.py", line 13, in <module>
ImportError: cannot import name chunks
```