### PR TITLE
fix TRAFFIC_LEFT_PATTERN for ddownload.com not matching negative numbers

### DIFF
--- a/module/plugins/accounts/DdlTo.py
+++ b/module/plugins/accounts/DdlTo.py
@@ -8,7 +8,7 @@ from ..internal.XFSAccount import XFSAccount
 class DdlTo(XFSAccount):
     __name__ = "DdlTo"
     __type__ = "account"
-    __version__ = "0.02"
+    __version__ = "0.03"
     __status__ = "testing"
 
     __description__ = """Ddl.to account plugin"""
@@ -18,5 +18,5 @@ class DdlTo(XFSAccount):
     PLUGIN_DOMAIN = "ddownload.com"
 
     PREMIUM_PATTERN = r'remium Account \(expires'
-    TRAFFIC_LEFT_PATTERN = r'<span>Traffic available</span>\s*<div class="price">(?:<sup>(?P<U>[^<>]+)</sup>)?(?P<S>\d+|[Uu]nlimited)</div>'
+    TRAFFIC_LEFT_PATTERN = r'<span>Traffic available</span>\s*<div class="price">(?:<sup>(?P<U>[^<>]+)</sup>)?(?P<S>-?\d+|[Uu]nlimited)</div>'
     VALID_UNTIL_PATTERN = r'Premium Account \(expires ([^)]+)\)'


### PR DESCRIPTION
Traffic left for ddownload.com may be negative, if the last downloaded file was larger than the traffic left. This will match the negative traffic left instead of falling back to unlimited.

I was also thinking about capping the traffic value to 0 if a negative value is matched, but this has to be done in XFSAccount.py (or by copying the whole grab_info method).. This seems to work as is, as the negative traffic does not match the first pattern in misc.parse_size, which already short circuits to 0.