### PR TITLE
[Main] Fix upload of dlc container

### DIFF
--- a/src/pyload/core/managers/file_manager.py
+++ b/src/pyload/core/managers/file_manager.py
@@ -173,7 +173,7 @@ class FileManager:
 
         e = RemoveEvent("pack", id, "collector" if not p.queue else "queue")
 
-        pyfiles = self.cache.values()
+        pyfiles = list(self.cache.values())
         for pyfile in pyfiles:
             if pyfile.packageid == id:
                 pyfile.abort_download()

--- a/src/pyload/plugins/base/container.py
+++ b/src/pyload/plugins/base/container.py
@@ -48,7 +48,7 @@ class BaseContainer(BaseDecrypter):
 
     def _delete_tmpfile(self):
         if os.path.basename(self.pyfile.name).startswith("tmp_"):
-            self.remove(self.pyfile.url, try_trash=False)
+            self.remove(self.pyfile.url, trash=False)
 
     def _make_tmpfile(self):
         """

--- a/src/pyload/plugins/base/decrypter.py
+++ b/src/pyload/plugins/base/decrypter.py
@@ -102,10 +102,10 @@ class BaseDecrypter(BaseHoster):
                 self.pyload.api.set_package_data(pid, {"password": pack_password})
 
             #: Workaround to do not break API add_package method
-            def set_folder(x):
+            '''def set_folder(x):
                 return self.pyload.api.set_package_data(
                     pid, {"folder": safename(x or "")}
-                )
+                )'''
 
             if not folder_per_package:
                 folder = pack_folder
@@ -119,4 +119,4 @@ class BaseDecrypter(BaseHoster):
                 )
             )
 
-            set_folder(folder)
+            # set_folder(folder)

--- a/src/pyload/plugins/containers/CCF.py
+++ b/src/pyload/plugins/containers/CCF.py
@@ -12,7 +12,7 @@ from ..base.container import BaseContainer
 class CCF(BaseContainer):
     __name__ = "CCF"
     __type__ = "container"
-    __version__ = "0.29"
+    __version__ = "0.30"
     __status__ = "testing"
 
     __pattern__ = r".+\.ccf$"
@@ -30,7 +30,7 @@ class CCF(BaseContainer):
     __description__ = """CCF container decrypter plugin"""
     __license__ = "GPLv3"
     __authors__ = [
-        ("Willnix", "Willnix@pyload.net"),
+        ("Willnix", "Willnix@pyload.org"),
         ("Walter Purcaro", "vuolter@gmail.com"),
     ]
 

--- a/src/pyload/plugins/downloaders/Http.py
+++ b/src/pyload/plugins/downloaders/Http.py
@@ -70,11 +70,11 @@ class Http(BaseDownloader):
         errmsg = self.scan_download(
             {
                 "Html error": re.compile(
-                    r"\A(?:\s*<.+>)?((?:[\w\s]*(?:[Ee]rror|ERROR)\s*\:?)?\s*\d{3})(?:\Z|\s+)"
+                    rb"\A(?:\s*<.+>)?((?:[\w\s]*(?:[Ee]rror|ERROR)\s*\:?)?\s*\d{3})(?:\Z|\s+)"
                 ),
-                "Html file": re.compile(r"\A\s*<!DOCTYPE html"),
+                "Html file": re.compile(rb"\A\s*<!DOCTYPE html"),
                 "Request error": re.compile(
-                    r"([Aa]n error occured while processing your request)"
+                    rb"([Aa]n error occured while processing your request)"
                 ),
             }
         )


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Update dlc decrpter to version 0.34.
Fixed encoding issues with dlc version 0.34
Added DLC in capital letters to recognized container format
version bump CCF files (to be even with stable)
Changed last parameter of container.py remove to trash instead of try_trash
Changed regex in http.py scan_download to binary ones 
Removed `set_folder(folder)` from Crypter.py _create_packages as this leads to the attached debug file (can't set attribute)
Another fix for our old friend dict size changed during iteration in file_manager.py (occured durring deleting packages while they are trying to get downloaded)

All problems (except the last one) occur right after upload of a dlc container.

My sample container is this one:
[MFRR.DLC.txt](https://github.com/pyload/pyload/files/5397506/MFRR.DLC.txt)

<!-- WRITE HERE -->

### Is this related to a problem?

scan_download created the following stack trace:
```
TRACEBACK:
 Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 56, in run
    pyfile.plugin.preprocessing(self)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 304, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 102, in _process
    self.process(self.pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/downloaders/Http.py", line 67, in process
    self.check_download()
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/downloaders/Http.py", line 70, in check_download
    errmsg = self.scan_download(
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 384, in scan_download
    m = rule.search(content)
TypeError: cannot use a string pattern on a bytes-like object
```
container.py remove created the following stack trace:
```
TRACEBACK:
 Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/decrypter_thread.py", line 40, in run
    self.active.plugin.preprocessing(self)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 304, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 294, in _process
    self.process(self.pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/container.py", line 45, in process
    self._delete_tmpfile()
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/container.py", line 51, in _delete_tmpfile
    self.remove(self.pyfile.url, try_trash=False)
TypeError: remove() got an unexpected keyword argument 'try_trash'
 
```

Debug log for set_folder:

[debug_DLC_2020-10-18_13-40-20.zip](https://github.com/pyload/pyload/files/5397486/debug_DLC_2020-10-18_13-40-20.zip)

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
