### PR TITLE
Package list shows URL instead of filename (#3390)

### DIFF
--- a/src/pyload/webui/app/themes/pyplex/templates/js/packages.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/packages.js
@@ -176,7 +176,7 @@ function Package (ui, id, ele){
                 link.icon = 'glyphicon glyphicon-cloud-download';
 
             var html = "<span class='child_status'><span style='margin-right: 2px;color: #f9be03;' class='" + link.icon + "'></span></span>\n" +
-                       "<span style='font-size: 16px; font-weight: bold;'><a href='" + link.url + "'>" + link.url + "</a></span><br/>" +
+                       "<span style='font-size: 16px; font-weight: bold;'><a href='" + link.url + "'>" + link.name + "</a></span><br/>" +
                        "<div class='child_secrow' style='margin-left: 21px; margin-bottom: 7px; border-radius: 4px;'>" +
                        "<span class='child_status' style='font-size: 12px; color:#eee; padding-left: 5px;'>" + link.statusmsg + "</span>&nbsp;" + link.error + "&nbsp;" +
                        "<span class='child_status' style='font-size: 12px; color:#eee;'>" + link.format_size + "</span>" +


### PR DESCRIPTION
Webinterface pyplex didn't show the filename of downloaded files.
This will show the filename instead of the files URL.
fixes #3390.