### PR TITLE
Updated Linkfilter plugin (Added whitelist ...)

### DIFF
--- a/module/plugins/hooks/LinkFilter.py
+++ b/module/plugins/hooks/LinkFilter.py
@@ -1,13 +1,12 @@
 
 from ..internal.Addon import Addon
 
-import re
 from itertools import chain
 
 class LinkFilter(Addon):
     __name__ = "LinkFilter"
     __type__ = "hook"
-    __version__ = "0.15"
+    __version__ = "0.14"
     __status__ = "testing"
 
     __config__ = [("activated", "bool", "Activated", False),
@@ -40,11 +39,11 @@ class LinkFilter(Addon):
         linkcount -= len(links)
 
         if linkcount > 0:
-            linkstring = '' if self.config.get('forceExecute') else 'hoster '
-            linkstring += 'links' if linkcount == 1 else 'links'
-            self.log_info(
-                'Whitelist filter removed %s %s not containing (%s)' % 
-                (linkcount, linkstring, ', '.join(filters)))
+                linkstring = '' if self.config.get('forceExecute') else 'hoster '
+                linkstring += 'links' if linkcount > 1 else 'link'
+                self.log_info(
+                    'Whitelist filter removed %s %s not containing (%s)' %
+                    (linkcount, linkstring, ', '.join(filters)))
 
     def blacklist(self, links, filters):
         for filter in filters:
@@ -56,7 +55,7 @@ class LinkFilter(Addon):
 
             if linkcount > 0:
                 linkstring = '' if self.config.get('forceExecute') else 'hoster '
-                linkstring += 'link' if linkcount == 1 else 'links'
+                linkstring += 'links' if linkcount > 1 else 'link'
                 self.log_info(
                     'Blacklist filter removed %s %s containing %s' %
                     (linkcount, linkstring, filter))

--- a/module/plugins/hooks/LinkFilter.py
+++ b/module/plugins/hooks/LinkFilter.py
@@ -1,17 +1,21 @@
 
 from ..internal.Addon import Addon
 
+import re
+from itertools import chain
 
 class LinkFilter(Addon):
     __name__ = "LinkFilter"
     __type__ = "hook"
-    __version__ = "0.14"
+    __version__ = "0.15"
     __status__ = "testing"
 
     __config__ = [("activated", "bool", "Activated", False),
-                  ("filter", "str", "Filter links containing (seperate by comma)", "ul.to,share-online.biz")]
+                  ("filter", "str", "Filter links containing (seperate by comma)", "ul.to,uploaded.net,share-online.biz"),
+                  ("whitelist", "bool", "Execute filter as whitelist", False),
+                  ("forceExecute", "bool", "Force execution on all links (also crypters, containers...)", False)]
 
-    __description__ = "Filters all added links"
+    __description__ = "Filters all added hoster links"
     __license__ = "GPLv3"
     __authors__ = [("segelkma", None)]
 
@@ -22,18 +26,46 @@ class LinkFilter(Addon):
         self.manager.removeEvent('linksAdded', self.filter_links)
 
     def filter_links(self, links, pid):
-        filter_entries = self.config.get('filter').split(',')
+        filters = self.config.get('filter').replace(' ', '').split(',')
+        if self.config.get('whitelist'):
+            self.whitelist(links, filters)
+        else:
+            self.blacklist(links, filters)
 
-        for filter in filter_entries:
-            if filter == "":
-                break
+    def whitelist(self, links, filters):
+        linkcount = len(links)
+        links[:] = [link for link in links if
+            not self.isHosterLink(link) or
+            [True for filter in filters if link.find(filter) != -1]]
+        linkcount -= len(links)
 
+        if linkcount > 0:
+            linkstring = '' if self.config.get('forceExecute') else 'hoster '
+            linkstring += 'links' if linkcount == 1 else 'links'
+            self.log_info(
+                'Whitelist filter removed %s %s not containing (%s)' % 
+                (linkcount, linkstring, ', '.join(filters)))
+
+    def blacklist(self, links, filters):
+        for filter in filters:
             linkcount = len(links)
