### PR TITLE
[Main] Update hoerbuchIn and Fix BeautyfulSoup

### DIFF
--- a/src/pyload/plugins/decrypters/DuckCryptInfo.py
+++ b/src/pyload/plugins/decrypters/DuckCryptInfo.py
@@ -49,7 +49,7 @@ class DuckCryptInfo(BaseDecrypter):
         m = re.match(self.__pattern__, html)
         self.log_debug("Redirect to " + m.group(0))
         html = self.load(str(m.group(0)))
-        soup = BeautifulSoup(html)
+        soup = BeautifulSoup(html, 'html.parser')
         cryptlinks = soup.findAll("div", attrs={"class": "folderbox"})
         self.log_debug("Redirect to " + cryptlinks)
         if not cryptlinks:
@@ -60,7 +60,7 @@ class DuckCryptInfo(BaseDecrypter):
 
     def handle_link(self, url):
         html = self.load(url)
-        soup = BeautifulSoup(html)
+        soup = BeautifulSoup(html, 'html.parser')
         self.links = [soup.find("iframe")["src"]]
         if not self.links:
             self.log_info(self._("No link found"))

--- a/src/pyload/plugins/decrypters/HoerbuchIn.py
+++ b/src/pyload/plugins/decrypters/HoerbuchIn.py
@@ -9,10 +9,10 @@ from ..base.decrypter import BaseDecrypter
 class HoerbuchIn(BaseDecrypter):
     __name__ = "HoerbuchIn"
     __type__ = "decrypter"
-    __version__ = "0.67"
+    __version__ = "0.68"
     __status__ = "testing"
 
