### PR TITLE
[Main] Fix dictionary changed size during iteration in abort_all_downloads() and stop()

### DIFF
--- a/src/pyload/core/__init__.py
+++ b/src/pyload/core/__init__.py
@@ -366,7 +366,7 @@ class Core:
             for thread in self.thread_manager.threads:
                 thread.put("quit")
 
-            for pyfile in self.files.cache.values():
+            for pyfile in list(self.files.cache.values()):
                 pyfile.abort_download()
 
             self.addon_manager.core_exiting()

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -868,7 +868,7 @@ class Api:
         """
         Aborts all running downloads.
         """
-        pyfiles = self.pyload.files.cache.values()
+        pyfiles = list(self.pyload.files.cache.values())
         for pyfile in pyfiles:
             pyfile.abort_download()
 


### PR DESCRIPTION
### Describe the changes

I converted both problematic calls to a list similar to the path you applied for fixing #3751

### Is this related to a problem?

Similiar to  #3751 you get the same dictionary changed size during iteration if you press the stop download button while a download is active or if you stop pyload-ng with  a keyboard interrupt (by pressing ctrl+c)


### Additional references

Stopping pyload:
```
[2020-10-10 19:08:08]  INFO                pyload  Download aborted: xxxxx
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/__init__.py", line 331, in start
    time.sleep(1)
KeyboardInterrupt

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/__main__.py", line 120, in run
    pyload_core.start()
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/__init__.py", line 337, in start
    self.terminate()
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/__init__.py", line 354, in terminate
    self.stop()
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/__init__.py", line 371, in stop
    for pyfile in self.files.cache.values():
RuntimeError: dictionary changed size during iteration
python-BaseException
```

Pressing Abort all downloads:
![grafik](https://user-images.githubusercontent.com/6438895/95661154-5efced00-0b2d-11eb-9d9d-a6b6fe47f837.png)

```
[2020-10-10 19:10:35]  INFO                pyload  Download aborted: xxxxx
[2020-10-10 19:10:35]  DEBUG         pyload.webui  Object of type RuntimeError is not JSON serializable
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/api_blueprint.py", line 40, in rpc
    response = call_api(func, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/api_blueprint.py", line 54, in call_api
    result = getattr(api, func)(
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/api/__init__.py", line 80, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/api/__init__.py", line 873, in stop_all_downloads
    for pyfile in pyfiles:
RuntimeError: dictionary changed size during iteration
```