### PR TITLE
[Main] Prettier error message in default theme

### DIFF
--- a/src/pyload/webui/app/handlers.py
+++ b/src/pyload/webui/app/handlers.py
@@ -18,7 +18,8 @@ def handle_error(exc):
 
     flask.current_app.logger.debug(exc, exc_info=True)
 
-    messages = [f"Error {code}: {desc}", tb]
+    messages = [f"Error {code}: {desc}"]
+    messages.extend(tb.split('\n'))
     return render_template("error.html", messages=messages), code
 
 

--- a/src/pyload/webui/app/templates/base.html
+++ b/src/pyload/webui/app/templates/base.html
@@ -134,6 +134,9 @@
 
 <h1>{% block subtitle %}pyLoad{% endblock %}</h1>
 
+{% block error %}
+{% endblock error %}
+
 {% block statusbar %}
 {% endblock %}
 
@@ -142,10 +145,6 @@
 <div class="level1" style="clear:both">
 </div>
 <noscript><h1>Enable JavaScript to use the webinterface.</h1></noscript>
-
-{% for message in messages %}
-    <b><p>{{message}}</p></b>
-{% endfor %}
 
 <div id="load-indicator" style="opacity: 0; float: right; margin-top: -10px;">
     <img src="{{url_for('static', filename='img/ajax-loader.gif')}}" alt="" style="padding-right: 5px"/>

--- a/src/pyload/webui/app/templates/error.html
+++ b/src/pyload/webui/app/templates/error.html
@@ -1,2 +1,11 @@
 {% extends 'base.html' %}
-{% block title %}{{_("Sorry, something went wrong... :(")}}{% endblock %}
+{% block subtitle %}{{_("Sorry, something went wrong... :")}}{% endblock %}
+{% block error %}
+  <div id="body-wrapper">
+{% for message in messages %}
+ <b>
+    <div style="font-size:12px;">{{message}}</div>
+  </b>
+{% endfor %}
+  </div>
+{% endblock %}


### PR DESCRIPTION


### Describe the changes

The error message before seemed to be a bit buggy, the message "Something went wrong wasn't output, the error message wasn't formated well, just a very long string
The "Something went wrong text is now outputted as subtitle, the errormessage itself is printed in diferent paragrahs, is much more readable

### Is this related to a problem?
Related to every error message displayed on the ui

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

Before:
![grafik](https://user-images.githubusercontent.com/6438895/93016565-827e5780-f5c2-11ea-9021-fbd177a305f2.png)


After:
![grafik](https://user-images.githubusercontent.com/6438895/93016489-ea806e00-f5c1-11ea-8a9d-8b4587c713c8.png)

