### PR TITLE
Fixes for usernames and passwords with non-ascii characters

### DIFF
--- a/module/database/UserDatabase.py
+++ b/module/database/UserDatabase.py
@@ -33,7 +33,7 @@ class UserMethods():
 
         salt = r[2][:5]
         pw = r[2][5:]
-        h = sha1(salt + password)
+        h = sha1((salt + password).encode('utf-8'))
         if h.hexdigest() == pw:
             return {"id": r[0], "name": r[1], "role": r[3],
                     "permission": r[4], "template": r[5], "email": r[6]}
@@ -43,9 +43,11 @@ class UserMethods():
     @style.queue
     def addUser(db, user, password):
         salt = reduce(lambda x, y: x + y, [str(random.randint(0, 9)) for i in range(0, 5)])
-        h = sha1(salt + password)
+        if isinstance(password, str):
+            password = password.decode('utf-8')
+        h = sha1((salt + password).encode('Utf-8'))
         password = salt + h.hexdigest()
-
+        print('HexPassword: ' + password)
         c = db.c
         c.execute('SELECT name FROM users WHERE name=?', (user, ))
         if c.fetchone() is not None:
@@ -63,13 +65,15 @@ class UserMethods():
 
         salt = r[2][:5]
         pw = r[2][5:]
-        h = sha1(salt + oldpw)
+        h = sha1((salt + oldpw).encode('utf-8'))
         if h.hexdigest() == pw:
             salt = reduce(lambda x, y: x + y, [str(random.randint(0, 9)) for i in range(0, 5)])
-            h = sha1(salt + newpw)
+            h = sha1((salt + newpw).encode('utf-8'))
             password = salt + h.hexdigest()
 
             db.c.execute("UPDATE users SET password=? WHERE name=?", (password, user))
+            # without commit it's never saved
+            db.commit()
             return True
 
         return False

--- a/module/web/api_app.py
+++ b/module/web/api_app.py
@@ -95,8 +95,8 @@ def login():
     response.headers.replace("Content-type", "application/json")
     response.headers.append("Cache-Control", "no-cache, must-revalidate")
 
-    user = request.forms.get("username")
-    password = request.forms.get("password")
+    user = request.forms.username
+    password = request.forms.password
 
     info = PYLOAD.checkAuth(user, password)
 

--- a/module/web/json_app.py
+++ b/module/web/json_app.py
@@ -317,9 +317,9 @@ def update_accounts():
 @route("/json/change_password", method="POST")
 def change_password():
 
-    user = request.POST["user_login"]
-    oldpw = request.POST["login_current_password"]
-    newpw = request.POST["login_new_password"]
+    user = request.POST.user_login
+    oldpw = request.POST.login_current_password
+    newpw = request.POST.login_new_password
 
     if not PYLOAD.changePassword(user, oldpw, newpw):
         print "Wrong password"

--- a/module/web/pyload_app.py
+++ b/module/web/pyload_app.py
@@ -221,8 +221,8 @@ def nopermission():
 
 @route("/login", method="POST")
 def login_post():
-    user = request.forms.get("username")
-    password = request.forms.get("password")
+    user = request.forms.username
+    password = request.forms.password
 
     info = PYLOAD.checkAuth(user, password)
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -8,19 +8,13 @@ import requests
 import time
 from nose.tools import *
 
-if os.name =='nt':
-    from wexpect import spawn as p_spawn
+if os.name == 'nt':
+    from pexpect.popen_spawn import PopenSpawn as p_spawn
     PY_PATH = 'c:\\python27\\python.exe'
 else:
     from pexpect import spawn as p_spawn
     PY_PATH = '/usr/bin/python2.7'
-try:
-    from urllib import urlencode
-    from urllib2 import urlopen, HTTPError
-except ImportError:
-    from urllib.parse import urlencode
-    from urllib.request import urlopen
-    from urllib.error import HTTPError
+
 from nose.tools import *
 
 api_url = "http://localhost:8000/api/%s"
@@ -31,7 +25,7 @@ pyloadpath = os.path.abspath(os.path.join(base_path, '..', 'pyLoadCore.py'))
 
 
 def setup_start(pyloadpath):
-    c = p_spawn(PY_PATH + ' ' +  pyloadpath)
+    c = p_spawn(PY_PATH + ' ' + pyloadpath)
     if os.name != 'nt':
         c.logfile = sys.stdout
     else:
@@ -43,12 +37,13 @@ def setup_start(pyloadpath):
     c.sendline('j')
     c.expect('System check finished.*')
     systemresult = c.before
-    var = re.findall('py-OpenSSL:\s(OK|missing)',systemresult)
+    var = re.findall('py-OpenSSL:\s(OK|missing)', systemresult)
     c.sendline('')
     c.expect('Continue.*')
     c.sendline('')
     c.expect('Change config.*')
     return var, c
