### PR TITLE
[Main] Fix for nonworking ClickNLoad

### DIFF
--- a/src/pyload/plugins/addons/ClickNLoad.py
+++ b/src/pyload/plugins/addons/ClickNLoad.py
@@ -133,7 +133,7 @@ class ClickNLoad(BaseAddon):
                             socket.AF_INET, socket.SOCK_STREAM
                         )
 
-                        if self.pyload.config.get("webui", "https"):
+                        if self.pyload.config.get("webui", "use_ssl"):
                             try:
                                 server_socket = ssl.wrap_socket(server_socket)
 

--- a/src/pyload/webui/app/blueprints/cnl_blueprint.py
+++ b/src/pyload/webui/app/blueprints/cnl_blueprint.py
@@ -57,6 +57,7 @@ def add():
         api.add_package(package, urls, 0)
     else:
         api.generate_and_add_packages(urls, 0)
+    return jsonify(True)
 
 
 @bp.route("/addcrypted", methods=["POST"], endpoint="addcrypted")


### PR DESCRIPTION
### Describe the changes

Added `return "true"` to /flash/add routine in case is succeds, changed `self.pyload.config.get("webui", "use_ssl")`, before it was parameter 'https' which isn't a valid parameter

### Is this related to a problem?

Issue ##3724

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
