### PR TITLE
Patch delete files

### DIFF
--- a/src/pyload/webui/app/templates/js/packages.js
+++ b/src/pyload/webui/app/templates/js/packages.js
@@ -68,7 +68,7 @@ var PackageUI = new Class({
         indicateLoad();
         new Request.JSON({
             method: 'get',
-            url: '/api/deleteFinished',
+            url: '/api/delete_finished',
             onSuccess: function(data) {
                 if (data.length > 0) {
                     window.location.reload()
@@ -86,7 +86,7 @@ var PackageUI = new Class({
         indicateLoad();
         new Request.JSON({
             method: 'get',
-            url: '/api/restartFailed',
+            url: '/api/restart_failed',
             onSuccess: function(data) {
                 this.packages.each(function(pack) {
                     pack.close();
@@ -242,7 +242,7 @@ var Package = new Class({
             imgs[0].addEvent('click', function(e) {
                 new Request({
                     method: 'get',
-                    url: '/api/delete_files/[' + this.id + ']',
+                    url: '/api/delete_files/[' + this + ']',
                     onSuccess: function() {
                         $('file_' + this).nix()
                     }.bind(this),
@@ -252,7 +252,7 @@ var Package = new Class({
             imgs[1].addEvent('click', function(e) {
                 new Request({
                     method: 'get',
-                    url: '/api/restartFile/' + this.id,
+                    url: '/api/restart_file/' + this,
                     onSuccess: function() {
                         var ele = $('file_' + this);
                         var imgs = ele.getElements("img");
@@ -282,7 +282,7 @@ var Package = new Class({
         indicateLoad();
         new Request({
             method: 'get',
-            url: '/api/deletePackages/[' + this.id + ']',
+            url: '/api/delete_packages/[' + this.id + ']',
             onSuccess: function() {
                 this.ele.nix();
                 indicateFinish();
@@ -295,7 +295,7 @@ var Package = new Class({
         indicateLoad();
         new Request({
             method: 'get',
-            url: '/api/restartPackage/' + this.id,
+            url: '/api/restart_package/' + this.id,
             onSuccess: function() {
                 this.close();
                 indicateSuccess();


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Change some missing api endpoint in default theme. Also changed api calls from `this.id` to `this` to make the function calls to `delete_files`, `restart_files` work

<!-- WRITE HERE -->

### Is this related to a problem?

The problem only occurs in Default Theme if you try to delete files or restart files in a package. A request to `delete_files/[undefined]` is issued and subsequently the function fails.
![grafik](https://user-images.githubusercontent.com/6438895/93663464-7f72e380-fa68-11ea-8e68-f9eef18deb7e.png)
 -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
