### PR TITLE
change atexit decorator to method

### DIFF
--- a/pyload/core/base.py
+++ b/pyload/core/base.py
@@ -96,6 +96,8 @@ class Core(object):
 
         self._init_api()
 
+        atexit.register(self.exit)
+
     def _init_api(self):
         from pyload.api import Api
         self.api = Api(self)
@@ -273,9 +275,6 @@ class Core(object):
             self.log.critical(exc, exc_info=True)
             self.exit()
 
-        else:
-            self.exit()
-
     def _remove_loggers(self):
         for handler in self.log.handlers:
             with closing(handler) as hdlr:
@@ -287,13 +286,11 @@ class Core(object):
         self.evm.fire('pyload:restarting')
         self.run()
 
-    @atexit.register
     def exit(self):
         self.stop()
         self.log.info(self._('Exiting pyLoad...'))
         self.tsm.exit()
         self.db.exit()  # NOTE: Why here?
-        self.config.close()
         self._remove_loggers()
         # if cleanup:
         # self.log.info(self._("Deleting temp files..."))


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

the decorator points to the class method. when used during initialisation it points to the method of the object and passes self as argument.

before you might have gotten this error:
Error in atexit._run_exitfuncs:
TypeError: exit() missing 1 required positional argument: 'self'

also removed self.config.close() as ConfigParser does not have a close method

PS: self.exit() at line 277 was unreachable

### Reasons for making this change:

if exit is not called properly, the database does not commit its changes. Maybe committing changes after inserts of packages etc. should be done within the api, otherwise much information will be lost, if pyload crashes unexpectedly. 