### PR TITLE
[Hoster] Fix Hoster Plugins for interactive reCAPTCHA V2

### DIFF
--- a/module/plugins/hoster/FilerNet.py
+++ b/module/plugins/hoster/FilerNet.py
@@ -36,6 +36,8 @@ class FilerNet(SimpleHoster):
 
     LINK_FREE_PATTERN = LINK_PREMIUM_PATTERN = r'href="([^"]+)">Get download</a>'
 
+    RECAPTCHA_KEY = "6LdB1kcUAAAAAAVPepnD-6TEd4BXKzS7L4FZFkpO"
+
     def handle_free(self, pyfile):
         inputs = self.parse_html_form(
             input_names={'token': re.compile(r'.+')})[1]
@@ -49,16 +51,16 @@ class FilerNet(SimpleHoster):
         if 'hash' not in inputs:
             self.error(_("Unable to detect hash"))
 
-        self.captcha = ReCaptcha(pyfile)
-        response, challenge = self.captcha.challenge()
+        self.log_debug("start reCAPTCHA V2 javascript")
+        self.captcha = ReCaptcha(self.pyfile)
+        challenge = self.captcha.challenge(self.RECAPTCHA_KEY, version='v2_javascript')
 
         #: Avoid 'Correct catcha'
         captcha_task = self.captcha.task
         self.captcha.task = None
 
         self.download(pyfile.url,
-                      post={'recaptcha_challenge_field': challenge,
-                            'recaptcha_response_field': response,
+                      post={'g-recaptcha-response': challenge,
                             'hash': inputs['hash']})
 
         #: Restore the captcha task

--- a/module/plugins/hoster/ShareonlineBiz.py
+++ b/module/plugins/hoster/ShareonlineBiz.py
@@ -12,7 +12,7 @@ from ..internal.SimpleHoster import SimpleHoster
 class ShareonlineBiz(SimpleHoster):
     __name__ = "ShareonlineBiz"
     __type__ = "hoster"
-    __version__ = "0.66"
+    __version__ = "0.67"
     __status__ = "testing"
 
     __pattern__ = r'https?://(?:www\.)?(share-online\.biz|egoshare\.com)/(download\.php\?id=|dl/)(?P<ID>\w+)'
@@ -36,7 +36,7 @@ class ShareonlineBiz(SimpleHoster):
 
     CHECK_TRAFFIC = True
 
-    RECAPTCHA_KEY = "6LdatrsSAAAAAHZrB70txiV5p-8Iv8BtVxlTtjKX"
+    RECAPTCHA_KEY = "6LdnPkIUAAAAABqC_ITR9-LTJKSdyR_Etj1Sf-Xi"
 
     ERROR_PATTERN = r'<p class="b">Information:</p>\s*<div>\s*<strong>(.*?)</strong>'
 
@@ -68,8 +68,10 @@ class ShareonlineBiz(SimpleHoster):
         self.multiDL = False
 
     def handle_captcha(self):
+        self.log_debug("start reCAPTCHA V2 javascript")
         self.captcha = ReCaptcha(self.pyfile)
-        response, challenge = self.captcha.challenge(self.RECAPTCHA_KEY)
+        challenge = self.captcha.challenge(self.RECAPTCHA_KEY, version='v2_javascript')
+        response = challenge
 
         m = re.search(r'var wait=(\d+);', self.data)
         self.set_wait(int(m.group(1)) if m else 30)

--- a/module/plugins/hoster/ShareonlineBiz.py
+++ b/module/plugins/hoster/ShareonlineBiz.py
@@ -70,7 +70,7 @@ class ShareonlineBiz(SimpleHoster):
     def handle_captcha(self):
         self.log_debug("start reCAPTCHA V2 javascript")
         self.captcha = ReCaptcha(self.pyfile)
-        challenge = self.captcha.challenge(self.RECAPTCHA_KEY, version='v2_javascript')
+        challenge = self.captcha.challenge(version='v2_javascript')
         response = challenge
 
         m = re.search(r'var wait=(\d+);', self.data)

--- a/module/plugins/hoster/UploadedTo.py
+++ b/module/plugins/hoster/UploadedTo.py
@@ -13,7 +13,7 @@ from ..internal.SimpleHoster import SimpleHoster
 class UploadedTo(SimpleHoster):
     __name__ = "UploadedTo"
     __type__ = "hoster"
-    __version__ = "1.07"
+    __version__ = "1.08"
     __status__ = "testing"
 
     __pattern__ = r'https?://(?:www\.)?(uploaded\.(to|net)|ul\.to)(/file/|/?\?id=|.*?&id=|/)(?P<ID>\w+)'
@@ -34,6 +34,8 @@ class UploadedTo(SimpleHoster):
         (__pattern__ + ".*", r'http://uploaded.net/file/\g<ID>')]
 
     API_KEY = "lhF2IeeprweDfu9ccWlxXVVypA5nA3EL"
+
+    RECAPTCHA_KEY = "6Le1WUIUAAAAAG0gEh0atRevv3TT-WP4HW8FLMoe"
 
     OFFLINE_PATTERN = r'>Page not found'
     TEMP_OFFLINE_PATTERN = r'<title>uploaded\.net - Maintenance|Downloads have been blocked for today.<'
@@ -80,12 +82,13 @@ class UploadedTo(SimpleHoster):
 
         self.data = self.load("http://uploaded.net/js/download.js")
 
+        self.log_debug("start reCAPTCHA V2 javascript")
         self.captcha = ReCaptcha(pyfile)
-        response, challenge = self.captcha.challenge()
+        challenge = self.captcha.challenge(self.RECAPTCHA_KEY, version='v2_javascript')
+        response = challenge
 
         self.data = self.load("http://uploaded.net/io/ticket/captcha/%s" % self.info['pattern']['ID'],
-                              post={'recaptcha_challenge_field': challenge,
-                                    'recaptcha_response_field': response})
+                              post={'g-recaptcha-response': challenge})
         self.check_errors()
 
         SimpleHoster.handle_free(self, pyfile)

--- a/module/plugins/hoster/UploadedTo.py
+++ b/module/plugins/hoster/UploadedTo.py
@@ -84,7 +84,7 @@ class UploadedTo(SimpleHoster):
 
         self.log_debug("start reCAPTCHA V2 javascript")
         self.captcha = ReCaptcha(pyfile)
-        challenge = self.captcha.challenge(self.RECAPTCHA_KEY, version='v2_javascript')
+        challenge = self.captcha.challenge(version='v2_javascript')
         response = challenge
 
         self.data = self.load("http://uploaded.net/io/ticket/captcha/%s" % self.info['pattern']['ID'],


### PR DESCRIPTION
### Type of request:

> **NOTE:**
> Please, fill with an `x` one of the checkboxes below (eg. `[x] Bugfix`).

- [ ] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [x] Plugin bugfix/enhancement

### Short description:

Updates the hoster plugins share-online.biz, uploaded.net and filer.net to the new reCAPTCHA V2 API https://github.com/pyload/pyload/pull/3125

### Reasons for making this change:

Handling of interactive reCAPTCHA V2 captchas are not supported by the current plugin

### References to this change (related pull requests, issues, etc.):

https://github.com/pyload/pyload/issues/3074
https://github.com/pyload/pyload/issues/3122
https://github.com/pyload/pyload/issues/3120