### PR TITLE
rename c -> curl; making abort protected; minor fixes

### DIFF
--- a/pyload/requests/curl/chunk.py
+++ b/pyload/requests/curl/chunk.py
@@ -8,6 +8,7 @@ import os
 import re
 import time
 from contextlib import closing
+from codecs import BOM_UTF8
 
 from future import standard_library
 from future.builtins import int
@@ -147,7 +148,7 @@ class CurlChunk(CurlRequest):
     def write_body(self, buf):
         # ignore BOM, it confuses unrar
         if self.check_bom:
-            if buf[:3] == b'\xef\xbb\xbf':
+            if buf[:3] == BOM_UTF8:
                 buf = buf[3:]
             self.check_bom = False
 

--- a/pyload/requests/curl/chunk.py
+++ b/pyload/requests/curl/chunk.py
@@ -15,6 +15,7 @@ from future.builtins import int
 import pycurl
 from pyload.requests.curl.request import CurlRequest
 from pyload.utils import purge
+from pyload.utils.convert import to_str
 from pyload.utils.struct import HeaderDict
 
 standard_library.install_aliases()
@@ -38,9 +39,9 @@ class CurlChunk(CurlRequest):
 
         self.size = range[1] - range[0] if range else - 1
         self.arrived = 0
-        self.last_url = self.p.referer
+        self.last_url = None
 
-        self.c = pycurl.Curl()
+        self.curl = pycurl.Curl()
 
         self.header = ''
         # indicates if the header has been processed
@@ -123,9 +124,10 @@ class CurlChunk(CurlRequest):
 
             self.fp = io.open(filename, mode='wb')
 
-        return self.c
+        return self.curl
 
     def write_header(self, buf):
+        buf = to_str(buf) # everything uses buf as string, so a conversion is needed
         self.header += buf
         # TODO: forward headers?, this is possibly unneeded,
         # when we just parse valid 200 headers as first chunk,
@@ -145,7 +147,7 @@ class CurlChunk(CurlRequest):
     def write_body(self, buf):
         # ignore BOM, it confuses unrar
         if self.check_bom:
-            if [ord(b) for b in buf[:3]] == [239, 187, 191]:
+            if [b for b in buf[:3]] == [239, 187, 191]:
                 buf = buf[3:]
             self.check_bom = False
 
@@ -223,6 +225,6 @@ class CurlChunk(CurlRequest):
             self.fp.close()
         except AttributeError:
             pass
-        self.c.close()
+        self.curl.close()
         if hasattr(self, 'p'):
             del self.p

--- a/pyload/requests/curl/chunk.py
+++ b/pyload/requests/curl/chunk.py
@@ -147,7 +147,7 @@ class CurlChunk(CurlRequest):
     def write_body(self, buf):
         # ignore BOM, it confuses unrar
         if self.check_bom:
-            if [b for b in buf[:3]] == [239, 187, 191]:
+            if buf[:3] == b'\xef\xbb\xbf':
                 buf = buf[3:]
             self.check_bom = False
 

--- a/pyload/requests/curl/download.py
+++ b/pyload/requests/curl/download.py
@@ -57,6 +57,12 @@ class CurlDownload(DownloadRequest):
         self.speeds = []
         self.last_speeds = [0, 0]
 
+    def init_context(self):
+        """Should be used to initialize everything from given context and
+        options."""
+        #TODO: What should we do here?
+        pass
+
     @property
     def speed(self):
         last = [sum(x) for x in self.last_speeds if x]
@@ -103,7 +109,6 @@ class CurlDownload(DownloadRequest):
             self.set_path(filepath)
 
         shutil.move(init, self.path)
-        self.info.remove()  # remove info file
 
     def check_resume(self):
         try:
@@ -282,7 +287,7 @@ class CurlDownload(DownloadRequest):
                     # note that other chunks are closed and everything
                     # downloaded with initial connection
                     if failed:
