### PR TITLE
The file info are now under the 'infos' json node

### DIFF
--- a/module/plugins/hoster/AlldebridCom.py
+++ b/module/plugins/hoster/AlldebridCom.py
@@ -7,7 +7,7 @@ from ..internal.MultiHoster import MultiHoster
 class AlldebridCom(MultiHoster):
     __name__ = "AlldebridCom"
     __type__ = "hoster"
-    __version__ = "0.55"
+    __version__ = "0.56"
     __status__ = "testing"
 
     __pattern__ = r'https?://(?:www\.|s\d+\.)?alldebrid\.com/dl/[\w^_]+'
@@ -36,15 +36,17 @@ class AlldebridCom(MultiHoster):
     def handle_premium(self, pyfile):
         json_data = self.api_response("link/unlock", link=pyfile.url, token=self.account.info['data']['token'])
 
-        if json_data.get("error", False):
-            if json_data['errorCode'] == 12:
-                self.offline()
-
-            else:
-                self.log_warning(json_data['error'])
-                self.temp_offline()
+        if json_data.get("infos") and json_data["success"]:
+            json_infos = json_data['infos']
+            pyfile.name = json_infos['filename']
+            pyfile.size = parse_size(json_infos['filesize'])
+            self.link = json_infos['link']
 
         else:
-            pyfile.name = json_data['filename']
-            pyfile.size = parse_size(json_data['filesize'])
-            self.link = json_data['link']
+            if json_data.get("error", False):
+                if json_data['errorCode'] == 12:
+                    self.offline()
+
+                else:
+                    self.log_warning(json_data['error'])
+                    self.temp_offline()


### PR DESCRIPTION
### Type of request:

- [ ] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [x] Plugin bugfix/enhancement

### Short description:
Hello, it seems that the Alldebrid API has changed recently for the premium links management.
I changed the AlldebridCom.py script to comply with the new schema.

### Additional info:
Before the API response was:
`{"link":"a.zip","host":"uptobox","filename":"a.zip","streaming":[],"paws":false,"filesize":5905580032}`

Now the API reponse is:
`{success: true, infos: {"link":"a.zip","host":"uptobox","filename":"a.zip","streaming":[],"paws":false,"filesize":5905580032}}`

Regards