### PR TITLE
[UptoboxCom] multi downloads require premium account

### DIFF
--- a/module/plugins/hoster/UptoboxCom.py
+++ b/module/plugins/hoster/UptoboxCom.py
@@ -8,7 +8,7 @@ from ..internal.SimpleHoster import SimpleHoster
 class UptoboxCom(SimpleHoster):
     __name__ = "UptoboxCom"
     __type__ = "hoster"
-    __version__ = "0.36"
+    __version__ = "0.37"
     __status__ = "testing"
 
     __pattern__ = r'https?://(?:www\.)?(uptobox|uptostream)\.com/\w{12}'
@@ -38,7 +38,7 @@ class UptoboxCom(SimpleHoster):
     URL_REPLACEMENTS = [("http://", "https://")]
 
     def setup(self):
-        self.multiDL = True
+        self.multiDL = self.premium
         self.chunk_limit = 1
         self.resume_download = True
 


### PR DESCRIPTION
Multi Downloads require a premium account, otherwise we start waiting for concurrent downloads but only one really start and others fails.