### PR TITLE
[master] Fix Pyload ico path

### DIFF
--- a/src/pyload/core/cli.py
+++ b/src/pyload/core/cli.py
@@ -134,7 +134,7 @@ def parse_args(argv=None):
 
 
 def _setup_console():
-    icon = resource_filename(__package__, 'pyload.ico')
+    icon = resource_filename(__package__, 'icon.ico')
     try:
         set_console_title("pyLoad console")
         set_console_icon(icon)


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

`ico` file is now named `icon.ico`, not `pyload.ico`. See: https://github.com/pyload/pyload/blob/master/media/icon.ico

### Additional info:

Relevant stacktrace:
```
Traceback (most recent call last):
  File "$HOME/.virtualenvs/pyload2/bin/pyload", line 11, in <module>
    load_entry_point('pyload.core==0.6.2', 'console_scripts', 'pyload')()
  File "build/bdist.linux-x86_64/egg/pyload/core/cli.py", line 148, in main
  File "build/bdist.linux-x86_64/egg/pyload/core/cli.py", line 137, in _setup_console
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1206, in resource_filename
    self, resource_name
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1719, in get_resource_filename
    return self._extract_resource(manager, zip_path)
  File "$HOME/.virtualenvs/pyload2/local/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1740, in _extract_resource
    timestamp, size = self._get_date_and_size(self.zipinfo[zip_path])
KeyError: u'pyload/core/pyload.ico'
```