+
 
 def doInitalConfig(username, password, download_folder=None, config_folder=None):
     if not config_folder:
@@ -137,7 +132,10 @@ class TestSystem:
         r.close()
         # Login Via Web Interface
         r = requests.Session()
-        u = r.post(url % "login", data={"username": "Mäf", "password": "müfo", "submit":"login", "do":"login"})
+        u = r.post(url % "login", data={"username": "Mäf",
+                                        "password": "müfo",
+                                        "submit": "login",
+                                        "do": "login"})
         content = u.text
         assert "Incorrect username/email or password." not in content
         assert "Logout" in content
@@ -174,7 +172,10 @@ class TestSystem:
         c.expect('ADDON ClickNLoad: Proxy listening.*')
         # Login Via Web Interface
         r = requests.Session()
-        u = r.post(url % "login", data={"username": "Mäf", "password": "Külu", "submit":"login", "do":"login"})
+        u = r.post(url % "login", data={"username": "Mäf",
+                                        "password": "Külu",
+                                        "submit": "login",
+                                        "do": "login"})
         content = u.text
         assert "Logout" in content
         # Change Password in UI
@@ -219,4 +220,3 @@ class TestSystem:
         assert "Trübo" not in result
         if os.name == 'nt':
             c.logfile.close()
-

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+
+import os
+import shutil
+import sys
+import re
+import requests
+import time
+from nose.tools import *
+
+if os.name =='nt':
+    from wexpect import spawn as p_spawn
+    PY_PATH = 'c:\\python27\\python.exe'
+else:
+    from pexpect import spawn as p_spawn
+    PY_PATH = '/usr/bin/python2.7'
+try:
+    from urllib import urlencode
+    from urllib2 import urlopen, HTTPError
+except ImportError:
+    from urllib.parse import urlencode
+    from urllib.request import urlopen
+    from urllib.error import HTTPError
+from nose.tools import *
+
+api_url = "http://localhost:8000/api/%s"
+url = "http://localhost:8000/%s"
+
+base_path = os.path.dirname(os.path.abspath(__file__))
+pyloadpath = os.path.abspath(os.path.join(base_path, '..', 'pyLoadCore.py'))
+
+
+def setup_start(pyloadpath):
+    c = p_spawn(PY_PATH + ' ' +  pyloadpath)
+    if os.name != 'nt':
+        c.logfile = sys.stdout
+    else:
+        lgfile = open('logfile.txt', 'w')
+        c.logfile = lgfile
+    c.expect('Choose your Language .*:')
+    c.sendline('en')
+    c.expect('When you are ready.*')
+    c.sendline('j')
+    c.expect('System check finished.*')
+    systemresult = c.before
+    var = re.findall('py-OpenSSL:\s(OK|missing)',systemresult)
+    c.sendline('')
+    c.expect('Continue.*')
+    c.sendline('')
+    c.expect('Change config.*')
+    return var, c
+
+def doInitalConfig(username, password, download_folder=None, config_folder=None):
+    if not config_folder:
+        if os.name == 'nt':
+            conf_path = 'pyload'
+        else:
+            conf_path = '.pyload'
+        configdir = os.path.join(os.path.expanduser("~"), conf_path)
+        shutil.rmtree(configdir, ignore_errors=True)
+        configdirfile = os.path.join(base_path, '..', 'module', 'config', 'configdir')
+        if os.path.exists(configdirfile):
+            os.remove(configdirfile)
+    else:
+        shutil.rmtree(config_folder, ignore_errors=True)
+    var, c = setup_start(pyloadpath)
+    if config_folder:
+        c.sendline('y')
+        c.expect('Configpath.*')
+        c.sendline(config_folder)
+        c.sendline('')
+        # finished start again
+        var, c = setup_start(pyloadpath)
+    c.sendline('n')
+    c.expect('Make basic.*')
+    c.sendline('y')
+    c.expect('Username.*')
+    c.sendline(username)
+    c.expect('Password.*')
+    c.sendline(password)
+    c.expect('Password.*again.*')
+    c.sendline(password)
+    c.expect('Enable remote access.*')
+    c.sendline('y')
+    c.expect('Language.*')
+    c.sendline('en')
+    c.expect('Downloadfolder.*')
+    if download_folder:
+        c.sendline(download_folder)
+    else:
+        c.sendline('')
+    c.expect('Max.*')
+    c.sendline('')
+    c.expect('Use Reconnect.*')
+    c.sendline('')
+    if var[0] == 'OK':
+        c.expect('Do you want to configure ssl.*')
+        c.sendline('')
+    c.expect('Do you want to configure webinterface.*')
+    c.sendline('')
+    c.expect('Activate webinterface.*')
+    c.sendline('')
+    c.expect('Address.*')
+    c.sendline('')
+    c.expect('Port.*')
+    c.sendline('')
+    c.expect('Server.*')
+    c.sendline('')
+    c.expect('Template.*')
+    c.sendline('')
+    c.expect('Hit enter.*')
+    c.sendline('')
+    if os.name == 'nt':
+        c.logfile.close()
+
+
+class TestSystem:
+
+    @classmethod
+    def setupClass(cls):
+        doInitalConfig('Mäf', 'müfo')
+
+    def test_login(self):
+        c = p_spawn(PY_PATH + ' ' + pyloadpath)
+        if os.name != 'nt':
+            c.logfile = sys.stdout
+        else:
+            lgfile = open('login_logfile.txt', 'w')
+            c.logfile = lgfile
+        # Wait pyload is running
+        c.expect('ADDON ClickNLoad: Proxy listening.*')
+        # Login via API
+        r = requests.Session()
+        u = r.post(api_url % "login", data={"username": "Mäf", "password": "müfo"})
+        self.key = u.json()
+        assert self.key is not False
+        r.close()
+        # Login Via Web Interface
+        r = requests.Session()
+        u = r.post(url % "login", data={"username": "Mäf", "password": "müfo", "submit":"login", "do":"login"})
+        content = u.text
+        assert "Incorrect username/email or password." not in content
+        assert "Logout" in content
+        r.close()
+        if os.name == 'nt':
+            c.logfile.close()
+
+    def test_change_password(self):
+        c = p_spawn(PY_PATH + ' ' + pyloadpath + ' -u')
+        if os.name != 'nt':
+            c.logfile = sys.stdout
+        else:
+            lgfile = open('password_logfile.txt', 'w')
+            c.logfile = lgfile
+        c.expect('.*/2/3/4:')
+        c.sendline('1')
+        c.expect('Username.*')
+        c.sendline('Mäf')
+        c.expect('Password.*')
+        c.sendline('Külu')
+        c.expect('Password.*again.*')
+        c.sendline('Külu')
+        c.expect('.*/2/3/4:')
+        c.sendline('4')
+        if os.name == 'nt':
+            c.logfile.close()
+        c = p_spawn(PY_PATH + ' ' + pyloadpath)
+        if os.name != 'nt':
+            c.logfile = sys.stdout
+        else:
+            lgfile = open('pyload_logfile.txt', 'w')
+            c.logfile = lgfile
+        # Wait pyload is running
+        c.expect('ADDON ClickNLoad: Proxy listening.*')
+        # Login Via Web Interface
+        r = requests.Session()
+        u = r.post(url % "login", data={"username": "Mäf", "password": "Külu", "submit":"login", "do":"login"})
+        content = u.text
+        assert "Logout" in content
+        # Change Password in UI
+        u = r.post(url % "json/change_password", data={"user_login": "Mäf",
+                                                       "login_current_password": "Külu",
+                                                       "login_new_password": "müfo",
+                                                       "login_new_password2": "müfo"})
+        assert u.status_code == 200
+
+        # c.terminate()
+        # Needs some time to save database
+        time.sleep(2)
+        u = r.get(url % "api/kill")
+        assert u.status_code == 200
+        r.close()
+        if os.name == 'nt':
+            c.logfile.close()
+
+    def test_delete_user(self):
+        c = p_spawn(PY_PATH + ' ' + pyloadpath + ' -u')
+        if os.name != 'nt':
+            c.logfile = sys.stdout
+        else:
+            lgfile = open('delete_logfile.txt', 'w')
+            c.logfile = lgfile
+        c.expect('.*/2/3/4:')
+        c.sendline('1')
+        c.expect('Username.*')
+        c.sendline('Türbo')
+        c.expect('Password.*')
+        c.sendline('Küku')
+        c.expect('Password.*again.*')
+        c.sendline('Küku')
+        c.expect('.*/2/3/4:')
+        c.sendline('3')
+        c.expect('Username.*')
+        c.sendline('Türbo')
+        c.sendline('2')
+        c.expect('Users.*Mäf.*(.*)----.*')
+        result = c.after
+        c.sendline('4')
+        assert "Trübo" not in result
+        if os.name == 'nt':
+            c.logfile.close()
+


### PR DESCRIPTION
During my tests for the python3 version of pyload I found out that usernames with non-ascii characters (like ü) are not working. The inital config accepts the usernames, but later one you are not able to login. 
This affects:
- The normal Web Login
- The API Login
- Changing passwords on the Web UI

Furthermore it looks to me that password changes from the Web-UI are not saved. 
This PR fixes all these problems. 
To illustrate the problems I created tests for nose (only running on Linux, on Windows I only got it running in my Debugger with some strip('\r') additions, I didn't include in this fix). (The pyCharm Debugger has only proper support for nose and not nose2). To run the test you need to install "requests" and "pexpect".  During the test it ***deletes your config*** and creates a new config from scratch. So be carefull using it on a productive system. With the original code the tests fails, with the patch the tests runs properly. This tests can also help us to ensure that the migration to python3 will not cause more trouble than necessary.