-            links[:] = [link for link in links if link.find(filter) == -1]
+            links[:] = [link for link in links if
+                not self.isHosterLink(link) or
+                link.find(filter) == -1]
             linkcount -= len(links)
 
             if linkcount > 0:
-                linkstring = 'links' if linkcount > 1 else 'link'
+                linkstring = '' if self.config.get('forceExecute') else 'hoster '
+                linkstring += 'link' if linkcount == 1 else 'links'
                 self.log_info(
-                    "Removed %s %s containing %s" %
+                    'Blacklist filter removed %s %s containing %s' %
                     (linkcount, linkstring, filter))
+
+    def isHosterLink(self, link):
+        #declare all links as hoster links so the filter will work on all links
+        if self.config.get('forceExecute'):
+            return True
+        for name, value in chain(self.pyload.pluginManager.hosterPlugins.iteritems()):
+            if value['re'].match(link):
+                return True
+        return False

--- a/module/plugins/hooks/LinkFilter.py
+++ b/module/plugins/hooks/LinkFilter.py
@@ -39,11 +39,11 @@ class LinkFilter(Addon):
         linkcount -= len(links)
 
         if linkcount > 0:
-                linkstring = '' if self.config.get('forceExecute') else 'hoster '
-                linkstring += 'links' if linkcount > 1 else 'link'
-                self.log_info(
-                    'Whitelist filter removed %s %s not containing (%s)' %
-                    (linkcount, linkstring, ', '.join(filters)))
+            linkstring = '' if self.config.get('forceExecute') else 'hoster '
+            linkstring += 'link' if linkcount == 1 else 'links'
+            self.log_info(
+                'Whitelist filter removed %s %s not containing (%s)' %
+                (linkcount, linkstring, ', '.join(filters)))
 
     def blacklist(self, links, filters):
         for filter in filters:
@@ -55,7 +55,7 @@ class LinkFilter(Addon):
 
             if linkcount > 0:
                 linkstring = '' if self.config.get('forceExecute') else 'hoster '
-                linkstring += 'links' if linkcount > 1 else 'link'
+                linkstring += 'link' if linkcount == 1 else 'links'
                 self.log_info(
                     'Blacklist filter removed %s %s containing %s' %
                     (linkcount, linkstring, filter))

--- a/module/plugins/hooks/LinkFilter.py
+++ b/module/plugins/hooks/LinkFilter.py
@@ -6,7 +6,7 @@ from itertools import chain
 class LinkFilter(Addon):
     __name__ = "LinkFilter"
     __type__ = "hook"
-    __version__ = "0.14"
+    __version__ = "0.15"
     __status__ = "testing"
 
     __config__ = [("activated", "bool", "Activated", False),

--- a/module/plugins/hooks/LinkFilter.py
+++ b/module/plugins/hooks/LinkFilter.py
@@ -35,7 +35,7 @@ class LinkFilter(Addon):
         linkcount = len(links)
         links[:] = [link for link in links if
             not self.isHosterLink(link) or
-            [True for filter in filters if link.find(filter) != -1]]
+            any(link.find(filter) != -1 for filter in filters)]
         linkcount -= len(links)
 
         if linkcount > 0:
@@ -64,7 +64,7 @@ class LinkFilter(Addon):
         #declare all links as hoster links so the filter will work on all links
         if self.config.get('forceExecute'):
             return True
-        for name, value in chain(self.pyload.pluginManager.hosterPlugins.iteritems()):
-            if value['re'].match(link):
+        for hoster in chain(self.pyload.pluginManager.hosterPlugins.iteritems()):
+            if hoster[1]['re'].match(link):
                 return True
         return False


### PR DESCRIPTION

### Type of request:

- [ ] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [x] New feature
- [ ] New plugin
- [x] Plugin enhancement

### Short description:

- Changed default behaviour: Only filters hoster links on default instead of all links
- Added whitelist filter function
- Added option to force execution on all links (previous default behaviour)

### References to this change (related pull requests, issues, etc.):

https://github.com/pyload/pyload/issues/3000



Tested it successfully with several different hoster links and containers/crypters.
Since the default behaviour changed, does it make sense to rename the plugin? E.g. HosterLinkFilter, HosterFilter, FilterHosterLinks ...