### PR TITLE
[master] Remove import reference to pyload.core.plugin

### DIFF
--- a/src/pyload/core/__init__.py
+++ b/src/pyload/core/__init__.py
@@ -36,6 +36,6 @@ locale.setlocale(locale.LC_ALL, '')
 # codecs.register(lambda enc: codecs.lookup('utf-8') if enc == 'cp65001' else None)
 # sys.stdout = codecs.getwriter(sys.console_encoding(sys.stdout.encoding))(sys.stdout, errors="replace")
 
-from . import api, config, database, datatype, manager, network, plugin, thread
-from .iface import cleanup, quit, restart, start, status, version, upgrade
-from .init import Core, Restart, Shutdown
+from pyload.core import api, config, database, datatype, manager, network, thread
+from pyload.core.iface import cleanup, quit, restart, start, status, version, upgrade
+from pyload.core.init import Core, Restart, Shutdown


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

`pyload.core.plugin` is no longer in this branch, removing to bypass its ImportError.

### Additional info:

Relevant stacktrace:
```
Traceback (most recent call last):
  File "$HOME/.virtualenvs/pyload2/bin/pyload", line 11, in <module>
    load_entry_point('pyload.core==0.6.2', 'console_scripts', 'pyload')()
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 563, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2651, in load_entry_point
    return ep.load()
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2305, in load
    return self.resolve()
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2311, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "build/bdist.linux-x86_64/egg/pyload/core/__init__.py", line 39, in <module>
ImportError: cannot import name plugin
```