### PR TITLE
[Main] Fix scan download cannot use a string pattern on a bytes-like object

### DIFF
--- a/src/pyload/plugins/base/downloader.py
+++ b/src/pyload/plugins/base/downloader.py
@@ -396,7 +396,7 @@ class BaseDownloader(BaseHoster):
             else:
                 self.error(self._("No file downloaded"))
 
-        elif self.scan_download({"Empty file": re.compile(b"\A((.|)(\2|\s)*)\Z")}):
+        elif self.scan_download({"Empty file": re.compile(rb"\A((.|)(\2|\s)*)\Z")}):
             if self.remove(self.last_download):
                 self.last_download = ""
             self.error(self._("Empty file"))

--- a/src/pyload/plugins/base/downloader.py
+++ b/src/pyload/plugins/base/downloader.py
@@ -8,6 +8,7 @@ from pyload.core.network.exceptions import Fail
 from pyload.core.network.http.exceptions import BadHeader
 from pyload.core.utils import parse
 from pyload.core.utils.old import safejoin
+from pyload.core.utils.convert import to_str
 
 from ..helpers import exists
 from .hoster import BaseHoster
@@ -395,7 +396,7 @@ class BaseDownloader(BaseHoster):
             else:
                 self.error(self._("No file downloaded"))
 
-        elif self.scan_download({"Empty file": re.compile(r"\A((.|)(\2|\s)*)\Z")}):
+        elif self.scan_download({"Empty file": re.compile(b"\A((.|)(\2|\s)*)\Z")}):
             if self.remove(self.last_download):
                 self.last_download = ""
             self.error(self._("Empty file"))

--- a/src/pyload/plugins/base/downloader.py
+++ b/src/pyload/plugins/base/downloader.py
@@ -369,7 +369,7 @@ class BaseDownloader(BaseHoster):
             self.log_warning(self._("No file to scan"))
             return
 
-        with open(dl_file, mode="rb") as fp:
+        with open(dl_file, mode="r") as fp:
             content = fp.read(read_size)
 
         #: Produces encoding errors, better log to other file in the future?

--- a/src/pyload/plugins/base/downloader.py
+++ b/src/pyload/plugins/base/downloader.py
@@ -370,7 +370,7 @@ class BaseDownloader(BaseHoster):
             self.log_warning(self._("No file to scan"))
             return
 
-        with open(dl_file, mode="r") as fp:
+        with open(dl_file, mode="rb") as fp:
             content = fp.read(read_size)
 
         #: Produces encoding errors, better log to other file in the future?

--- a/src/pyload/plugins/base/downloader.py
+++ b/src/pyload/plugins/base/downloader.py
@@ -8,7 +8,6 @@ from pyload.core.network.exceptions import Fail
 from pyload.core.network.http.exceptions import BadHeader
 from pyload.core.utils import parse
 from pyload.core.utils.old import safejoin
-from pyload.core.utils.convert import to_str
 
 from ..helpers import exists
 from .hoster import BaseHoster

--- a/src/pyload/plugins/base/simple_downloader.py
+++ b/src/pyload/plugins/base/simple_downloader.py
@@ -132,10 +132,10 @@ class SimpleDownloader(BaseDownloader):
     FILE_ERRORS = [
         (
             "Html error",
-            r"\A(?:\s*<.+>)?((?:[\w\s]*(?:[Ee]rror|ERROR)\s*\:?)?\s*\d{3})(?:\Z|\s+)",
+            b"\A(?:\s*<.+>)?((?:[\w\s]*(?:[Ee]rror|ERROR)\s*\:?)?\s*\d{3})(?:\Z|\s+)",
         ),
-        ("Request error", r"([Aa]n error occured while processing your request)"),
-        ("Html file", r"\A\s*<!DOCTYPE html"),
+        ("Request error", b"([Aa]n error occured while processing your request)"),
+        ("Html file", b"\A\s*<!DOCTYPE html"),
     ]
 
     @classmethod

--- a/src/pyload/plugins/base/simple_downloader.py
+++ b/src/pyload/plugins/base/simple_downloader.py
@@ -132,10 +132,10 @@ class SimpleDownloader(BaseDownloader):
     FILE_ERRORS = [
         (
             "Html error",
-            b"\A(?:\s*<.+>)?((?:[\w\s]*(?:[Ee]rror|ERROR)\s*\:?)?\s*\d{3})(?:\Z|\s+)",
+            rb"\A(?:\s*<.+>)?((?:[\w\s]*(?:[Ee]rror|ERROR)\s*\:?)?\s*\d{3})(?:\Z|\s+)",
         ),
-        ("Request error", b"([Aa]n error occured while processing your request)"),
-        ("Html file", b"\A\s*<!DOCTYPE html"),
+        ("Request error", rb"([Aa]n error occured while processing your request)"),
+        ("Html file", rb"\A\s*<!DOCTYPE html"),
     ]
 
     @classmethod


### PR DESCRIPTION
### Describe the changes

Convert all regexes in scan_download to binary ones, so binary files can be checked

### Is this related to a problem?

Trying to download a file from anonfiles (e.g. https://anonfiles.com/v5a2adX7oa/Europa-Report.part1_rar) causes the following traceback:
```
[2020-09-20 07:09:12]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `download_failed`
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 56, in run
    pyfile.plugin.preprocessing(self)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 306, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 101, in _process
    self.process(self.pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/downloaders/Http.py", line 67, in process
    self.check_download()
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/downloaders/Http.py", line 70, in check_download
    errmsg = self.scan_download(
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 383, in scan_download
    m = rule.search(content)
TypeError: cannot use a string pattern on a bytes-like object
```


### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
