### PR TITLE
[master] Fix logging strings that receive multiple params

### DIFF
--- a/src/pyload/core/init.py
+++ b/src/pyload/core/init.py
@@ -190,14 +190,14 @@ class Core(Process):
                 group = self.config.get('permission', 'group')
                 set_process_group(group)
             except Exception as e:
-                self.log.error(self._("Unable to change gid"), str(e))
+                self.log.error(self._("Unable to change gid: %s"), str(e))
 
         if change_user:
             try:
                 user = self.config.get('permission', 'user')
                 set_process_user(user)
             except Exception as e:
-                self.log.error(self._("Unable to change uid"), str(e))
+                self.log.error(self._("Unable to change uid: %s"), str(e))
 
     def set_language(self, lang):
         localedir = resource_filename(__package__, 'locale')
@@ -220,10 +220,14 @@ class Core(Process):
         except Exception as e:
             if lang == default:
                 raise
+
             self.log.warning(
-                self._("Unable to load `{0}` language, "
-                       "use default `{1}`").format(lang, default),
-                str(e))
+                self._(
+                    "Unable to load `%(lang)s` language, using default "
+                    "`%(default)s`: %(error)s",
+                ),
+                {'lang': lang, 'default': default, 'error': str(e)},
+            )
             self.set_language(default)
 
     def _setup_debug(self):


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

Logging functions only receives a message, and `args` that are interpolated into that message. Current implementation was failing because it was trying to interpolate `str(e)` to a message that doesn't include placeholders for it.

Moved from `.format` to `%`, as that's what `logging` uses for the interpolation.

### Additional info:

After the fix:
```
2017-07-26 22:23:58  WARNING   Unable to load `es` language, using default `english`: [Errno 2] No translation file found for domain: u'core'
```

Relevant stacktrace:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Logged from file init.py, line 240
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/handlers.py", line 845, in emit
    msg = self.format(record) + '\000'
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
```