-    __pattern__ = r"http://(?:www\.)?hoerbuch\.us/(wp/horbucher/\d+/|tp/out\.php\?.+|protection/folder_\d+\.html)"
+    __pattern__ = r"https?://(?:www\.)?hoerbuch\.us/(wp/horbucher/\d+/|tp/out\.php\?.+|protection/folder_\d+\.html)"
     __config__ = [
         ("enabled", "bool", "Activated", True),
         ("use_premium", "bool", "Use premium account if available", True),
@@ -28,12 +28,12 @@ class HoerbuchIn(BaseDecrypter):
     __license__ = "GPLv3"
     __authors__ = [("spoob", "spoob@pyload.net"), ("mkaay", "mkaay@mkaay.de")]
 
-    article = re.compile(r"http://(?:www\.)?hoerbuch\.us/wp/horbucher/\d+/.+/")
-    protection = re.compile(r"http://(?:www\.)?hoerbuch\.us/protection/folder_\d+.html")
+    article = re.compile(r"https?://(?:www\.)?hoerbuch\.us/wp/horbucher/\d+/.+/")
+    protection = re.compile(r"https?://(?:www\.)?hoerbuch\.us/protection/folder_\d+.html")
     uploaded = re.compile(
-        r"http://(?:www\.)?hoerbuch\.us/protection/uploaded/(\w+)\.html"
+        r"https?://(?:www\.)?hoerbuch\.us/protection/uploaded/(\w+)\.html"
     )
-    hoster_links = re.compile(r"http://(?:www\.)?hoerbuch\.us/wp/goto/Download/\d+/")
+    hoster_links = re.compile(r"https?://(?:www\.)?hoerbuch\.us/wp/goto/Download/\d+/")
 
     def decrypt(self, pyfile):
         self.pyfile = pyfile
@@ -41,7 +41,7 @@ class HoerbuchIn(BaseDecrypter):
         if self.article.match(pyfile.url):
             html = self.load(pyfile.url)
             soup = BeautifulSoup(
-                html, convertEntities=BeautifulSoup.BeautifulStoneSoup.HTML_ENTITIES
+                html, 'html.parser'
             )
 
             links = []
@@ -72,7 +72,7 @@ class HoerbuchIn(BaseDecrypter):
         links = []
 
         soup = BeautifulSoup(
-            html, convertEntities=BeautifulSoup.BeautifulStoneSoup.HTML_ENTITIES
+            html, 'html.parser'
         )
 
         for container in soup.findAll("div", attrs={"class": "container"}):

--- a/src/pyload/plugins/downloaders/ZippyshareCom.py
+++ b/src/pyload/plugins/downloaders/ZippyshareCom.py
@@ -73,7 +73,7 @@ class ZippyshareCom(SimpleDownloader):
 
     def get_link(self):
         #: Get all the scripts inside the html body
-        soup = BeautifulSoup(self.data)
+        soup = BeautifulSoup(self.data, 'html.parser')
         scripts = [
             s.getText()
             for s in soup.body.findAll("script", type="text/javascript")


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes
This PR moves all HoerbuchIN link pattern to https

Furthermore it solves issues with BeautifulSoup.

1) According to the documentation of BeautifulSoup, `BeautifulStoneSoup` is deprecated:

[https://www.crummy.com/software/BeautifulSoup/bs4/doc/#xml]()
[https://www.crummy.com/software/BeautifulSoup/bs4/doc/#entities]()

2) After removing the convertEntities in both calls of BeautifulSoup the second output arises on stderr. According to documenatation this can be solved by specifiying a parser. 
https://www.crummy.com/software/BeautifulSoup/bs4/doc/#you-need-a-parser

I changed all calls of BeautyfulSoup in all 3 affected plugins:
- HoerbuchIn
- ZippyshareCom
- DuckCryptInfo

<!-- WRITE HERE -->

### Is this related to a problem?

1)
```
[2020-10-21 18:21:32]  INFO                pyload  DECRYPTER HoerbuchIn[11]: Processing url: https://www.hoerbuch.us/protection/folder_148937.html
[2020-10-21 18:21:32]  DEBUG               pyload  DECRYPTER HoerbuchIn[11]: LOAD URL https://www.hoerbuch.us/protection/folder_148937.html | get={} | post={'viewed': 'adpg'} | ref=True | cookies=True | just_header=False | decode=True | multipart=False | redirect=True | req=None
[2020-10-21 18:21:33]  WARNING             pyload  Decrypting failed: folder_148937.html | type object 'BeautifulSoup' has no attribute 'BeautifulStoneSoup'
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/decrypter_thread.py", line 40, in run
    self.active.plugin.preprocessing(self)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 304, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 294, in _process
    self.process(self.pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/decrypter.py", line 42, in process
    self.decrypt(pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/decrypters/HoerbuchIn.py", line 54, in decrypt
    self.links = self.decrypt_folder(pyfile.url)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/decrypters/HoerbuchIn.py", line 75, in decrypt_folder
    html, convertEntities=BeautifulSoup.BeautifulStoneSoup.HTML_ENTITIES # 'html.parser'
AttributeError: type object 'BeautifulSoup' has no attribute 'BeautifulStoneSoup'
[2020-10-21 18:21:33]  INFO                pyload  Debug Report written to /tmp/pyLoad/debug_HoerbuchIn_2020-10-21_18-21-33.zip

```

2)
```
[2020-10-21 18:23:59]  DEBUG               pyload  DECRYPTER HoerbuchIn[11]: LOAD URL https://www.hoerbuch.us/protection/folder_148937.html | get={} | post={'viewed': 'adpg'} | ref=True | cookies=True | just_header=False | decode=True | multipart=False | redirect=True | req=None
/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/decrypters/HoerbuchIn.py:74: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.
The code that caused this warning is on line 74 of the file /home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/decrypters/HoerbuchIn.py. To get rid of this warning, pass the additional argument 'features="lxml"' to the BeautifulSoup constructor.
  soup = BeautifulSoup(

```


<!-- WRITE HERE - OPTIONAL -->

### Additional references

Pull request #3788 does the same for stable 
