### PR TITLE
ExtractArchive 'no archive to extract'-fix

### DIFF
--- a/module/plugins/hooks/ExtractArchive.py
+++ b/module/plugins/hooks/ExtractArchive.py
@@ -286,7 +286,7 @@ class ExtractArchive(Addon):
                 new_files_ids = []
 
                 if extensions:  #: Include only specified archive types
-                    files_ids = filter(lambda file_id: any([Extractor.archivetype(file_id[1].lower()) in extensions
+                    files_ids = filter(lambda file_id: any([Extractor.archivetype(file_id[1]) in extensions
                                                             for Extractor in self.extractors]), files_ids)
 
                 #: Sort by filename to ensure (or at least try) that a multivolume archive is targeted by its first part


### PR DESCRIPTION
### Type of request:

> **NOTE:**
> Please, fill with an `x` one of the checkboxes below (eg. `[x] Bugfix`).

- [ ] Bugfix
- [ ] Code cosmetics
- [ ] Feature enhancement
- [ ] New feature
- [ ] New plugin
- [X] Plugin bugfix/enhancement

### Short description:
Pyload does not recognize an archive to extract.

### Reasons for making this change:

_OPTIONAL_

### References to this change (related pull requests, issues, etc.):

_OPTIONAL_
