### PR TITLE
[Main] Fix for missing file status icons in default theme

### DIFF
--- a/src/pyload/webui/app/templates/js/packages.js
+++ b/src/pyload/webui/app/templates/js/packages.js
@@ -171,7 +171,7 @@ var Package = new Class({
         }));
         ul.set("html", "");
         data.links.each(function(link) {
-            /*if (link.status === 0)
+            if (link.status === 0)
                 link.icon = 'status-finished.png';
             else if (link.status === 2 || link.status === 3)
                 link.icon = 'status-queue.png';
@@ -186,7 +186,7 @@ var Package = new Class({
             else if (link.status ===  11 || link.status === 13)
                 link.icon = 'status-proc.png';
             else
-                link.icon = 'status-downloading.png';*/
+                link.icon = 'status-downloading.png';
 
             link.id = link.fid;
             var li = new Element("li", {

--- a/src/pyload/webui/app/templates/js/packages.js
+++ b/src/pyload/webui/app/templates/js/packages.js
@@ -171,13 +171,30 @@ var Package = new Class({
         }));
         ul.set("html", "");
         data.links.each(function(link) {
+            /*if (link.status === 0)
+                link.icon = 'status-finished.png';
+            else if (link.status === 2 || link.status === 3)
+                link.icon = 'status-queue.png';
+            else if (link.status ===  9 || link.status === 1)
+                link.icon = 'status-offline.png';
+            else if (link.status === 5)
+                link.icon = 'status-waiting.png';
+            else if (link.status === 8)
+                link.icon = 'status-failed.png';
+            else if (link.status === 4)
+                link.icon = 'arrow-right';
+            else if (link.status ===  11 || link.status === 13)
+                link.icon = 'status-proc.png';
+            else
+                link.icon = 'status-downloading.png';*/
+
             link.id = link.fid;
             var li = new Element("li", {
                 "style": {
                     "margin-left": 0
                 }
             });
-            var html = "<span style='cursor: move' class='child_status sorthandle'><img src='{{url_for('static', filename='img')}}/{icon}' style='width: 12px; height:12px;'/></span>\n".substitute({
+            var html = "<span style='cursor: move' class='child_status sorthandle'><img src='static/img/{icon}' style='width: 12px; height:12px;'/></span>\n".substitute({
                 icon: link.icon
             });
             html += "<span style='font-size: 15px'>{name}</span><br /><div class='child_secrow'>".substitute({


### PR DESCRIPTION
### Describe the changes

I create the link.icon from the linc status as it's also done for the pylex theme (in 4.20 this was done in the python code). Furthermore the call to url_for was replaced by a pure html/js link generation. If the html page is generating the icon name at runtime, so the sever-side (jinia interpreter) can't create the link to the file before the js is running.

### Is this related to a problem?

The packages in queue and Packages tab are not showing the status icons in the packages details. The browser development console shows a call to the img folder but not a call to a special icon file
![grafik](https://user-images.githubusercontent.com/6438895/93662567-6581d280-fa61-11ea-905b-6dc651284c75.png)

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
