### PR TITLE
[Main] Fix for settingspage in Default theme not working

### DIFF
--- a/src/pyload/webui/app/templates/js/settings.js
+++ b/src/pyload/webui/app/templates/js/settings.js
@@ -14,7 +14,7 @@ document.addEvent('domready', function() {
   root.accountDialog = new MooDialog({destroyOnHide: false});
   root.accountDialog.setContent($('account_box'));
 
-  new TinyTab($$('#tabs li a'), $$('#tabs-body > span'));
+  new TinyTab($$('#toptabs li a'), $$('#tabs-body > span'));
 
   $$('ul.nav').each(nav =>
     new MooDropMenu(nav, {


### PR DESCRIPTION
### Describe the changes

The element selector for tiny tab wasn't point to the right one changed tab to top_tab, the settings-page is now working as expected again.

### Is this related to a problem?

The problem was reported in issue #3728 

### Additional references
![image](https://user-images.githubusercontent.com/6438895/93242787-9de68f80-f787-11ea-93c1-b88014bd814a.png)

