### PR TITLE
[master] Fix incorrectly initialized PluginLoader

### DIFF
--- a/src/pyload/core/manager/plugin.py
+++ b/src/pyload/core/manager/plugin.py
@@ -60,8 +60,9 @@ class PluginManager(BaseManager):
         self.loader = LoaderFactory(
             PluginLoader(fullpath(self.LOCALROOT),
                          self.LOCALROOT, self.pyload_core.config),
-            PluginLoader(resource_filename(__package__, 'network')),
-            self.ROOT, self.pyload_core.config)
+            PluginLoader(resource_filename(__package__, 'network'),
+                         self.ROOT, self.pyload_core.config),
+        )
 
         self.loader.check_versions()
 


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

`PuginLoader` was being incorrectly initialized, as it should be done as the one in the previous line.

### Additional info:

Relevant error:
```
CRITICAL  __init__() takes exactly 4 arguments (2 given)
```