### PR TITLE
[Main] Fix crash before captcha is shown

### DIFF
--- a/src/pyload/core/managers/captcha_manager.py
+++ b/src/pyload/core/managers/captcha_manager.py
@@ -70,7 +70,7 @@ class CaptchaTask:
         self.captcha_result_type = result_type
         self.handler = []  #: the addon plugins that will take care of the solution
         self.result = None
-        self.wait_until = None
+        self.wait_until = 0
         self.error = None  #: error message
 
         self.status = "init"


### PR DESCRIPTION
### Describe the changes

After starting pyload NG and appling the path_name not defined patch it's possible to add filer.net links. After adding one link starting the sownload, pyload NG waits for the filer time to count down, afterwards it's starting to display the captcha and is creating a max wait time for this. In this moment the application crashes with the following log output:
```
[2020-09-15 18:43:55]  INFO                pyload  DOWNLOADER FilerNet[13]: Processing url: https://filer.net/get/wlpwjckcyp1glsnp
[2020-09-15 18:43:55]  INFO                pyload  DOWNLOADER FilerNet[13]: Looking for direct download link...
[2020-09-15 18:43:55]  DEBUG               pyload  DOWNLOADER FilerNet[13]: LOAD URL https://filer.net/get/wlpwjckcyp1glsnp 'get': {}, 'post': {}, 'ref': True, 'cookies': True, 'just_header': True, 'decode': True, 'multipart': False, 'redirect': True, 'req': None
[2020-09-15 18:43:55]  INFO                pyload  DOWNLOADER FilerNet[13]: Direct download link not found
[2020-09-15 18:43:55]  DEBUG               pyload  DOWNLOADER FilerNet[13]: LOAD URL https://filer.net/get/wlpwjckcyp1glsnp 'get': {}, 'post': {}, 'ref': False, 'cookies': True, 'just_header': False, 'decode': True, 'multipart': False, 'redirect': True, 'req': None
[2020-09-15 18:43:56]  INFO                pyload  DOWNLOADER FilerNet[13]: Checking for link errors...
[2020-09-15 18:43:56]  DEBUG               pyload  DOWNLOADER FilerNet[13]: WAIT set to timestamp 1600188297.0523875, Previous wait_until: 0
[2020-09-15 18:43:56]  INFO                pyload  DOWNLOADER FilerNet[13]: Waiting 1 minute...
[2020-09-15 18:44:58]  INFO                pyload  DOWNLOADER FilerNet[13]: No errors found
[2020-09-15 18:44:58]  INFO                pyload  DOWNLOADER FilerNet[13]: Processing as free download...
[2020-09-15 18:44:58]  DEBUG               pyload  DOWNLOADER FilerNet[13]: LOAD URL https://filer.net/get/wlpwjckcyp1glsnp 'get': {}, 'post': {'token': '954f380083c035a4406f894059d0926ef0750da14fdd53d548132e48984d7bbb'}, 'ref': True, 'cookies': True, 'just_header': False, 'decode': True, 'multipart': False, 'redirect': True, 'req': None
[2020-09-15 18:44:58]  DEBUG               pyload  ANTICAPTCHA FilerNet[13]: ReCaptchaKey: 6LdB1kcUAAAAAAVPepnD-6TEd4BXKzS7L4FZFkpO
[2020-09-15 18:44:58]  DEBUG               pyload  ANTICAPTCHA FilerNet[13]: ReCaptchaDetected reCAPTCHA v2
[2020-09-15 18:44:58]  WARNING             pyload  ANTICAPTCHA FilerNet[13]: ReCaptchaSecure Token pattern not found
[2020-09-15 18:44:58]  DEBUG               pyload  DOWNLOADER FilerNet[13]: LOAD URL http://www.google.com/recaptcha/api/fallback?k=6LdB1kcUAAAAAAVPepnD-6TEd4BXKzS7L4FZFkpO 'get': {}, 'post': {}, 'ref': https://filer.net/get/wlpwjckcyp1glsnp, 'cookies': True, 'just_header': False, 'decode': True, 'multipart': False, 'redirect': True, 'req': None
[2020-09-15 18:44:58]  WARNING             pyload  ANTICAPTCHA FilerNet[13]: ReCaptchareCAPTCHA noscript is blocked, trying reCAPTCHA interactive
[2020-09-15 18:44:58]  DEBUG               pyload  ANTICAPTCHA FilerNet[13]: ReCaptchaChallenge reCAPTCHA v2 interactive
[2020-09-15 18:44:58]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `download_processed`
[2020-09-15 18:44:58]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `package_processed`
[2020-09-15 18:44:58]  WARNING             pyload  Download failed: 0Q8k43nmqSJejf563TLV.rar | '>' not supported between instances of 'NoneType' and 'float'
Traceback (most recent call last):
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 56, in run
    pyfile.plugin.preprocessing(self)
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 304, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 101, in _process
    self.process(self.pyfile)
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/plugins/base/simple_downloader.py", line 314, in process
    if self.link and not self.last_download:
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/plugins/downloaders/FilerNet.py", line 51, in handle_free
    response, challenge = self.captcha.challenge()
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/plugins/anticaptchas/ReCaptcha.py", line 154, in challenge
    return self.challenge(
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/plugins/anticaptchas/ReCaptcha.py", line 150, in challenge
    return getattr(self, "_challenge_v{}".format(version))(
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/plugins/anticaptchas/ReCaptcha.py", line 361, in _challenge_v2
    return self._challenge_v2js(key, secure_token=secure_token)
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/plugins/anticaptchas/ReCaptcha.py", line 443, in _challenge_v2js
    result = self.decrypt_interactive(params, timeout=300)
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/plugins/base/captcha.py", line 169, in decrypt_interactive
    captcha_manager.handle_captcha(self.task, timeout)
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/core/managers/captcha_manager.py", line 45, in handle_captcha
    task.set_waiting(timeout)
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/core/managers/captcha_manager.py", line 103, in set_waiting
    self.wait_until = max(time.time() + sec, self.wait_until)
TypeError: '>' not supported between instances of 'NoneType' and 'float'
[2020-09-15 18:44:58]  INFO                pyload  Debug Report written to /tmp/pyLoad/debug_FilerNet_2020-09-15_18-44-58.zip
```
Per default `self.wait_until` is set to none, this worked on python2, but on python 3 this causes a crash, the fix changes the default value of `self.wait_until` to `0`, this solves the problem.

### Is this related to a problem?

Crash before download starts

### Additional references

Tested on Linux Mint 20, python 3.8