-                        if init in failed or init.c in chunks_done:
+                        if init in failed or init.curl in chunks_done:
                             raise exc
                         self.log.error(
                             'Download chunks failed, fallback to '
@@ -328,7 +333,7 @@ class CurlDownload(DownloadRequest):
                 self.last_arrived = [c.arrived for c in self.chunks]
                 last_time_check = t
 
-            if self.__abort:
+            if self._abort:
                 raise Abort
 
             self.manager.select(1)
@@ -342,12 +347,12 @@ class CurlDownload(DownloadRequest):
         """Linear search to find a chunk (should be ok since chunk size is
         usually low)."""
         for chunk in self.chunks:
-            if chunk.c == handle:
+            if chunk.curl == handle:
                 return chunk
 
     def close_chunk(self, chunk):
         try:
-            self.manager.remove_handle(chunk.c)
+            self.manager.remove_handle(chunk.curl)
 
         except pycurl.error as exc:
             self.log.debug('Error removing chunk')

--- a/pyload/requests/curl/request.py
+++ b/pyload/requests/curl/request.py
@@ -16,7 +16,7 @@ from pyload.requests.base.request import (BAD_HTTP_RESPONSES, Abort,
                                           ResponseException)
 from pyload.requests.cookie import CookieJar
 from pyload.utils.check import isiterable
-from pyload.utils.convert import to_bytes
+from pyload.utils.convert import to_bytes, to_str
 
 standard_library.install_aliases()
 
@@ -43,7 +43,7 @@ class CurlRequest(LoadRequest):
     DEFAULT_LIMIT = 1 << 20
 
     def __init__(self, *args, **kwargs):
-        self.c = pycurl.Curl()
+        self.curl = pycurl.Curl()
         self.limit = kwargs.pop(
             'limit', self.DEFAULT_LIMIT)  # TODO: Rename `limit`
 
@@ -60,11 +60,6 @@ class CurlRequest(LoadRequest):
         self.setopt(pycurl.WRITEFUNCTION, self.write)
         self.setopt(pycurl.HEADERFUNCTION, self.write_header)
 
-    # TODO: Rename to curl
-    @property
-    def c(self):
-        return self.c
-
     # TODO: addHeader
 
     @property
@@ -80,10 +75,10 @@ class CurlRequest(LoadRequest):
             self.init_options(self.config)
 
     def setopt(self, option, value):
-        self.c.setopt(option, to_bytes(value))
+        self.curl.setopt(option, value)
 
     def unsetopt(self, option):
-        self.c.unsetopt(option)
+        self.curl.unsetopt(option)
 
     def init_handle(self):
         """Sets common options to curl handle."""
@@ -165,7 +160,7 @@ class CurlRequest(LoadRequest):
     def set_request_context(self, url, get, post,
                             referer, cookies, multipart=False):
         """Sets everything needed for the request."""
-        self.rep = io.StringIO()
+        self.rep = io.BytesIO()
         url = safequote(url)
 
         if get:
@@ -187,9 +182,9 @@ class CurlRequest(LoadRequest):
             self.setopt(pycurl.POST, 0)
 
         if referer and self.last_url:
-            self.headers['Referer'] = to_bytes(self.last_url)
+            self.headers['Referer'] = self.last_url
         else:
-            self.headers['Referer'] = b''
+            self.headers['Referer'] = ''
 
         if cookies:
             for c in self.cj.output().splitlines():
@@ -228,7 +223,7 @@ class CurlRequest(LoadRequest):
                 self.setopt(pycurl.CUSTOMREQUEST, 'GET')
 
             try:
-                self.c.perform()
+                self.curl.perform()
                 rep = self.header
             finally:
                 self.setopt(pycurl.FOLLOWLOCATION, 1)
@@ -236,12 +231,12 @@ class CurlRequest(LoadRequest):
                 self.unsetopt(pycurl.CUSTOMREQUEST)
 
         else:
-            self.c.perform()
+            self.curl.perform()
             rep = self.get_response()
 
         self.setopt(pycurl.POSTFIELDS, '')
         self.last_url = safequote(url)
-        self.last_effective_url = self.c.getinfo(pycurl.EFFECTIVE_URL)
+        self.last_effective_url = self.curl.getinfo(pycurl.EFFECTIVE_URL)
         if self.last_effective_url:
             self.last_url = self.last_effective_url
 
@@ -260,7 +255,7 @@ class CurlRequest(LoadRequest):
         return rep
 
     def parse_cookies(self):
-        for c in self.c.getinfo(pycurl.INFO_COOKIELIST):
+        for c in self.curl.getinfo(pycurl.INFO_COOKIELIST):
             # http://xiix.wordpress.com/2006/03/23/mozillafirefox-cookie-format
             domain, _, path, secure, expires, name, value = c.split('\t')
             # http only was added in py 2.6
@@ -269,7 +264,7 @@ class CurlRequest(LoadRequest):
 
     def verify_header(self):
         """Raise an exceptions on bad headers."""
-        code = int(self.c.getinfo(pycurl.RESPONSE_CODE))
+        code = int(self.curl.getinfo(pycurl.RESPONSE_CODE))
         if code in BAD_HTTP_RESPONSES:
             raise ResponseException(
                 code,
@@ -321,10 +316,10 @@ class CurlRequest(LoadRequest):
 
     def write(self, buf):
         """Writes response."""
-        if self.rep.tell() > self.limit or self.__abort:
+        if self.rep.tell() > self.limit or self._abort:
             rep = self.get_response()
             self.close()
-            if self.__abort:
+            if self._abort:
                 raise Abort
             with io.open('response.dump', mode='wb') as fp:
                 fp.write(rep)
@@ -334,7 +329,7 @@ class CurlRequest(LoadRequest):
 
     def write_header(self, buf):
         """Writes header."""
-        self.header += buf
+        self.header += to_str(buf)
 
     def reset(self):
         self.cj.clear()
@@ -348,5 +343,4 @@ class CurlRequest(LoadRequest):
         if hasattr(self, 'cj'):
             del self.cj
         if hasattr(self, 'c'):
-            self.c.close()
-            del self.c
+            self.curl.close()


### PR DESCRIPTION
### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

curl/chunk.py rename self.c to self.curl and minor fixes
curl/download.py add implementation for abstract method. removed line self.info.remove as the file has been moved in the previous line
curl/request.py renaming of self.c to self.curl also fix bytes/string problems

### References to this change (related pull requests, issues, etc.):

needs https://github.com/pyload/pyload/pull/3013 to be merged as well
