### PR TITLE
remove DatabaseBackend object from args

### DIFF
--- a/pyload/core/database/backend.py
+++ b/pyload/core/database/backend.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, unicode_literals
 import io
 import os
 import shutil
+from functools import wraps
 from queue import Queue
 
 from future import standard_library
@@ -33,22 +34,28 @@ def set_db(db):
 
 
 def queue(f):
+    @wraps(f)
     def x(*args, **kwargs):
         if DB:
+            args = args[1:] if len(args) > 0 and DB == args[0] else args
             return DB.queue(f, *args, **kwargs)
     return x
 
 
 def async(f):
+    @wraps(f)
     def x(*args, **kwargs):
         if DB:
+            args = args[1:] if len(args) > 0 and DB == args[0] else args
             return DB.async(f, *args, **kwargs)
     return x
 
 
 def inner(f):
+    @wraps(f)
     def x(*args, **kwargs):
         if DB:
+            args = args[1:] if len(args) > 0 and DB == args[0] else args
             return f(DB, *args, **kwargs)
     return x
 


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

remove DatabaseBackend object from args as it is added later on anyway (see. [queue](https://github.com/pyload/pyload/blob/master/pyload/core/database/backend.py#L431) and [async](https://github.com/pyload/pyload/blob/master/pyload/core/database/backend.py#L423))

This problem prevents calling DatabaseBackend.commit, DatabaseBackend.rollback and DatabaseBackend.sync_save.

At the moment it seems that commit is only called when pyload exits. If pyload stops working unexpectedly all information will be lost. Maybe commit after every INSERT/UPDATE?