### PR TITLE
[master] Fix CLI commands 'status' and 'quit'

### DIFF
--- a/src/pyload/core/iface.py
+++ b/src/pyload/core/iface.py
@@ -38,7 +38,7 @@ def version(**kwargs):
     return __version__
 
 
-def status(profile=None, configdir=None):
+def status(profile=None, configdir=None, **kwargs):
     profiledir = _mkdprofile(profile, configdir)
     if profiledir not in _pmap:
         return None
@@ -53,7 +53,7 @@ def status(profile=None, configdir=None):
     # return SetupAssistant(configfile, version()).start()
 
 
-def quit(profile=None, configdir=None):
+def quit(profile=None, configdir=None, **kwargs):
     profiledir = _mkdprofile(profile, configdir)
     if profiledir not in _pmap:
         return None


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

Same fix as https://github.com/pyload/pyload/pull/2923, for the commands `status` and `quit`.

### Additional info:

Relevant stacktrace:
```
Traceback (most recent call last):
  File "$HOME/.virtualenvs/pyload2/bin/pyload", line 11, in <module>
    load_entry_point('pyload.core==0.6.2', 'console_scripts', 'pyload')()
  File "build/bdist.linux-x86_64/egg/pyload/core/cli.py", line 156, in main
TypeError: status() got an unexpected keyword argument 'restore'

Traceback (most recent call last):
  File "$HOME/.virtualenvs/pyload2/bin/pyload", line 11, in <module>
    load_entry_point('pyload.core==0.6.2', 'console_scripts', 'pyload')()
  File "build/bdist.linux-x86_64/egg/pyload/core/cli.py", line 156, in main
TypeError: quit() got an unexpected keyword argument 'restore'
```