### PR TITLE
[Main] Prettier debug output on LOAD url and WAIT

### DIFF
--- a/src/pyload/plugins/base/hoster.py
+++ b/src/pyload/plugins/base/hoster.py
@@ -334,7 +334,7 @@ class BaseHoster(BasePlugin):
         new_wait_until = time.time() + wait_time + float(not strict)
 
         self.log_debug(
-            "WAIT set to timestamp {}".format(new_wait_until),
+            "WAIT set to timestamp {}, ".format(new_wait_until),
             "Previous wait_until: {}".format(old_wait_until),
         )
 

--- a/src/pyload/plugins/base/plugin.py
+++ b/src/pyload/plugins/base/plugin.py
@@ -172,12 +172,10 @@ class BasePlugin:
         """
         if self.pyload.debug:
             self.log_debug(
-                "LOAD URL " + url,
-                *[
-                    "{}={}".format(key, value)
-                    for key, value in locals().items()
-                    if key not in ("self", "url", "_[1]")
-                ],
+                "LOAD URL " + url, " ",
+                ", ".join(["'{}': {}".format(key, value)
+                           for key, value in locals().items()
+                           if key not in ("self", "url", "_[1]")])
             )
 
         url = fixurl(url, unquote=True)  #: Recheck in 0.6.x


### PR DESCRIPTION
### Describe the changes

Debug log for WAIT set and LOAD url didn't look very pretty before, I added some spaces and commas 

### Is this related to a problem?

Before:

[2020-09-15 18:38:35]  DEBUG               pyload  DOWNLOADER FilerNet[13]: LOAD URL xxx://filer.net/get/**wlpwjckcyp1glsnpget={}post={}ref=Truecookies=Truejust_header=Truedecode=Truemultipart=Falseredirect=Truereq=None**
[2020-09-15 18:38:36]  INFO                pyload  DOWNLOADER FilerNet[13]: Direct download link not found
[2020-09-15 18:38:36]  DEBUG               pyload  DOWNLOADER FilerNet[13]: LOAD URL xxx://filer.net/get/**wlpwjckcyp1glsnpget={}post={}ref=Falsecookies=Truejust_header=Falsedecode=Truemultipart=Falseredirect=Truereq=None**
[2020-09-15 18:38:36]  INFO                pyload  DOWNLOADER FilerNet[13]: Checking for link errors...
[2020-09-15 18:38:36]  DEBUG               pyload  DOWNLOADER FilerNet[13]: WAIT set to timestamp **1600187977.6262631Previous** wait_until: 0

After:

[2020-09-15 18:30:08]  DEBUG               pyload  DOWNLOADER FilerNet[13]: LOAD URL xxx://filer.net/get/**wlpwjckcyp1glsnp 'get': {}, 'post': {}, 'ref': True, 'cookies': True, 'just_header': True, 'decode': True, 'multipart': False, 'redirect': True, 'req': None**
[2020-09-15 18:30:08]  INFO                pyload  DOWNLOADER FilerNet[13]: Direct download link not found
[2020-09-15 18:30:08]  DEBUG               pyload  DOWNLOADER FilerNet[13]: LOAD URL xxx://filer.net/get/**wlpwjckcyp1glsnp 'get': {}, 'post': {}, 'ref': False, 'cookies': True, 'just_header': False, 'decode': True, 'multipart': False, 'redirect': True, 'req': None**
[2020-09-15 18:30:08]  INFO                pyload  DOWNLOADER FilerNet[13]: Checking for link errors...
[2020-09-15 18:30:08]  DEBUG               pyload  DOWNLOADER FilerNet[13]: WAIT set to timestamp **1600187469.9132776, Previous** wait_until: 0

### Additional references

