### PR TITLE
[master] Use a global absolute import for RequestFactory

### DIFF
--- a/src/pyload/core/init.py
+++ b/src/pyload/core/init.py
@@ -29,6 +29,7 @@ from pyload.utils.misc import get_translation
 from pyload.utils.system import (ionice, renice, set_process_group,
                                  set_process_name, set_process_user)
 
+from pyload.core.network.factory import RequestFactory
 from .__about__ import (__namespace__, __package__, __version__,
                         __version_info__)
 from .config import config_defaults, session_defaults
@@ -307,7 +308,6 @@ class Core(Process):
         self.db.manager = self.files  # ugly?
 
     def _init_requests(self):
-        from .network.factory import RequestFactory
         self.request = self.req = RequestFactory(self)
 
     def _init_config(self):


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

For some reason, this relative import is broken when trying to start pyLoad. By using an absolute import, it gets fixed. Also, moved to the beginning of the file, as it seems there are no circular dependencies.

### Additional info:

Relevant error:
```
CRITICAL  find_module() takes exactly 2 arguments (3 given)
```