### PR TITLE
[master] Avoid name mangling on pyload core object

### DIFF
--- a/src/pyload/core/api/account.py
+++ b/src/pyload/core/api/account.py
@@ -22,7 +22,7 @@ class AccountApi(BaseApi):
 
         :return: string list
         """
-        return list(self.__pyload.pgm.get_plugins("account").keys())
+        return list(self.pyload_core.pgm.get_plugins("account").keys())
 
     @requireperm(Permission.Accounts)
     def get_accounts(self):
@@ -31,7 +31,7 @@ class AccountApi(BaseApi):
 
         :return: list of `AccountInfo`
         """
-        accounts = self.__pyload.acm.get_all_accounts()
+        accounts = self.pyload_core.acm.get_all_accounts()
         return [acc.to_info_data() for acc in accounts]
 
     @requireperm(Permission.Accounts)
@@ -41,7 +41,7 @@ class AccountApi(BaseApi):
 
         :param refresh: reload account info
         """
-        account = self.__pyload.acm.get_account(aid, plugin)
+        account = self.pyload_core.acm.get_account(aid, plugin)
 
         # Admins can see and refresh accounts
         if not account:
@@ -60,7 +60,7 @@ class AccountApi(BaseApi):
 
         :return class:`AccountInfo`
         """
-        return self.__pyload.acm.create_account(
+        return self.pyload_core.acm.create_account(
             plugin, loginname, password, self.user.true_primary).to_info_data()
 
     @requireperm(Permission.Accounts)
@@ -70,7 +70,7 @@ class AccountApi(BaseApi):
 
         :return: updated account info
         """
-        return self.__pyload.acm.update_account(
+        return self.pyload_core.acm.update_account(
             aid, plugin, loginname, password, self.user).to_info_data()
 
     @requireperm(Permission.Accounts)
@@ -78,7 +78,7 @@ class AccountApi(BaseApi):
         """
         Update account settings from :class:`AccountInfo`.
         """
-        inst = self.__pyload.acm.get_account(
+        inst = self.pyload_core.acm.get_account(
             account.aid, account.plugin, self.user)
         if not inst:
             return None
@@ -94,4 +94,4 @@ class AccountApi(BaseApi):
 
         :param account: :class:`ÀccountInfo` instance
         """
-        self.__pyload.acm.remove_account(account.aid, account.plugin)
+        self.pyload_core.acm.remove_account(account.aid, account.plugin)

--- a/src/pyload/core/api/addon.py
+++ b/src/pyload/core/api/addon.py
@@ -32,7 +32,7 @@ class AddonApi(BaseApi):
         :param plugin: pluginName
         :return: list of :class:`AddonInfo`
         """
-        return self.__pyload.adm.get_info(plugin)
+        return self.pyload_core.adm.get_info(plugin)
 
     @requireperm(Permission.Interaction)
     def get_addon_handler(self):
@@ -42,7 +42,7 @@ class AddonApi(BaseApi):
         :return: dict of plugin name to list of :class:`AddonService`
         """
         handler = {}
-        for name, data in self.__pyload.adm.iter_addons():
+        for name, data in self.pyload_core.adm.iter_addons():
             if not data.handler:
                 continue
             handler[name] = list(data.handler.values())
@@ -53,7 +53,7 @@ class AddonApi(BaseApi):
         """
         Calls any function exposed by an addon.
         """
-        return self.__pyload.adm.invoke(plugin, func, func_args)
+        return self.pyload_core.adm.invoke(plugin, func, func_args)
 
     @requireperm(Permission.Interaction)
     def invoke_addon_handler(self, plugin, func, pid_or_fid):

--- a/src/pyload/core/api/base.py
+++ b/src/pyload/core/api/base.py
@@ -28,6 +28,10 @@ class BaseApi(AbstractApi):
         # No instantiating!
         raise Exception
 
+    @property
+    def pyload_core(self):
+        return self.__pyload
+
 
 class AbstractApi(object):
 

--- a/src/pyload/core/api/config.py
+++ b/src/pyload/core/api/config.py
@@ -22,7 +22,7 @@ class ConfigApi(BaseApi):
         :rtype: str
         :return: config value as string
         """
-        return self.__pyload.config.get(section, option)
+        return self.pyload_core.config.get(section, option)
 
     def set_config_value(self, section, option, value):
         """
@@ -32,7 +32,7 @@ class ConfigApi(BaseApi):
         :param option:
         :param value: new config value
         """
-        self.__pyload.config.set(section, option, value)
+        self.pyload_core.config.set(section, option, value)
 
     # def get_config(self):
         # """
@@ -41,7 +41,7 @@ class ConfigApi(BaseApi):
         # :rtype: dict of section -> ConfigHolder
         # """
         # data = {}
-        # for section, config, values in self.__pyload.config.iter_core_sections():
+        # for section, config, values in self.pyload_core.config.iter_core_sections():
         # data[section] = to_config_holder(section, config, values)
         # return data
 
@@ -53,7 +53,7 @@ class ConfigApi(BaseApi):
         # """
         # return [ConfigInfo(section, config.label, config.description, False, False)
         # for section, config, values in
-        # self.__pyload.config.iter_core_sections()]
+        # self.pyload_core.config.iter_core_sections()]
 
     # @requireperm(Permission.Plugins)
     # def get_plugin_config(self):
@@ -66,15 +66,15 @@ class ConfigApi(BaseApi):
         # # TODO: multi user
         # # TODO: better plugin / addon activated config
         # data = []
-        # active = [x.get_name() for x in self.__pyload.adm.active_plugins()]
-        # for name, config, values in self.__pyload.config.iter_sections():
+        # active = [x.get_name() for x in self.pyload_core.adm.active_plugins()]
+        # for name, config, values in self.pyload_core.config.iter_sections():
         # # skip unmodified and inactive addons
         # if not values and name not in active:
         # continue
 
         # item = ConfigInfo(name, config.label, config.description,
-        # self.__pyload.pgm.get_category(name),
-        # self.__pyload.pgm.is_user_plugin(name),
+        # self.pyload_core.pgm.get_category(name),
+        # self.pyload_core.pgm.is_user_plugin(name),
         # # TODO: won't work probably
         # values.get("activated",
         # None if "activated" not in config.config else config.config['activated'].input.default))
@@ -91,9 +91,9 @@ class ConfigApi(BaseApi):
         # """
         # # TODO: filter user_context / addons when not allowed
         # plugins = [ConfigInfo(name, config.label, config.description,
-        # self.__pyload.pgm.get_category(name),
-        # self.__pyload.pgm.is_user_plugin(name))
-        # for name, config, values in self.__pyload.config.iter_sections()]
+        # self.pyload_core.pgm.get_category(name),
+        # self.pyload_core.pgm.is_user_plugin(name))
+        # for name, config, values in self.pyload_core.config.iter_sections()]
 
         # return plugins
 
@@ -107,7 +107,7 @@ class ConfigApi(BaseApi):
         # """
         # # requires at least plugin permissions, but only admin can load core
         # # config
-        # config, values = self.__pyload.config.get_section(name)
+        # config, values = self.pyload_core.config.get_section(name)
         # return to_config_holder(name, config, values)
 
     # @requireperm(Permission.Plugins)
@@ -118,9 +118,9 @@ class ConfigApi(BaseApi):
         # :param config: :class:`ConfigHolder`
         # """
         # for item in config.items:
-        # self.__pyload.config.set(config.name, item.name, item.value, store=False)
+        # self.pyload_core.config.set(config.name, item.name, item.value, store=False)
         # # save the changes
-        # self.__pyload.config.store()
+        # self.pyload_core.config.store()
 
     # # NOTE: No delete method in ConfigParser, maybe in ConfigManager...
     # @requireperm(Permission.Plugins)
@@ -131,4 +131,4 @@ class ConfigApi(BaseApi):
         # :param plugin: plugin name
         # """
         # TODO: delete should deactivate addons?
-        # self.__pyload.config.delete(plugin)
+        # self.pyload_core.config.delete(plugin)

--- a/src/pyload/core/api/core.py
+++ b/src/pyload/core/api/core.py
@@ -26,18 +26,18 @@ class CoreApi(BaseApi):
         """
         PyLoad Core version.
         """
-        return self.__pyload.version
+        return self.pyload_core.version
 
     def is_ws_secure(self):
         # needs to use TLS when either requested or webui is also using
         # encryption
-        if not self.__pyload.config.get('ssl', 'activated'):
+        if not self.pyload_core.config.get('ssl', 'activated'):
             return False
 
-        cert = self.__pyload.config.get('ssl', 'cert')
-        key = self.__pyload.config.get('ssl', 'key')
+        cert = self.pyload_core.config.get('ssl', 'cert')
+        key = self.pyload_core.config.get('ssl', 'key')
         if not os.path.isfile(cert) or not os.path.isfile(key):
-            self.__pyload.log.warning(
+            self.pyload_core.log.warning(
                 self._('SSL key or certificate not found'))
             return False
 
@@ -50,21 +50,21 @@ class CoreApi(BaseApi):
 
         :return: `StatusInfo`
         """
-        queue = self.__pyload.files.get_queue_stats()
-        total = self.__pyload.files.get_download_stats()
+        queue = self.pyload_core.files.get_queue_stats()
+        total = self.pyload_core.files.get_download_stats()
 
         server_status = StatusInfo(0,
                                    total[0], queue[0],
                                    total[1], queue[1],
                                    self.is_interaction_waiting(
                                        Interaction.All),
-                                   not self.__pyload.tsm.pause,
-                                   self.__pyload.tsm.pause,
-                                   self.__pyload.config.get(
+                                   not self.pyload_core.tsm.pause,
+                                   self.pyload_core.tsm.pause,
+                                   self.pyload_core.config.get(
                                        'reconnect', 'activated'),
                                    self.get_quota())
 
-        for file in self.__pyload.tsm.active_downloads():
+        for file in self.pyload_core.tsm.active_downloads():
             server_status.speed += file.get_speed()  # bytes/s
 
         return server_status
@@ -76,21 +76,21 @@ class CoreApi(BaseApi):
 
         :rtype: list of :class:`ProgressInfo`
         """
-        return (self.__pyload.tsm.get_progress_list() +
-                self.__pyload.iom.get_progress_list())
+        return (self.pyload_core.tsm.get_progress_list() +
+                self.pyload_core.iom.get_progress_list())
 
     def pause_server(self):
         """
         Pause server: It won't start any new downloads,
         but nothing gets aborted.
         """
-        self.__pyload.tsm.pause = True
+        self.pyload_core.tsm.pause = True
 
     def unpause_server(self):
         """
         Unpause server: New Downloads will be started.
         """
-        self.__pyload.tsm.pause = False
+        self.pyload_core.tsm.pause = False
 
     def toggle_pause(self):
         """
@@ -98,8 +98,8 @@ class CoreApi(BaseApi):
 
         :return: new pause state
         """
-        self.__pyload.tsm.pause ^= True
-        return self.__pyload.tsm.pause
+        self.pyload_core.tsm.pause ^= True
+        return self.pyload_core.tsm.pause
 
     def toggle_reconnect(self):
         """
@@ -107,27 +107,27 @@ class CoreApi(BaseApi):
 
         :return: new reconnect state
         """
-        self.__pyload.config['reconnect']['activated'] ^= True
-        return self.__pyload.config.get('reconnect', 'activated')
+        self.pyload_core.config['reconnect']['activated'] ^= True
+        return self.pyload_core.config.get('reconnect', 'activated')
 
     def avail_space(self):
         """
         Available free space at download directory in bytes.
         """
-        return availspace(self.__pyload.config.get(
+        return availspace(self.pyload_core.config.get(
             'general', 'storage_folder'))
 
     def shutdown(self):
         """
         Clean way to quit pyLoad.
         """
-        self.__pyload._Core__do_shutdown = True
+        self.pyload_core._Core__do_shutdown = True
 
     def restart(self):
         """
         Restart pyload core.
         """
-        self.__pyload._Core__do_restart = True
+        self.pyload_core._Core__do_restart = True
 
     def get_log(self, offset=0):
         """
@@ -139,7 +139,7 @@ class CoreApi(BaseApi):
         # TODO: Rewrite!
         logfile_folder = self.config.get('log', 'logfile_folder')
         if not logfile_folder:
-            logfile_folder = self.__pyload.DEFAULT_LOGDIRNAME
+            logfile_folder = self.pyload_core.DEFAULT_LOGDIRNAME
         logfile_name = self.config.get('log', 'logfile_name')
         if not logfile_name:
             logfile_name = self.DEFAULT_LOGFILENAME
@@ -161,8 +161,8 @@ class CoreApi(BaseApi):
 
         # :return: bool
         # """
-        # start = self.__pyload.config.get('connection', 'start').split(":")
-        # end = self.__pyload.config.get('connection', 'end').split(":")
+        # start = self.pyload_core.config.get('connection', 'start').split(":")
+        # end = self.pyload_core.config.get('connection', 'end').split(":")
         # return compare_time(start, end)
 
     # @requireperm(Permission.All)
@@ -172,7 +172,7 @@ class CoreApi(BaseApi):
 
         # :return: bool
         # """
-        # start = self.__pyload.config.get('reconnect', 'start').split(":")
-        # end = self.__pyload.config.get('reconnect', 'end').split(":")
+        # start = self.pyload_core.config.get('reconnect', 'start').split(":")
+        # end = self.pyload_core.config.get('reconnect', 'end').split(":")
         # return compare_time(start, end) and
-        # self.__pyload.config.get('reconnect', 'activated')
+        # self.pyload_core.config.get('reconnect', 'activated')

--- a/src/pyload/core/api/download.py
+++ b/src/pyload/core/api/download.py
@@ -26,7 +26,7 @@ class DownloadApi(BaseApi):
         if self.user:
             return self.user.true_primary
         else:
-            return self.__pyload.db.get_user_data(role=Role.Admin).uid
+            return self.pyload_core.db.get_user_data(role=Role.Admin).uid
 
     @requireperm(Permission.Add)
     def create_package(self, name, folder, root, password="",
@@ -49,9 +49,9 @@ class DownloadApi(BaseApi):
         folder = folder.replace("http://", "").replace(":", "")
         folder = folder.replace("\\", "_").replace("..", "")
 
-        self.__pyload.log.info(
+        self.pyload_core.log.info(
             self._("Added package {0} as folder {1}").format(name, folder))
-        pid = self.__pyload.files.add_package(
+        pid = self.pyload_core.files.add_package(
             name, folder, root, password, site, comment, paused,
             self.true_primary())
 
@@ -82,7 +82,7 @@ class DownloadApi(BaseApi):
         :param root: parents package id
         :return: package id of the new package
         """
-        if self.__pyload.config.get('general', 'folder_pack'):
+        if self.pyload_core.config.get('general', 'folder_pack'):
             folder = name
         else:
             folder = ""
@@ -101,17 +101,17 @@ class DownloadApi(BaseApi):
         :param pid: package id
         :param links: list of urls
         """
-        hoster, crypter = self.__pyload.pgm.parse_urls(links)
+        hoster, crypter = self.pyload_core.pgm.parse_urls(links)
 
-        self.__pyload.files.add_links(
+        self.pyload_core.files.add_links(
             hoster + crypter, pid, self.true_primary())
         if hoster:
-            self.__pyload.iom.create_info_thread(hoster, pid)
+            self.pyload_core.iom.create_info_thread(hoster, pid)
 
-        self.__pyload.log.info((self._(
+        self.pyload_core.log.info((self._(
             "Added {0:d} links to package "
             "#{0:d}").format(pid)).format(len(hoster + crypter)))
-        self.__pyload.files.save()
+        self.pyload_core.files.save()
 
     @requireperm(Permission.Add)
     def upload_container(self, filename, data):
@@ -121,7 +121,7 @@ class DownloadApi(BaseApi):
         :param filename: name of the file
         :param data: file content
         """
-        storagedir = self.__pyload.config.get('general', 'storage_folder')
+        storagedir = self.pyload_core.config.get('general', 'storage_folder')
         filename = 'tmp_{0}'.format(filename)
         filepath = os.path.join(storagedir, filename)
         with lopen(filepath, mode='wb') as fp:
@@ -136,9 +136,9 @@ class DownloadApi(BaseApi):
         :param fids: list of file ids
         """
         for fid in fids:
-            self.__pyload.files.remove_file(fid)
+            self.pyload_core.files.remove_file(fid)
 
-        self.__pyload.files.save()
+        self.pyload_core.files.save()
 
     @requireperm(Permission.Delete)
     def remove_packages(self, pids):
@@ -148,9 +148,9 @@ class DownloadApi(BaseApi):
         :param pids: list of package ids
         """
         for pid in pids:
-            self.__pyload.files.remove_package(pid)
+            self.pyload_core.files.remove_package(pid)
 
-        self.__pyload.files.save()
+        self.pyload_core.files.save()
 
     @requireperm(Permission.Modify)
     def restart_package(self, pid):
@@ -159,7 +159,7 @@ class DownloadApi(BaseApi):
 
         :param pid: package id
         """
-        self.__pyload.files.restart_package(pid)
+        self.pyload_core.files.restart_package(pid)
 
     @requireperm(Permission.Modify)
     def restart_file(self, fid):
@@ -168,7 +168,7 @@ class DownloadApi(BaseApi):
 
         :param fid: file id
         """
-        self.__pyload.files.restart_file(fid)
+        self.pyload_core.files.restart_file(fid)
 
     @requireperm(Permission.Modify)
     def recheck_package(self, pid):
@@ -176,21 +176,21 @@ class DownloadApi(BaseApi):
         Check online status of all files in a package,
         also a default action when package is added.
         """
-        self.__pyload.files.re_check_package(pid)
+        self.pyload_core.files.re_check_package(pid)
 
     @requireperm(Permission.Modify)
     def restart_failed(self):
         """
         Restarts all failed failes.
         """
-        self.__pyload.files.restart_failed()
+        self.pyload_core.files.restart_failed()
 
     @requireperm(Permission.Modify)
     def stop_all_downloads(self):
         """
         Aborts all running downloads.
         """
-        for file in self.__pyload.files.cached_files():
+        for file in self.pyload_core.files.cached_files():
             if self.has_access(file):
                 file.abort_download()
 
@@ -202,7 +202,7 @@ class DownloadApi(BaseApi):
         :param fids: list of file ids
         :return:
         """
-        files = self.__pyload.files.cached_files()
+        files = self.pyload_core.files.cached_files()
         for file in files:
             if file.fid in fids and self.has_access(file):
                 file.abort_download()

--- a/src/pyload/core/api/exchange.py
+++ b/src/pyload/core/api/exchange.py
@@ -24,7 +24,7 @@ class UserExchangeApi(BaseApi):
         :param mode: binary or'ed output type
         :return: boolean
         """
-        return self.__pyload.im.is_task_waiting(mode)
+        return self.pyload_core.im.is_task_waiting(mode)
 
     @requireperm(Permission.Interaction)
     def get_interaction_tasks(self, mode):
@@ -34,12 +34,12 @@ class UserExchangeApi(BaseApi):
         :param mode: binary or'ed interaction types which should be retrieved
         :rtype list of :class:`InteractionTask`
         """
-        tasks = self.__pyload.im.get_tasks(mode)
+        tasks = self.pyload_core.im.get_tasks(mode)
         # retrieved tasks count as seen
         for tsk in tasks:
             tsk.seen = True
             if tsk.type == Interaction.Notification:
-                tsk.set_waiting(self.__pyload.im.CLIENT_THRESHOLD)
+                tsk.set_waiting(self.pyload_core.im.CLIENT_THRESHOLD)
 
         return tasks
 
@@ -52,7 +52,7 @@ class UserExchangeApi(BaseApi):
         :param iid: interaction id
         :param result: result as json string
         """
-        task = self.__pyload.im.get_task_by_id(iid)
+        task = self.pyload_core.im.get_task_by_id(iid)
         if task:
             task.set_result(result)
 

--- a/src/pyload/core/api/file.py
+++ b/src/pyload/core/api/file.py
@@ -54,7 +54,7 @@ class FileApi(BaseApi):
         :param full: go down the complete tree or only the first layer
         :return: :class:`TreeCollection`
         """
-        return self.__pyload.files.get_tree(pid, full, DownloadState.All)
+        return self.pyload_core.files.get_tree(pid, full, DownloadState.All)
 
     @requireperm(Permission.All)
     def get_filtered_file_tree(self, pid, full, state):
@@ -67,7 +67,7 @@ class FileApi(BaseApi):
         :param state: :class:`DownloadState`, the attributes used for filtering
         :return: :class:`TreeCollection`
         """
-        return self.__pyload.files.get_tree(pid, full, state)
+        return self.pyload_core.files.get_tree(pid, full, state)
 
     @requireperm(Permission.All)
     def get_package_content(self, pid):
@@ -86,7 +86,7 @@ class FileApi(BaseApi):
         :raises PackageDoesNotExist:
         :return: :class:`PackageInfo`
         """
-        info = self.__pyload.files.get_package_info(pid)
+        info = self.pyload_core.files.get_package_info(pid)
         if not info:
             raise PackageDoesNotExist(pid)
         return info
@@ -101,7 +101,7 @@ class FileApi(BaseApi):
         :return: :class:`FileInfo`
 
         """
-        info = self.__pyload.files.get_file_info(fid)
+        info = self.pyload_core.files.get_file_info(fid)
         if not info:
             raise FileDoesNotExist(fid)
         return info
@@ -111,17 +111,17 @@ class FileApi(BaseApi):
         Internal method to get the filepath.
         """
         info = self.get_file_info(fid)
-        pack = self.__pyload.files.get_package(info.package)
+        pack = self.pyload_core.files.get_package(info.package)
         return pack.get_path(), info.name
 
     @requireperm(Permission.All)
     def find_files(self, pattern):
-        return self.__pyload.files.get_tree(
+        return self.pyload_core.files.get_tree(
             -1, True, DownloadState.All, pattern)
 
     @requireperm(Permission.All)
     def search_suggestions(self, pattern):
-        names = self.__pyload.db.get_matching_filenames(pattern)
+        names = self.pyload_core.db.get_matching_filenames(pattern)
         # TODO: stemming and reducing the names to provide better suggestions
         return uniqify(names)
 
@@ -138,12 +138,12 @@ class FileApi(BaseApi):
         :return updated package info
         """
         pid = pack.pid
-        pack_ = self.__pyload.files.get_package(pid)
+        pack_ = self.pyload_core.files.get_package(pid)
         if not pack_:
             raise PackageDoesNotExist(pid)
         pack_.update_from_info_data(pack)
         pack_.sync()
-        self.__pyload.files.save()
+        self.pyload_core.files.save()
 
     @requireperm(Permission.Modify)
     def set_package_paused(self, pid, paused):
@@ -154,7 +154,7 @@ class FileApi(BaseApi):
         :param paused: desired paused state of the package
         :return the new package status
         """
-        pack = self.__pyload.files.get_package(pid)
+        pack = self.pyload_core.files.get_package(pid)
         if not pack:
             raise PackageDoesNotExist(pid)
 
@@ -180,7 +180,7 @@ class FileApi(BaseApi):
         :raises PackageDoesNotExist: When pid or root is missing
         :return: False if package can't be moved
         """
-        return self.__pyload.files.move_package(pid, root)
+        return self.pyload_core.files.move_package(pid, root)
 
     @requireperm(Permission.Modify)
     def move_files(self, fids, pid):
@@ -194,7 +194,7 @@ class FileApi(BaseApi):
         :param pid: destination package
         :return: False if files can't be moved
         """
-        return self.__pyload.files.move_files(fids, pid)
+        return self.pyload_core.files.move_files(fids, pid)
 
     def delete_files(self, fids):
         """
@@ -220,7 +220,7 @@ class FileApi(BaseApi):
         :param pid: package id
         :param position: new position, 0 for very beginning
         """
-        self.__pyload.files.order_package(pid, position)
+        self.pyload_core.files.order_package(pid, position)
 
     @requireperm(Permission.Modify)
     def order_files(self, fids, pid, position):
@@ -233,4 +233,4 @@ class FileApi(BaseApi):
         :param pid: package id of parent package
         :param position:  new position: 0 for very beginning
         """
-        self.__pyload.files.order_files(fids, pid, position)
+        self.pyload_core.files.order_files(fids, pid, position)

--- a/src/pyload/core/api/init.py
+++ b/src/pyload/core/api/init.py
@@ -77,6 +77,10 @@ class Api(AbstractApi):
         self.user_apis = {}
 
     @property
+    def pyload_core(self):
+        return self.__pyload
+
+    @property
     def user(self):
         return None  # TODO: return default user?
 
@@ -118,12 +122,12 @@ class Api(AbstractApi):
             uid = uid.uid
 
         if uid not in self.user_apis:
-            user = self.__pyload.db.get_user_data(uid=uid)
+            user = self.pyload_core.db.get_user_data(uid=uid)
             if not user:  # TODO: anonymous user?
                 return None
 
             self.user_apis[uid] = UserApi(
-                self.__pyload, User.from_user_data(self, user))
+                self.pyload_core, User.from_user_data(self, user))
 
         return self.user_apis[uid]
 
@@ -153,10 +157,10 @@ class Api(AbstractApi):
         :param remoteip:
         :return: dict with info, empty when login is incorrect
         """
-        self.__pyload.log.info(
+        self.pyload_core.log.info(
             self._("User '{0}' tries to log in").format(username))
 
-        return self.__pyload.db.check_auth(username, password)
+        return self.pyload_core.db.check_auth(username, password)
 
     @staticmethod
     def is_authorized(func, user):

--- a/src/pyload/core/api/predownload.py
+++ b/src/pyload/core/api/predownload.py
@@ -38,7 +38,7 @@ class PreDownloadApi(BaseApi):
         :param links:
         :return: {plugin: urls}
         """
-        data, crypter = self.__pyload.pgm.parse_urls(links)
+        data, crypter = self.pyload_core.pgm.parse_urls(links)
         plugins = {}
 
         for url, plugin in chain(data, crypter):
@@ -58,7 +58,7 @@ class PreDownloadApi(BaseApi):
         :return: initial set of data as :class:`OnlineCheck` instance
         containing the result id
         """
-        hoster, crypter = self.__pyload.pgm.parse_urls(links)
+        hoster, crypter = self.pyload_core.pgm.parse_urls(links)
 
         # TODO: withhold crypter, derypt or add later
         # initial result does not contain the crypter links
@@ -67,7 +67,7 @@ class PreDownloadApi(BaseApi):
                            pluginname))
                for url, pluginname in hoster]
         data = parse.packs(tmp)
-        rid = self.__pyload.iom.create_result_thread(hoster + crypter)
+        rid = self.pyload_core.iom.create_result_thread(hoster + crypter)
 
         return OnlineCheck(rid, data)
 
@@ -80,7 +80,7 @@ class PreDownloadApi(BaseApi):
         :param data: file content
         :return: :class:`OnlineCheck`
         """
-        storagedir = self.__pyload.config.get('general', 'storage_folder')
+        storagedir = self.pyload_core.config.get('general', 'storage_folder')
         filename = 'tmp_{0}'.format(filename)
         filepath = os.path.join(storagedir, filename)
         with lopen(filepath, mode='wb') as fp:
@@ -100,7 +100,7 @@ class PreDownloadApi(BaseApi):
         if html:
             urls += [x[0] for x in _re_urlmatch.findall(html)]
         if url:
-            page = self.__pyload.req.get_url(url)
+            page = self.pyload_core.req.get_url(url)
             urls += [x[0] for x in _re_urlmatch.findall(page)]
 
         return self.check_links(uniqify(urls))
@@ -114,7 +114,7 @@ class PreDownloadApi(BaseApi):
         :return: `OnlineCheck`, if rid is -1 then there is
         no more data available
         """
-        result = self.__pyload.iom.get_info_result(rid)
+        result = self.pyload_core.iom.get_info_result(rid)
         if result:
             return result.to_api_data()
 

--- a/src/pyload/core/database/backend.py
+++ b/src/pyload/core/database/backend.py
@@ -139,6 +139,10 @@ class DatabaseBackend(Thread):
         set_db(self)
 
     @property
+    def pyload_core(self):
+        return self.__pyload
+
+    @property
     def running(self):
         return self.__running.is_set()
 
@@ -169,7 +173,7 @@ class DatabaseBackend(Thread):
                 self.conn.close()
 
                 try:
-                    self.__pyload.log.warning(
+                    self.pyload_core.log.warning(
                         self._("Database was deleted "
                                "due to incompatible version"))
                 except Exception:

--- a/src/pyload/core/datatype/file.py
+++ b/src/pyload/core/datatype/file.py
@@ -131,7 +131,7 @@ class File(BaseObject):
         self, manager, fid, name, size, filestatus, media, added,
             fileorder, url, pluginname, hash, status, error, package, owner):
         self.__manager = manager
-        self.__pyload = manager.get_core()
+        self.__pyload = manager.pyload_core
 
         self.fid = int(fid)
         self._name = purge.name(name)
@@ -159,6 +159,10 @@ class File(BaseObject):
         self.abort = False
         self.reconnected = False
         self.statusname = None
+
+    @property
+    def pyload_core(self):
+        return self.__pyload
 
     def get_size(self):
         """
@@ -206,7 +210,7 @@ class File(BaseObject):
         Inits plugin instance.
         """
         if not self.plugin:
-            self.pluginclass = self.__pyload.pgm.get_plugin_class(
+            self.pluginclass = self.pyload_core.pgm.get_plugin_class(
                 "hoster", self.pluginname)
             self.plugin = self.pluginclass(self)
 
@@ -278,7 +282,7 @@ class File(BaseObject):
         """
         Abort file if possible.
         """
-        while self.fid in self.__pyload.tsm.processing_ids():
+        while self.fid in self.pyload_core.tsm.processing_ids():
             with self.lock(shared=True):
                 self.abort = True
                 if self.plugin and self.plugin.req:
@@ -297,7 +301,7 @@ class File(BaseObject):
         is finished with it.
         """
         # TODO: this is wrong now, it should check if addons are using it
-        if self.id in self.__pyload.tsm.processing_ids():
+        if self.id in self.pyload_core.tsm.processing_ids():
             return False
 
         self.set_status("finished")

--- a/src/pyload/core/datatype/package.py
+++ b/src/pyload/core/datatype/package.py
@@ -95,7 +95,7 @@ class Package(BaseObject):
             self, manager, pid, name, folder, root, owner, site, comment,
             password, added, tags, status, shared, packageorder):
         self.__manager = manager
-        self.__pyload = manager.get_core()
+        self.__pyload = manager.pyload_core
 
         self.pid = pid
         self.name = name
@@ -114,6 +114,10 @@ class Package(BaseObject):
 
         # Finish event already fired
         self.set_finished = False
+
+    @property
+    def pyload_core(self):
+        return self.__pyload
 
     def is_stale(self):
         return self.timestamp + 30 * 60 > time.time()
@@ -136,7 +140,7 @@ class Package(BaseObject):
         """
         Get contaied files data.
         """
-        return self.__pyload.db.get_all_files(package=self.pid)
+        return self.pyload_core.db.get_all_files(package=self.pid)
 
     def get_path(self, name=""):
         self.timestamp = time.time()
@@ -169,7 +173,7 @@ class Package(BaseObject):
         return False
 
     def notify_change(self):
-        self.__pyload.evm.fire("packageUpdated", self.id)
+        self.pyload_core.evm.fire("packageUpdated", self.id)
 
 
 class RootPackage(Package):
@@ -181,7 +185,7 @@ class RootPackage(Package):
                          "", "", "", 0, [], PackageStatus.Ok, False, 0)
 
     def get_path(self, name=""):
-        return os.path.join(self.__pyload.config.get(
+        return os.path.join(self.pyload_core.config.get(
             'general', 'storage_folder'), name)
 
     # no database operations

--- a/src/pyload/core/manager/addon.py
+++ b/src/pyload/core/manager/addon.py
@@ -73,7 +73,7 @@ class AddonManager(BaseManager):
         except Exception as e:
             plugin.log_error(
                 self._("Error when executing {0}".format(f)), str(e))
-            # self.__pyload.print_exc()
+            # self.pyload_core.print_exc()
 
     def invoke(self, plugin, func_name, args):
         """
@@ -95,48 +95,48 @@ class AddonManager(BaseManager):
         active = []
         deactive = []
 
-        for pluginname in self.__pyload.pgm.get_plugins("addon"):
+        for pluginname in self.pyload_core.pgm.get_plugins("addon"):
             try:
                 # check first for builtin plugin
-                attrs = self.__pyload.pgm.load_attributes("addon", pluginname)
+                attrs = self.pyload_core.pgm.load_attributes("addon", pluginname)
                 internal = attrs.get("internal", False)
 
-                if internal or self.__pyload.config.get(
+                if internal or self.pyload_core.config.get(
                         pluginname, "activated"):
-                    pluginclass = self.__pyload.pgm.load_class(
+                    pluginclass = self.pyload_core.pgm.load_class(
                         "addon", pluginname)
 
                     if not pluginclass:
                         continue
 
-                    plugin = pluginclass(self.__pyload, self)
+                    plugin = pluginclass(self.pyload_core, self)
                     self.plugins[pluginclass.__name__].instances.append(plugin)
 
                     # hide internals from printing
                     if not internal and plugin.is_activated():
                         active.append(pluginclass.__name__)
                     else:
-                        self.__pyload.log.debug(
+                        self.pyload_core.log.debug(
                             "Loaded internal plugin: {0}".format(
                                 pluginclass.__name__))
                 else:
                     deactive.append(pluginname)
 
             except Exception:
-                self.__pyload.log.warning(
+                self.pyload_core.log.warning(
                     self._("Failed activating {0}").format(pluginname))
-                # self.__pyload.print_exc()
+                # self.pyload_core.print_exc()
 
-        self.__pyload.log.info(
+        self.pyload_core.log.info(
             self._("Activated addons: {0}").format(", ".join(sorted(active))))
-        self.__pyload.log.info(self._("Deactivated addons: {0}").format(
+        self.pyload_core.log.info(self._("Deactivated addons: {0}").format(
             ", ".join(sorted(deactive))))
 
     def manage_addon(self, plugin, name, value):
         # TODO: multi user
 
         # check if section was a plugin
-        if plugin not in self.__pyload.pgm.get_plugins("addon"):
+        if plugin not in self.pyload_core.pgm.get_plugins("addon"):
             return None
 
         if name == "activated" and value:
@@ -150,14 +150,14 @@ class AddonManager(BaseManager):
         if plugin in self.plugins:
             return None
 
-        pluginclass = self.__pyload.pgm.load_class("addon", plugin)
+        pluginclass = self.pyload_core.pgm.load_class("addon", plugin)
 
         if not pluginclass:
             return None
 
-        self.__pyload.log.debug("Plugin loaded: {0}".format(plugin))
+        self.pyload_core.log.debug("Plugin loaded: {0}".format(plugin))
 
-        plugin = pluginclass(self.__pyload, self)
+        plugin = pluginclass(self.pyload_core, self)
         self.plugins[pluginclass.__name__].instances.append(plugin)
 
         # active the addon in new thread
@@ -175,11 +175,11 @@ class AddonManager(BaseManager):
             return None
 
         self.call(addon, "deactivate")
-        self.__pyload.log.debug("Plugin deactivated: {0}".format(plugin))
+        self.pyload_core.log.debug("Plugin deactivated: {0}".format(plugin))
 
         # remove periodic call
-        self.__pyload.log.debug("Removed callback {0}".format(
-            self.__pyload.scheduler.cancel(addon.cb)))
+        self.pyload_core.log.debug("Removed callback {0}".format(
+            self.pyload_core.scheduler.cancel(addon.cb)))
 
         # TODO: only delete instances, meta data is lost otherwise
         del self.plugins[addon.__name__].instances[:]
@@ -190,10 +190,10 @@ class AddonManager(BaseManager):
             if fname.startswith("__") or not isinstance(
                     getattr(addon, fname), MethodType):
                 continue
-            self.__pyload.evm.remove_from_events(getattr(addon, fname))
+            self.pyload_core.evm.remove_from_events(getattr(addon, fname))
 
     def activate_addons(self):
-        self.__pyload.log.info(self._("Activating addons ..."))
+        self.pyload_core.log.info(self._("Activating addons ..."))
         for plugin in self.plugins.values():
             for inst in plugin.instances:
                 if inst.is_activated():
@@ -205,7 +205,7 @@ class AddonManager(BaseManager):
         """
         Called when core is shutting down.
         """
-        self.__pyload.log.info(self._("Deactivating addons ..."))
+        self.pyload_core.log.info(self._("Deactivating addons ..."))
         for plugin in self.plugins.values():
             for inst in plugin.instances:
                 self.call(inst, "deactivate")
@@ -224,7 +224,7 @@ class AddonManager(BaseManager):
 
     @lock
     def start_thread(self, func, *args, **kwargs):
-        thread = AddonThread(self.__pyload.iom, func, args, kwargs)
+        thread = AddonThread(self.pyload_core.iom, func, args, kwargs)
         thread.start()
         return thread
 
@@ -280,7 +280,7 @@ class AddonManager(BaseManager):
         self.info_props[h] = AddonInfo(name, desc)
 
     def listen_to(self, *args):
-        self.__pyload.evm.listen_to(*args)
+        self.pyload_core.evm.listen_to(*args)
 
     def fire(self, *args):
-        self.__pyload.evm.fire(*args)
+        self.pyload_core.evm.fire(*args)

--- a/src/pyload/core/manager/base.py
+++ b/src/pyload/core/manager/base.py
@@ -24,5 +24,6 @@ class BaseManager(object):
         self._ = core._
         self.lock = Lock()
 
-    def get_core(self):
+    @property
+    def pyload_core(self):
         return self.__pyload

--- a/src/pyload/core/manager/event.py
+++ b/src/pyload/core/manager/event.py
@@ -48,7 +48,7 @@ class EventManager(BaseManager):
         """
         if event in self.events:
             if func in self.events[event]:
-                self.__pyload.log.debug(
+                self.pyload_core.log.debug(
                     "Function already registered {0}".format(func))
             else:
                 self.events[event].append(func)
@@ -83,8 +83,8 @@ class EventManager(BaseManager):
                 try:
                     func(*args, **kwargs)
                 except Exception as e:
-                    self.__pyload.log.warning(
+                    self.pyload_core.log.warning(
                         "Error calling event handler "
                         "{0}: {1}, {2}, {3}".format(event, func, args, str(e))
                     )
-                    # self.__pyload.print_exc()
+                    # self.pyload_core.print_exc()

--- a/src/pyload/core/manager/exchange.py
+++ b/src/pyload/core/manager/exchange.py
@@ -120,7 +120,7 @@ class ExchangeManager(BaseManager):
     def remove_task(self, task):
         if task.iid in self.tasks:
             del self.tasks[task.iid]
-            self.__pyload.evm.fire("interaction:deleted", task.iid)
+            self.pyload_core.evm.fire("interaction:deleted", task.iid)
 
     @lock
     def get_task_by_id(self, iid):
@@ -159,12 +159,12 @@ class ExchangeManager(BaseManager):
             # notifications are valid for 30h
             task.set_waiting(self.NOTIFICATION_TIMEOUT)
 
-        for plugin in self.__pyload.adm.active_plugins():
+        for plugin in self.pyload_core.adm.active_plugins():
             try:
                 plugin.new_interaction_task(task)
             except Exception:
-                # self.__pyload.print_exc()
+                # self.pyload_core.print_exc()
                 pass
 
         self.tasks[task.iid] = task
-        self.__pyload.evm.fire("interaction:added", task)
+        self.pyload_core.evm.fire("interaction:added", task)

--- a/src/pyload/core/manager/info.py
+++ b/src/pyload/core/manager/info.py
@@ -90,7 +90,7 @@ class InfoManager(BaseManager):
         return self.info_results.get(rid)
 
     def set_info_results(self, oc, result):
-        self.__pyload.evm.fire("linkcheck:updated", oc.rid,
+        self.pyload_core.evm.fire("linkcheck:updated", oc.rid,
                                result, owner=oc.owner)
         oc.update(result)
 
@@ -113,7 +113,7 @@ class InfoManager(BaseManager):
         """
         if self.info_cache and self.timestamp < time.time():
             self.info_cache.clear()
-            self.__pyload.log.debug("Cleared Result cache")
+            self.pyload_core.log.debug("Cleared Result cache")
 
         for rid in self.info_results:
             if self.info_results[rid].is_stale():

--- a/src/pyload/core/manager/plugin.py
+++ b/src/pyload/core/manager/plugin.py
@@ -59,9 +59,9 @@ class PluginManager(BaseManager):
         sys.path.append(os.getcwd())  # TODO: Recheck...
         self.loader = LoaderFactory(
             PluginLoader(fullpath(self.LOCALROOT),
-                         self.LOCALROOT, self.__pyload.config),
+                         self.LOCALROOT, self.pyload_core.config),
             PluginLoader(resource_filename(__package__, 'network')),
-            self.ROOT, self.__pyload.config)
+            self.ROOT, self.pyload_core.config)
 
         self.loader.check_versions()
 
@@ -97,7 +97,7 @@ class PluginManager(BaseManager):
 
         for url in urls:
             if not isinstance(url, str):
-                self.__pyload.log.debug(
+                self.pyload_core.log.debug(
                     "Parsing invalid type {0}".format(type(url)))
                 continue
 
@@ -204,10 +204,10 @@ class PluginManager(BaseManager):
                     self.modules[(type_, name)] = module
                     return module
                 except Exception as e:
-                    self.__pyload.log.error(
+                    self.pyload_core.log.error(
                         self._("Error importing {0}: {1}").format(
                             name, str(e)))
-                    # self.__pyload.print_exc()
+                    # self.pyload_core.print_exc()
 
     def load_class(self, type_, name):
         """
@@ -218,7 +218,7 @@ class PluginManager(BaseManager):
             if module:
                 return getattr(module, name)
         except AttributeError:
-            self.__pyload.log.error(
+            self.pyload_core.log.error(
                 self._("Plugin does not define class '{0}'").format(name))
 
     def find_module(self, fullname):

--- a/src/pyload/core/manager/remote.py
+++ b/src/pyload/core/manager/remote.py
@@ -22,8 +22,8 @@ class RemoteManager(BaseManager):
         self.backends = []
 
     def start(self):
-        host = self.__pyload.config.get('rpc', 'host')
-        port = self.__pyload.config.get('rpc', 'port')
+        host = self.pyload_core.config.get('rpc', 'host')
+        port = self.pyload_core.config.get('rpc', 'port')
 
         for b in self.available:
             klass = getattr(
@@ -35,13 +35,13 @@ class RemoteManager(BaseManager):
                 continue
             try:
                 backend.setup(host, port)
-                self.__pyload.log.info(
+                self.pyload_core.log.info(
                     self._("Starting {0}: {1}:{2}").format(b, host, port))
             except Exception as e:
-                self.__pyload.log.error(
+                self.pyload_core.log.error(
                     self._("Failed loading backend {0} | {1}").format(
                         b, str(e)))
-                if self.__pyload.debug:
+                if self.pyload_core.debug:
                     print_exc()
             else:
                 backend.start()

--- a/src/pyload/core/network/account.py
+++ b/src/pyload/core/network/account.py
@@ -61,7 +61,7 @@ class Account(Base):
 
     def __init__(self, manager, aid, loginname, owner,
                  activated, shared, password, options):
-        Base.__init__(self, manager.get_core(), owner)
+        Base.__init__(self, manager.pyload_core, owner)
 
         self.aid = aid
         self.loginname = loginname
@@ -172,7 +172,7 @@ class Account(Base):
                 self._("Could not login with account {0} | {1}").format(
                     self.loginname, str(e)))
             self.valid = False
-            # self.__pyload.print_exc()
+            # self.pyload_core.print_exc()
 
         return self.valid
 
@@ -206,7 +206,7 @@ class Account(Base):
                 self.set_config(item.name, item.value)
 
     def get_account_request(self):
-        return self.__pyload.req.get_request(self.cj)
+        return self.pyload_core.req.get_request(self.cj)
 
     def get_download_settings(self):
         """
@@ -258,7 +258,7 @@ class Account(Base):
 
             self.log_debug("Account Info: {0}".format(infos))
             self.timestamp = time.time()
-            self.__pyload.evm.fire("account:loaded", self.to_info_data())
+            self.pyload_core.evm.fire("account:loaded", self.to_info_data())
 
     # TODO: remove user
     def load_account_info(self, req):
@@ -361,7 +361,7 @@ class Account(Base):
         self.log_debug(
             "Scheduled Account refresh for {0} in {1} seconds".format(
                 self.loginname, time))
-        self.__pyload.scheduler.enter(time, 1, self.get_account_info, [force])
+        self.pyload_core.scheduler.enter(time, 1, self.get_account_info, [force])
 
     @lock
     def check_login(self, req):

--- a/src/pyload/core/network/addon.py
+++ b/src/pyload/core/network/addon.py
@@ -137,7 +137,7 @@ class Addon(Base):
         if self.cb:
             self.stop_periodical()
 
-        self.cb = self.__pyload.scheduler.enter(wait, 2, self._periodical)
+        self.cb = self.pyload_core.scheduler.enter(wait, 2, self._periodical)
         self.interval = interval
         return True
 
@@ -146,7 +146,7 @@ class Addon(Base):
         Stops periodical call if existing
         :return: True if the callback was stopped, false otherwise
         """
-        if self.cb and self.__pyload.scheduler.cancel(self.cb):
+        if self.cb and self.pyload_core.scheduler.cancel(self.cb):
             self.cb = None
             return True
         else:
@@ -157,12 +157,12 @@ class Addon(Base):
             if self.is_activated():
                 self.periodical()
         except Exception as e:
-            self.__pyload.log.error(
+            self.pyload_core.log.error(
                 self._("Error executing addon: {0}").format(str(e)))
-            # self.__pyload.print_exc()
+            # self.pyload_core.print_exc()
 
         if self.cb:
-            self.cb = self.__pyload.scheduler.enter(
+            self.cb = self.pyload_core.scheduler.enter(
                 self.interval, 2, self._periodical)
 
     def __repr__(self):
@@ -175,7 +175,7 @@ class Addon(Base):
         return True if self.__internal__ else self.get_config("activated")
 
     def get_category(self):
-        return self.__pyload.pgm.get_category(self.__name__)
+        return self.pyload_core.pgm.get_category(self.__name__)
 
     def init(self):
         pass

--- a/src/pyload/core/network/base.py
+++ b/src/pyload/core/network/base.py
@@ -94,14 +94,14 @@ class Base(object):
 
         if owner is not None:
             # :class:`Api`, user api when user is set
-            self.api = self.__pyload.api.with_user_context(owner)
+            self.api = self.pyload_core.api.with_user_context(owner)
             if not self.api:
                 raise Exception("Plugin running with invalid user")
 
             # :class:`User`, user related to this plugin
             self.owner = self.api.user
         else:
-            self.api = self.__pyload.api
+            self.api = self.pyload_core.api
             self.owner = None
 
         # last interaction task
@@ -112,6 +112,10 @@ class Base(object):
         Retrieves meta data attribute.
         """
         return getattr(self, "__{0}__".format(item))
+
+    @property
+    def pyload_core(self):
+        return self.__pyload
 
     def log_info(self, *args, **kwargs):
         """
@@ -155,40 +159,40 @@ class Base(object):
         """
         Gives the compiled pattern of the plugin.
         """
-        return self.__pyload.pgm.get_plugin(self.__type__, self.__name__).re
+        return self.pyload_core.pgm.get_plugin(self.__type__, self.__name__).re
 
     def set_config(self, option, value):
         """
         Set config value for current plugin.
         """
-        self.__pyload.config.set(self.__name__, option, value)
+        self.pyload_core.config.set(self.__name__, option, value)
 
     # TODO: Recheck...
     def get_config(self, option):
         """
         Returns config value for current plugin.
         """
-        return self.__pyload.config.get(self.__name__, option)
+        return self.pyload_core.config.get(self.__name__, option)
 
     def set_storage(self, key, value):
         """
         Saves a value persistently to the database.
         """
-        self.__pyload.db.set_storage(self.__name__, key, value)
+        self.pyload_core.db.set_storage(self.__name__, key, value)
 
     def store(self, key, value):
         """
         Same as `set_storage`.
         """
-        self.__pyload.db.set_storage(self.__name__, key, value)
+        self.pyload_core.db.set_storage(self.__name__, key, value)
 
     def get_storage(self, key=None, default=None):
         """
         Retrieves saved value or dict of all saved entries if key is None.
         """
         if key is not None:
-            return self.__pyload.db.get_storage(self.__name__, key) or default
-        return self.__pyload.db.get_storage(self.__name__, key)
+            return self.pyload_core.db.get_storage(self.__name__, key) or default
+        return self.pyload_core.db.get_storage(self.__name__, key)
 
     def retrieve(self, *args, **kwargs):
         """
@@ -200,7 +204,7 @@ class Base(object):
         """
         Delete entry in db.
         """
-        self.__pyload.db.del_storage(self.__name__, key)
+        self.pyload_core.db.del_storage(self.__name__, key)
 
     def abort(self):
         """
@@ -237,11 +241,11 @@ class Base(object):
         res = self.req.load(url, get, post, ref, cookies,
                             just_header, decode=decode)
 
-        if self.__pyload.debug:
+        if self.pyload_core.debug:
             from inspect import currentframe
 
             frame = currentframe()
-            dumpdir = os.path.join(self.__pyload.cachedir,
+            dumpdir = os.path.join(self.pyload_core.cachedir,
                                    'plugins', self.__name__)
             makedirs(dumpdir, exist_ok=True)
 
@@ -317,10 +321,10 @@ class Base(object):
             fp.write(img)
 
             name = "{0}OCR".format(self.__name__)
-            has_plugin = name in self.__pyload.pgm.get_plugins("internal")
+            has_plugin = name in self.pyload_core.pgm.get_plugins("internal")
 
-            if self.__pyload.captcha:
-                OCR = self.__pyload.pgm.load_class("internal", name)
+            if self.pyload_core.captcha:
+                OCR = self.pyload_core.pgm.load_class("internal", name)
             else:
                 OCR = None
 
@@ -331,18 +335,18 @@ class Base(object):
                 ocr = OCR()
                 result = ocr.get_captcha(fp.name)
             else:
-                task = self.__pyload.exm.create_captcha_task(
+                task = self.pyload_core.exm.create_captcha_task(
                     img, imgtype, fp.name, self.__name__, result_type)
                 self.task = task
 
                 while task.is_waiting():
                     if self.abort():
-                        self.__pyload.exm.remove_task(task)
+                        self.pyload_core.exm.remove_task(task)
                         raise Abort
                     time.sleep(1)
 
                 # TODO: task handling
-                self.__pyload.exm.remove_task(task)
+                self.pyload_core.exm.remove_task(task)
 
                 if task.error and has_plugin:  # ignore default error message since the user could use OCR
                     self.fail(
@@ -356,10 +360,10 @@ class Base(object):
                             "No captcha result obtained in appropriate time"))
 
                 result = task.result
-                self.__pyload.log.debug(
+                self.pyload_core.log.debug(
                     "Received captcha result: {0}".format(result))
 
-            if not self.__pyload.debug:
+            if not self.pyload_core.debug:
                 try:
                     remove(fp.name)
                 except Exception:

--- a/src/pyload/core/network/factory.py
+++ b/src/pyload/core/network/factory.py
@@ -23,6 +23,10 @@ class RequestFactory(object):
 
         self.__pyload.evm.listen_to("config:changed", self.update_config)
 
+    @property
+    def pyload_core(self):
+        return self.__pyload
+
     def get_url(self, *args, **kwargs):
         """
         See HTTPRequest for argument list.
@@ -51,38 +55,38 @@ class RequestFactory(object):
         return class_(self.bucket, request)
 
     def get_interface(self):
-        return self.__pyload.config.get('connection', 'interface')
+        return self.pyload_core.config.get('connection', 'interface')
 
     def get_proxies(self):
         """
         Returns a proxy list for the request classes.
         """
-        if not self.__pyload.config.get('proxy', 'activated'):
+        if not self.pyload_core.config.get('proxy', 'activated'):
             return {}
         else:
             _type = "http"
-            setting = self.__pyload.config.get('proxy', 'type').lower()
+            setting = self.pyload_core.config.get('proxy', 'type').lower()
             if setting == "socks4":
                 _type = "socks4"
             elif setting == "socks5":
                 _type = "socks5"
 
             username = None
-            if self.__pyload.config.get(
-                    'proxy', 'username') and self.__pyload.config.get(
+            if self.pyload_core.config.get(
+                    'proxy', 'username') and self.pyload_core.config.get(
                     'proxy', 'username').lower() != "none":
-                username = self.__pyload.config.get('proxy', 'username')
+                username = self.pyload_core.config.get('proxy', 'username')
 
             pw = None
-            if self.__pyload.config.get(
-                    'proxy', 'password') and self.__pyload.config.get(
+            if self.pyload_core.config.get(
+                    'proxy', 'password') and self.pyload_core.config.get(
                     'proxy', 'password').lower() != "none":
-                pw = self.__pyload.config.get('proxy', 'password')
+                pw = self.pyload_core.config.get('proxy', 'password')
 
             return {
                 'type': _type,
-                'address': self.__pyload.config.get('proxy', 'host'),
-                'port': self.__pyload.config.get('proxy', 'port'),
+                'address': self.pyload_core.config.get('proxy', 'host'),
+                'port': self.pyload_core.config.get('proxy', 'port'),
                 'username': username,
                 'password': pw,
             }
@@ -100,13 +104,13 @@ class RequestFactory(object):
         """
         return {'interface': self.get_interface(),
                 'proxies': self.get_proxies(),
-                'ipv6': self.__pyload.config.get('connection', 'ipv6')}
+                'ipv6': self.pyload_core.config.get('connection', 'ipv6')}
 
     def update_bucket(self):
         """
         Set values in the bucket according to settings.
         """
-        max_speed = self.__pyload.config.get('connection', 'max_speed')
+        max_speed = self.pyload_core.config.get('connection', 'max_speed')
         if max_speed > 0:
             self.bucket.set_rate(max_speed << 10)
         else:

--- a/src/pyload/core/thread/addon.py
+++ b/src/pyload/core/thread/addon.py
@@ -81,7 +81,7 @@ class AddonThread(PluginThread):
             if hasattr(self.func, "im_self"):
                 addon = self.func.__self__
                 addon.log_error(self._("An Error occurred"), str(e))
-                if self.__pyload.debug:
+                if self.pyload_core.debug:
                     print_exc()
                     # self.debug_report(addon.__name__, plugin=addon)
 

--- a/src/pyload/core/thread/decrypter.py
+++ b/src/pyload/core/thread/decrypter.py
@@ -40,8 +40,8 @@ class DecrypterThread(PluginThread):
         return self.__pi
 
     def run(self):
-        pack = self.__pyload.files.get_package(self.pid)
-        api = self.__pyload.api.with_user_context(self.owner)
+        pack = self.pyload_core.files.get_package(self.pid)
+        api = self.pyload_core.api.with_user_context(self.owner)
         links, packages = self.decrypt(accumulate(self.data), pack.password)
 
         # if there is only one package links will be added to current one
@@ -51,7 +51,7 @@ class DecrypterThread(PluginThread):
             del packages[0]
 
         if links:
-            self.__pyload.log.info(
+            self.pyload_core.log.info(
                 self._("Decrypted {0:d} links into package {1}").format(
                     len(links),
                     pack.name))
@@ -60,13 +60,13 @@ class DecrypterThread(PluginThread):
         for pack_ in packages:
             api.add_package(pack_.name, pack_.get_urls(), pack.password)
 
-        self.__pyload.files.set_download_status(
+        self.pyload_core.files.set_download_status(
             self.fid, DownloadStatus.Finished
             if not self.error else DownloadStatus.Failed)
         self.__manager.done(self)
 
     def _decrypt(self, name, urls, password):
-        klass = self.__pyload.pgm.load_class("crypter", name)
+        klass = self.pyload_core.pgm.load_class("crypter", name)
         plugin = None
         result = []
 
@@ -84,13 +84,13 @@ class DecrypterThread(PluginThread):
                 LinkStatus(
                     url, url, -1, DownloadStatus.NotPossible, name)
                 for url in urls)
-            self.__pyload.log.debug(
+            self.pyload_core.log.debug(
                 "Plugin '{0}' for decrypting was not loaded".format(name))
             self.__pi.done += len(urls)
             return None
 
         try:
-            plugin = klass(self.__pyload, password)
+            plugin = klass(self.pyload_core, password)
             try:
                 result = plugin._decrypt(urls)
             except Retry:
@@ -111,8 +111,8 @@ class DecrypterThread(PluginThread):
                 url, url, -1, DownloadStatus.Failed, name) for url in urls)
 
             # no debug for intentional errors
-            # if self.__pyload.debug and not isinstance(e, Fail):
-            # self.__pyload.print_exc()
+            # if self.pyload_core.debug and not isinstance(e, Fail):
+            # self.pyload_core.print_exc()
             # self.debug_report(plugin.__name__, plugin=plugin)
         finally:
             if plugin:

--- a/src/pyload/core/thread/download.py
+++ b/src/pyload/core/thread/download.py
@@ -44,7 +44,7 @@ class DownloadThread(PluginThread):
 
     def _handle_abort(self, file):
         try:
-            self.__pyload.log.info(
+            self.pyload_core.log.info(
                 self._("Download aborted: {0}").format(file.name))
         except Exception:
             pass
@@ -57,12 +57,12 @@ class DownloadThread(PluginThread):
             time.sleep(0.5)
 
     def _handle_retry(self, file, reason):
-        self.__pyload.log.info(
+        self.pyload_core.log.info(
             self._("Download restarted: {0} | {1}").format(file.name, reason))
         self.queue.put(file)
 
     def _handle_notimplement(self, file):
-        self.__pyload.log.error(
+        self.pyload_core.log.error(
             self._("Plugin {0} is missing a function").format(file.pluginname))
         file.set_status("failed")
         file.error = "Plugin does not work"
@@ -70,69 +70,69 @@ class DownloadThread(PluginThread):
 
     def _handle_tempoffline(self, file):
         file.set_status("temp. offline")
-        self.__pyload.log.warning(
+        self.pyload_core.log.warning(
             self._("Download is temporary offline: {0}").format(file.name))
         file.error = self._("Internal Server Error")
 
-        if self.__pyload.debug:
+        if self.pyload_core.debug:
             print_exc()
             self.debug_report(file)
 
-        self.__pyload.adm.download_failed(file)
+        self.pyload_core.adm.download_failed(file)
         self.clean(file)
 
     def _handle_failed(self, file, errmsg):
         file.set_status("failed")
-        self.__pyload.log.warning(
+        self.pyload_core.log.warning(
             self._("Download failed: {0} | {1}").format(file.name, errmsg))
         file.error = errmsg
 
-        if self.__pyload.debug:
+        if self.pyload_core.debug:
             print_exc()
             self.debug_report(file)
 
-        self.__pyload.adm.download_failed(file)
+        self.pyload_core.adm.download_failed(file)
         self.clean(file)
 
     # TODO: activate former skipped downloads
     def _handle_fail(self, file, errmsg):
         if errmsg == "offline":
             file.set_status("offline")
-            self.__pyload.log.warning(
+            self.pyload_core.log.warning(
                 self._("Download is offline: {0}").format(file.name))
         elif errmsg == "temp. offline":
             file.set_status("temp. offline")
-            self.__pyload.log.warning(
+            self.pyload_core.log.warning(
                 self._("Download is temporary offline: {0}").format(file.name))
         else:
             file.set_status("failed")
-            self.__pyload.log.warning(
+            self.pyload_core.log.warning(
                 self._("Download failed: {0} | {1}").format(file.name, errmsg))
             file.error = errmsg
 
-        self.__pyload.adm.download_failed(file)
+        self.pyload_core.adm.download_failed(file)
         self.clean(file)
 
     def _handle_skip(self, file, errmsg):
         file.set_status("skipped")
 
-        self.__pyload.log.info(
+        self.pyload_core.log.info(
             self._("Download skipped: {0} due to {1}").format(
                 file.name, errmsg))
 
         self.clean(file)
 
-        self.__pyload.files.check_package_finished(file)
+        self.pyload_core.files.check_package_finished(file)
 
         self.active = None
-        self.__pyload.files.save()
+        self.pyload_core.files.save()
 
     def _handle_error(self, file, errmsg, errcode=None):
-        self.__pyload.log.debug(
+        self.pyload_core.log.debug(
             "pycurl exception {0}: {1}".format(errcode, errmsg))
 
         if errcode in (7, 18, 28, 52, 56):
-            self.__pyload.log.warning(
+            self.pyload_core.log.warning(
                 self._(
                     "Couldn't connect to host or connection reset, "
                     "waiting 1 minute and retry"))
@@ -147,7 +147,7 @@ class DownloadThread(PluginThread):
                     break
 
             if file.abort:
-                self.__pyload.log.info(
+                self.pyload_core.log.info(
                     self._("Download aborted: {0}").format(file.name))
                 file.set_status("aborted")
                 # do not clean, aborting function does this itself
@@ -156,13 +156,13 @@ class DownloadThread(PluginThread):
                 self.queue.put(file)
         else:
             file.set_status("failed")
-            self.__pyload.log.error(
+            self.pyload_core.log.error(
                 self._("pycurl error {0}: {1}").format(errcode, errmsg))
-            if self.__pyload.debug:
+            if self.pyload_core.debug:
                 print_exc()
                 self.debug_report(file)
 
-            self.__pyload.adm.download_failed(file)
+            self.pyload_core.adm.download_failed(file)
 
     def _run(self, file):
         file.init_plugin()
@@ -175,20 +175,20 @@ class DownloadThread(PluginThread):
         # if not file.has_plugin(): continue
 
         file.plugin.check_for_same_files(starting=True)
-        self.__pyload.log.info(
+        self.pyload_core.log.info(
             self._("Download starts: {0}".format(file.name)))
 
         # start download
-        self.__pyload.adm.download_preparing(file)
+        self.pyload_core.adm.download_preparing(file)
         file.plugin.preprocessing(self)
 
-        self.__pyload.log.info(
+        self.pyload_core.log.info(
             self._("Download finished: {0}").format(file.name))
-        self.__pyload.adm.download_finished(file)
-        self.__pyload.files.check_package_finished(file)
+        self.pyload_core.adm.download_finished(file)
+        self.pyload_core.files.check_package_finished(file)
 
     def _finalize(self, file):
-        self.__pyload.files.save()
+        self.pyload_core.files.save()
         file.check_if_processed()
         sys.exc_clear()
         # manager could still be waiting for it
@@ -255,7 +255,7 @@ class DownloadThread(PluginThread):
             # file.plugin.req.clean()
             self.active = None
             file.finish_if_done()
-            self.__pyload.files.save()
+            self.pyload_core.files.save()
 
     def get_progress_info(self):
         if not self.active:

--- a/src/pyload/core/thread/info.py
+++ b/src/pyload/core/thread/info.py
@@ -46,7 +46,7 @@ class InfoThread(DecrypterThread):
         cb = self.update_db if self.pid > 1 else self.update_result
 
         # filter out crypter plugins
-        for name in self.__pyload.pgm.get_plugins("crypter"):
+        for name in self.pyload_core.pgm.get_plugins("crypter"):
             if name in plugins:
                 crypter[name] = plugins[name]
                 del plugins[name]
@@ -65,7 +65,7 @@ class InfoThread(DecrypterThread):
 
             # TODO: no plugin information pushed to GUI
             # parse links and merge
-            hoster, crypter = self.__pyload.pgm.parse_urls(
+            hoster, crypter = self.pyload_core.pgm.parse_urls(
                 l.url for l in links)
             accumulate(hoster + crypter, plugins)
 
@@ -75,14 +75,14 @@ class InfoThread(DecrypterThread):
             ProgressType.LinkCheck
         )
         for pluginname, urls in plugins.items():
-            plugin = self.__pyload.pgm.load_module("hoster", pluginname)
-            klass = self.__pyload.pgm.get_plugin_class(
+            plugin = self.pyload_core.pgm.load_module("hoster", pluginname)
+            klass = self.pyload_core.pgm.get_plugin_class(
                 "hoster", pluginname, overwrite=False)
             if hasmethod(klass, "get_info"):
                 self.fetch_for_plugin(klass, urls, cb)
             # TODO: this branch can be removed in the future
             elif hasmethod(plugin, "get_info"):
-                self.__pyload.log.debug(
+                self.pyload_core.log.debug(
                     "Deprecated .get_info() method on module level, "
                     "use staticmethod instead")
                 self.fetch_for_plugin(plugin, urls, cb)
@@ -103,9 +103,9 @@ class InfoThread(DecrypterThread):
         info_hash = [(l.name, l.size, l.status, l.hash, l.url)
                      for l in result if l.hash]
         if info:
-            self.__pyload.files.update_file_info(info, self.pid)
+            self.pyload_core.files.update_file_info(info, self.pid)
         if info_hash:
-            self.__pyload.files.update_file_info(info_hash, self.pid)
+            self.pyload_core.files.update_file_info(info_hash, self.pid)
 
     def update_result(self, result):
         tmp = {}
@@ -194,6 +194,6 @@ class InfoThread(DecrypterThread):
             self.__manager.log.warning(
                 self._("Info Fetching for {0} failed | {1}").format(
                     pluginname, str(e)))
-            # self.__pyload.print_exc()
+            # self.pyload_core.print_exc()
         finally:
             self.__pi.done = done

--- a/src/pyload/core/thread/plugin.py
+++ b/src/pyload/core/thread/plugin.py
@@ -29,10 +29,14 @@ class PluginThread(Thread):
         Thread.__init__(self)
         self.setDaemon(True)
         self.__manager = manager  # Thread manager
-        self.__pyload = manager.get_core()
+        self.__pyload = manager.pyload_core
         self._ = self.__pyload._
         # Owner of the thread, every type should set it or overwrite user
         self.owner = owner
+
+    @property
+    def pyload_core(self):
+        return self.__pyload
 
     @property
     def user(self):
@@ -61,7 +65,7 @@ class PluginThread(Thread):
 
     def _gen_reports(self, file):
         si_entries = (
-            ('pyload version', self.__pyload.version),
+            ('pyload version', self.pyload_core.version),
             ('system platform', sys.platform),
             ('system version', sys.version),
             ('system encoding', sys.getdefaultencoding()),
@@ -97,7 +101,7 @@ class PluginThread(Thread):
                 zip.writestr(arcname, data)
 
     def debug_report(self, file):
-        dumpdir = os.path.join(self.__pyload.cachedir,
+        dumpdir = os.path.join(self.pyload_core.cachedir,
                                'plugins', file.pluginname)
         makedirs(dumpdir, exist_ok=True)
 
@@ -112,5 +116,5 @@ class PluginThread(Thread):
         reports = self._gen_reports(file)
         self._zip(filepath, reports, dumpdir)
 
-        self.__pyload.log.info(
+        self.pyload_core.log.info(
             self._('Debug Report written to file {0}').format(filename))


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

Making the pyload core object a private (double-underscode) attribute `__pyload` is not a good idea because of name mangling when dealing with class inheritance.

### Additional info:

This means the private attribute is prepended with the base class' name, which means that, e.g. FileManager doesn't found its `__pyload` attribute because it's stored as `_BaseManager__pyload` instead.

For more information, see:
https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references

This could be fixed by using the `get_core` method instead, but I implemented a `pyload_core` property instead, to maintain the attribute's privacy and remove the getter.

Relevant log lines:
```
2017-07-27 08:22:54  CRITICAL  'FileManager' object has no attribute '_FileManager__pyload'
```