### PR TITLE
[master] Rename exit() to shutdown_os()

### DIFF
--- a/pyload/utils/system.py
+++ b/pyload/utils/system.py
@@ -197,7 +197,7 @@ def set_process_user(value):
     os.setuid(uid)
 
 
-def exit():
+def shutdown_os():
     if os.name == 'nt':
         call_cmd('rundll32.exe user.exe,ExitWindows')
 
@@ -217,4 +217,4 @@ def exit():
             stop_method = ck_iface.get_dbus_method('Stop')
             stop_method()
         except AttributeError:
-            call_cmd('stop -h now')  # NOTE: Root privileges needed
+            call_cmd('shutdown -h now')  # NOTE: Root privileges needed


### PR DESCRIPTION
### Type of request:

> **NOTE:**
> Please, fill with an `x` just one of the checkboxes below, like `[x] Bugfix`.

- [x] Bugfix
- [x] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

Rename exit() to shutdown_os() and fix a bug in this function.

### Additional info:

> **NOTE:**
> If this is a **plugin** request, remember to increase the value of the
> `__version__` attribute inside the files you're submitting.

1. **Related pull requests**: _OPTIONAL_
2. **Related issues**: _OPTIONAL_

### Reasons for making this change:

_OPTIONAL_

### References supporting this change:

_OPTIONAL_
