### PR TITLE
Patterns improvement + new HTML structure support

### DIFF
--- a/module/plugins/hoster/UptoboxCom.py
+++ b/module/plugins/hoster/UptoboxCom.py
@@ -26,14 +26,14 @@ class UptoboxCom(SimpleHoster):
 
     PLUGIN_DOMAIN = "uptobox.com"
 
-    INFO_PATTERN = r'(?:"para_title">|<h1>)(?P<N>.+) \((?P<S>[\d.,]+) (?P<U>[\w^_]+)\)'
-    OFFLINE_PATTERN = r'>(File not found|Access Denied|404 Not Found)'
-    TEMP_OFFLINE_PATTERN = r'>Service Unavailable'
-    WAIT_PATTERN = r"data-remaining-time='(\d+)'"
+    INFO_PATTERN = r"""(?:"para_title">|<h1>)(?P<N>.+) \((?P<S>[\d.,]+) (?P<U>[\w^_]+)\)"""
+    OFFLINE_PATTERN = r"""(File not found|Access Denied|404 Not Found)"""
+    TEMP_OFFLINE_PATTERN = r"""">Service Unavailable"""
+    WAIT_PATTERN = r"""data-remaining-time=["'](\d+)["']"""
 
-    LINK_PATTERN = r'"(https?://(?:obwp\d+\.uptobox\.com|\w+\.uptobox\.com/dl?)/.*?)"'
+    LINK_PATTERN = r"""["'](https?://(?:obwp\d+\.uptobox\.com|\w+\.uptobox\.com/dl?)/.*?)["']"""
 
-    DL_LIMIT_PATTERN = r'>or you can wait (.+) to launch a new download<'
+    DL_LIMIT_PATTERN = r"""or you can wait (.+) to launch a new download"""
 
     def setup(self):
         self.multiDL = True
@@ -41,7 +41,7 @@ class UptoboxCom(SimpleHoster):
         self.resume_download = True
 
     def handle_free(self, pyfile):
-        m = re.search(r"<input name='waitingToken' value='(.+?)'", self.data)
+        m = re.search(r"""<input name=["']waitingToken["'] value=["'](.+?)["']""", self.data)
         if m is not None:
             self.data = self.load(pyfile.url,
                                   post={'waitingToken': m.group(1),

--- a/module/plugins/hoster/UptoboxCom.py
+++ b/module/plugins/hoster/UptoboxCom.py
@@ -8,7 +8,7 @@ from ..internal.SimpleHoster import SimpleHoster
 class UptoboxCom(SimpleHoster):
     __name__ = "UptoboxCom"
     __type__ = "hoster"
-    __version__ = "0.33"
+    __version__ = "0.34"
     __status__ = "testing"
 
     __pattern__ = r'https?://(?:www\.)?(uptobox|uptostream)\.com/\w{12}'
@@ -28,7 +28,7 @@ class UptoboxCom(SimpleHoster):
 
     INFO_PATTERN = r"""(?:"para_title">|<h1>)(?P<N>.+) \((?P<S>[\d.,]+) (?P<U>[\w^_]+)\)"""
     OFFLINE_PATTERN = r"""(File not found|Access Denied|404 Not Found)"""
-    TEMP_OFFLINE_PATTERN = r"""">Service Unavailable"""
+    TEMP_OFFLINE_PATTERN = r""">Service Unavailable"""
     WAIT_PATTERN = r"""data-remaining-time=["'](\d+)["']"""
 
     LINK_PATTERN = r"""["'](https?://(?:obwp\d+\.uptobox\.com|\w+\.uptobox\.com/dl?)/.*?)["']"""


### PR DESCRIPTION
### Type of request:

> **NOTE:**
> Please, fill with an `x` one of the checkboxes below (eg. `[x] Bugfix`).

- [ ] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [x] Plugin bugfix/enhancement

### Short description:
For UptoboxCom hoster:
 * Using triple double quotes for pattern delimiting
 * Allowing values delimiters to be `'` or `"`
 * Removing `<` and `>` from `DL_LIMIT_PATTERN`:
   * no more found as string is only one line now
   * reduced pattern also works with old syntax

### Reasons for making this change:

If previous fix worked, it is not the case anymore

### References to this change (related pull requests, issues, etc.):

Previous fix: 70a31b1ac90f4c83655ce6dbbc3ee0021baa8de8
