### PR TITLE
[master] Fix pyload 'version' command

### DIFF
--- a/src/pyload/core/iface.py
+++ b/src/pyload/core/iface.py
@@ -34,7 +34,7 @@ def _mkdprofile(profile=None, rootdir=None):
     return profiledir
 
 
-def version():
+def version(**kwargs):
     return __version__
 
 


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

This change fixes the `pyload version` CLI command. Because the command functions are treated in a generic way (see https://github.com/pyload/pyload/blob/3323fc51fa2024455728e4a0e85413917641fe0c/src/pyload/core/cli.py#L156), it was failing because of unexpected parameters.

### Additional info:

Relevant stacktrace:
```
Traceback (most recent call last):
  File "$HOME/.virtualenvs/pyload2/bin/pyload", line 11, in <module>
    load_entry_point('pyload.core==0.6.2', 'console_scripts', 'pyload')()
  File "build/bdist.linux-x86_64/egg/pyload/core/cli.py", line 156, in main
TypeError: version() takes no arguments (6 given)
```