### PR TITLE
[master] Fix psp.pid usage

### DIFF
--- a/src/pyload/core/init.py
+++ b/src/pyload/core/init.py
@@ -320,7 +320,7 @@ class Core(Process):
         psp = psutil.Process()
         session.set('current', 'id', time.time())
         session.set('current', 'profile', 'path', profiledir)
-        session.set('current', 'profile', 'pid', psp.pid())
+        session.set('current', 'profile', 'pid', psp.pid)
         session.set('current', 'profile', 'ctime', psp.create_time())
 
         self.config = ConfigParser(self.__CONFIGFILENAME, config_defaults)


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

`psp.pid` returns the process ID as an integer number, and it's not a method, so using it as a callable was making it fail.

### Additional info:

Relevant stacktrace:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 461, in run
    self._init_config()
  File "build/bdist.linux-x86_64/egg/pyload/core/init.py", line 328, in _init_config
    session = ConfigParser(self.__SESSIONFILENAME, session_defaults)
TypeError: 'int' object is not callable
```