### PR TITLE
[RapidgatorNet] Fix accountless downloads

### DIFF
--- a/module/plugins/hoster/RapidgatorNet.py
+++ b/module/plugins/hoster/RapidgatorNet.py
@@ -14,7 +14,7 @@ from ..internal.SimpleHoster import SimpleHoster
 class RapidgatorNet(SimpleHoster):
     __name__ = "RapidgatorNet"
     __type__ = "hoster"
-    __version__ = "0.55"
+    __version__ = "0.56"
     __status__ = "testing"
 
     __pattern__ = r'https?://(?:www\.)?(?:rapidgator\.(?:net|asia|)|rg\.to)/file/(?P<ID>\w+)'
@@ -46,7 +46,7 @@ class RapidgatorNet(SimpleHoster):
                                ''
     WAIT_PATTERN = r'(?:Delay between downloads must be not less than|Try again in).+'
 
-    LINK_FREE_PATTERN = r'return \'(http://\w+.rapidgator.net/.*)\';'
+    LINK_FREE_PATTERN = r'return \'(https?://\w+.rapidgator.net/.*)\';'
 
     RECAPTCHA_PATTERN = r'"http://api\.recaptcha\.net/challenge\?k=(.*?)"'
     ADSCAPTCHA_PATTERN = r'(http://api\.adscaptcha\.com/Get\.aspx[^"\']+)'


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

I fixed free Rapidgator downloads by updating the regular expression to include the https protocol.

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

Previously, it would keep looping between "Waiting" and asking for a Captcha, now it works again.

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

Another attempt at #3783, stupid GitHub...
