### PR TITLE
Fix incorrect quotes in pyplex/package.js

### DIFF
--- a/module/web/media/js/pyplex/package.js
+++ b/module/web/media/js/pyplex/package.js
@@ -163,8 +163,8 @@ function Package (ui, id, ele){
                        "<span class='child_status' style='font-size: 12px; color:#eee; padding-left: 5px;'>" + link.statusmsg + "</span>&nbsp;" + link.error + "&nbsp;" +
                        "<span class='child_status' style='font-size: 12px; color:#eee;'>" + link.format_size + "</span>" +
                        "<span class='child_status' style='font-size: 12px; color:#eee;'> " + link.plugin + "</span>&nbsp;&nbsp;" +
-                       "<span class='glyphicon glyphicon-trash' title="{{_('Delete Link')}}" style='cursor: pointer;  font-size: 12px; color:#eee;' ></span>&nbsp;&nbsp;" +
-                       "<span class='glyphicon glyphicon-repeat' title="{{_('Restart Link')}}" style='cursor: pointer; font-size: 12px; color:#eee;' ></span></div>";
+                       "<span class='glyphicon glyphicon-trash' title='{{_('Delete Link')}}' style='cursor: pointer;  font-size: 12px; color:#eee;' ></span>&nbsp;&nbsp;" +
+                       "<span class='glyphicon glyphicon-repeat' title='{{_('Restart Link')}}' style='cursor: pointer; font-size: 12px; color:#eee;' ></span></div>";
 
             var div = document.createElement("div");
             $(div).attr("id","file_" + link.id);


### PR DESCRIPTION
Fixes `Uncaught SyntaxError: Unexpected identifier` / `Uncaught ReferenceError: PackageUI is not defined` JS errors which prevent Queue tab from working with Pyplex theme

### Type of request:

- [x] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [ ] Plugin bugfix/enhancement

### Short description:

Fix incorrect quotes (`"` instead of `'`) in pyplex/package.js

### Reasons for making this change:

Fixes `Uncaught SyntaxError: Unexpected identifier` / `Uncaught ReferenceError: PackageUI is not defined` JS errors which prevent Queue tab from working with Pyplex theme
