### PR TITLE
Thrift fix: eta data

### DIFF
--- a/module/remote/thriftbackend/pyload.thrift
+++ b/module/remote/thriftbackend/pyload.thrift
@@ -68,7 +68,7 @@ struct DownloadInfo {
   1: FileID fid,
   2: string name,
   3: i64 speed,
-  4: i32 eta,
+  4: i64 eta,
   5: string format_eta,
   6: i64 bleft,
   7: i64 size,

--- a/module/remote/thriftbackend/thriftgen/pyload/ttypes.py
+++ b/module/remote/thriftbackend/thriftgen/pyload/ttypes.py
@@ -193,7 +193,7 @@ class DownloadInfo(TBase):
     (1, TType.I32, 'fid', None, None, ), # 1
     (2, TType.STRING, 'name', None, None, ), # 2
     (3, TType.I64, 'speed', None, None, ), # 3
-    (4, TType.I32, 'eta', None, None, ), # 4
+    (4, TType.I64, 'eta', None, None, ), # 4
     (5, TType.STRING, 'format_eta', None, None, ), # 5
     (6, TType.I64, 'bleft', None, None, ), # 6
     (7, TType.I64, 'size', None, None, ), # 7


### PR DESCRIPTION
To reproduce the issue:

1. Start a server with an empty queue
2. From the webinterface:
Pause the server
Disable download speed limit
Add some valid package to download (preferably some large file, couple of gigabytes)
3. Start the CLI and unpause the server

Traceback (most recent call last):
...
...
  File "/home/snilt/pyload/module/lib/thrift/protocol/TBinaryProtocol.py", line 110, in writeI32
    buff = pack("!i", i32)
error: 'i' format requires -2147483648 <= number <= 2147483647

It seems that the server sends some bad eta value at the very beginning of a new download.
The PR just changes the data format to integer 64-bit.
(Works fine for me since years)
