### PR TITLE
Fix multiple links for one torrent issue

### DIFF
--- a/src/pyload/plugins/downloaders/RealdebridComTorrent.py
+++ b/src/pyload/plugins/downloaders/RealdebridComTorrent.py
@@ -161,7 +161,7 @@ class RealdebridComTorrent(BaseDownloader):
 
         self.pyfile.set_progress(100)
 
-        return torrent_info["links"][0]
+        return torrent_info["links"]
 
     def download_torrent(self, torrent_url):
         """
@@ -228,7 +228,8 @@ class RealdebridComTorrent(BaseDownloader):
         ]["password"]
 
         torrent_id = self.send_request_to_server()
-        torrent_url = self.wait_for_server_dl(torrent_id)
-        self.download_torrent(torrent_url)
+        torrent_urls = self.wait_for_server_dl(torrent_id)
+        for torrent_url in torrent_urls:
+            self.download_torrent(torrent_url)
         if self.config.get("del_finished"):
             self.delete_torrent_from_server(torrent_id)


### PR DESCRIPTION
<!--- Hey, annotations like this one will not be shown in your pull request ticket, so you don't have to delete them, just ignore them all -->

<!--- Don't share your account credentials or other sensitive data here, anyone could read them on GitHub -->

<!--- Thanks for your contributions! -->


### Type of request:
<!--- Please fill with an `x` one of the checkboxes below (eg. `[x] New plugin`) -->
<!--- Make sure there are no spaces between the brackets you fill -->

- [ ] New plugin
- [x] Plugin changes
- [ ] pyLoad changes
- [ ] Webui changes
- [ ] Other


### Types of changes:
<!--- Please fill with an `x` one or more checkboxes below (eg. `[x] Bugfix`) -->
<!--- Make sure there are no spaces between the brackets you fill -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Description:
<!--- Short description and reasons for applying these changes -->
Fix issue when real-debrid returns multiple link for one single torrent. Before, PyLoad was downloading the first link, now it downloads all links
<!--- WRITE HERE - REQUIRED -->


### References:
<!--- Related pull requests, issues, external links, screenshots, etc. -->

<!--- WRITE HERE - OPTIONAL -->
