### PR TITLE
[master] Initialize managers before requests

### DIFF
--- a/src/pyload/core/init.py
+++ b/src/pyload/core/init.py
@@ -454,9 +454,9 @@ class Core(Process):
             self._setup_language()
             self._setup_permissions()
             self._init_database()
+            self._init_managers()
             self._init_requests()
             self._init_api()
-            self._init_managers()
 
             self._show_info()
             self._setup_storage()


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

`RequestFactory` uses the `core` attribute `evm`, which is initialized during `_init_managers`, so we need to do that first.

### Additional info:

Relevant log lines:
```
2017-07-26 23:23:28  CRITICAL  'Core' object has no attribute 'evm'
```