### PR TITLE
[Main] Bool/Int Config settings are no longer converted to str

### DIFF
--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -156,6 +156,8 @@ class Api:
         """
         if section == "core":
             value = self.pyload.config[category][option]
+            if self.pyload.config.config[category][option]['type'] in ['bool', 'int']:
+                return value
         else:
             value = self.pyload.config.get_plugin(category, option)
         return str(value)


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Currently all config settings of type bool and int are converted to strings, whereas all requests to the settings are expecting bool values. E.g. the autologin function is set to "False" in Default.  In app_blueprint.py in the login routine this setting is requested with:
`if api.get_config_value("webui", "autologin"):`
The get_config_value resturns a string "False" which is evaluated as true, the autologin is activated.

In case a setting of type bool or int is requested the result is now returned directly without cast

### Is this related to a problem?

E.g. Autologin can't be deactivated
(I didn't check other functions, just saw it looks like it's always expecting bool values)

### Additional references
Checked on Linux Mint 20 with python3.8