### PR TITLE
[master] Rename missing function get_account_infos

### DIFF
--- a/src/pyload/core/init.py
+++ b/src/pyload/core/init.py
@@ -431,8 +431,8 @@ class Core(Process):
     def _start_plugins(self):
         # TODO: Move to accountmanager
         self.log.info(self._("Activating accounts ..."))
-        self.acm.get_account_infos()
-        # self.scheduler.enter(0, 0, self.acm.get_account_infos)
+        self.acm.load_accounts()
+        # self.scheduler.enter(0, 0, self.acm.load_accounts)
         self.adm.activate_addons()
 
     def _show_info(self):


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

`AccountManager` does not have a `get_account_infos` method. It seems the correct one to call is `load_accounts` instead.

### Additional info:

Relevant error:
```
CRITICAL  'AccountManager' object has no attribute 'get_account_infos'
```