### PR TITLE
[Main] Fix traceback on change user

### DIFF
--- a/src/pyload/webui/app/helpers.py
+++ b/src/pyload/webui/app/helpers.py
@@ -114,7 +114,7 @@ def set_permission(perms):
     """
     permission = 0
     for name in Perms:
-        if name.startswith("_"):
+        if str(name).startswith("_"):
             continue
 
         if name in perms and perms[name]:


### PR DESCRIPTION
### Describe the changes

Typecast of Perms enum to str to use startswith function

### Is this related to a problem?

If you go to admin page and try to change the users permissions you get an traceback:
```
[2020-09-18 17:49:59]  INFO                pyload  ADDON ClickNLoad: Proxy listening on 0.0.0.0:9666
[2020-09-18 17:51:02]  DEBUG         pyload.webui  'Perms' object has no attribute 'startswith'
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/helpers.py", line 181, in wrapper
    response = func(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/app_blueprint.py", line 463, in admin
    data["permission"] = set_permission(data["perms"])
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/helpers.py", line 117, in set_permission
    if name.startswith("_"):
AttributeError: 'Perms' object has no attribute 'startswith
```
This patch fixes this.

### Additional references

There is one more problem, I don't know how you like to handle it. After appling the fix you can change the users permisions. But if you are logged in as the only user pyload and try to remove it's admin rights you get the following traceback (untick the checkbox below admin):
```
[2020-09-19 08:14:50]  DEBUG         pyload.webui  'role'
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/webui/app/helpers.py", line 181, in wrapper
    response = func(*args, **kwargs)
  File "/home/matthias/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/app_blueprint.py", line 465, in admin
    api.set_user_permission(name, data["permission"], data["role"])
KeyError: 'role'
```
The code checks if the admin box is ticked and afterwards if the selected user not the session's user, both fail, so data['role'] isn't assigned. One possible solution could be to grey out the admin checkbox. So it's also prevented to remove admin rights from the own user and therefore its always ensured that at least one user has admin rights.
