### PR TITLE
[Main] Fix scan download function

### DIFF
--- a/src/pyload/plugins/base/downloader.py
+++ b/src/pyload/plugins/base/downloader.py
@@ -369,7 +369,7 @@ class BaseDownloader(BaseHoster):
             self.log_warning(self._("No file to scan"))
             return
 
-        with open(dl_file, mode="rb") as fp:
+        with open(dl_file, mode="r") as fp:
             content = fp.read(read_size)
 
         #: Produces encoding errors, better log to other file in the future?


### PR DESCRIPTION
### Describe the changes

Open the file in scan_download as normal file instead of binary file to make the regex later on working

### Is this related to a problem?

Trying to download a file from anonfiles (e.g. https://anonfiles.com/v5a2adX7oa/Europa-Report.part1_rar) causes the following traceback:
```
[2020-09-20 07:09:12]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `download_failed`
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 56, in run
    pyfile.plugin.preprocessing(self)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 306, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 101, in _process
    self.process(self.pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/downloaders/Http.py", line 67, in process
    self.check_download()
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/downloaders/Http.py", line 70, in check_download
    errmsg = self.scan_download(
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 383, in scan_download
    m = rule.search(content)
TypeError: cannot use a string pattern on a bytes-like object
```


### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
