### PR TITLE
[master] Fix inexistent attribute 'command' in CLI execution

### DIFF
--- a/src/pyload/core/cli.py
+++ b/src/pyload/core/cli.py
@@ -150,7 +150,7 @@ def main(argv=sys.argv[1:]):
     # TODO: Handle --help output
 
     func = getattr(iface, args.command)
-    kwgs = vars(args)
+    kwgs = vars(args).copy()
     kwgs.pop('command', None)
 
     res = func(**kwgs)


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

`vars()` returns the internal dict for `args`:

```
(Pdb) print id(args.__dict__)
139935486325936
(Pdb) print id(vars(args))
139935486325936
```

Because of this, the next line doing a `pop` over it actually removes the `command` attribute, which is referenced some lines after it, and it's not found.

### Additional info:

Relevant stacktrace:
```
Traceback (most recent call last):
  File "$HOME/.virtualenvs/pyload2/bin/pyload", line 11, in <module>
    load_entry_point('pyload.core==0.6.2', 'console_scripts', 'pyload')()
  File "build/bdist.linux-x86_64/egg/pyload/core/cli.py", line 159, in main
AttributeError: 'Namespace' object has no attribute 'command'
```