### PR TITLE
[master] Add default to storage_folder config option

### DIFF
--- a/src/pyload/core/config/default.py
+++ b/src/pyload/core/config/default.py
@@ -49,7 +49,7 @@ def _gen_config_defaults():
     general_config = (
         ('language', ('option', None, 'Language',
                       None, (None, 'english'), InputType.Str)),
-        ('storage_folder', ('option', None, 'Storage folder',
+        ('storage_folder', ('option', '.', 'Storage folder',
                             None, None, InputType.Folder)),
         ('min_storage_size', ('option', 1024, 'Min storage space (in MiB)',
                               None, None, InputType.Size)),


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

This adds the current folder as the default storage location for pyLoad. It could be changed to a better default value, but we need a default for pyLoad to work, because of the way `availspace` is being used, as it expects a valid path.

### Additional info:

Failing line:
https://github.com/pyload/pyload/blob/ac38e1f0ccdb04ae3a697b83954722753a6c5b7c/src/pyload/core/manager/transfer.py#L157

Relevant log error:
```
CRITICAL  [Errno 2] No existe el archivo o el directorio: ''
```