### PR TITLE
[Main] Fix _setup_permissions - gid should be integer, not str

### DIFF
--- a/src/pyload/core/__init__.py
+++ b/src/pyload/core/__init__.py
@@ -196,7 +196,9 @@ class Core:
 
         if change_group:
             try:
-                group = self.config.get("permission", "group")
+                from grp import getgrnam
+                
+                group = getgrnam(self.config.get("permission", "group"))
                 os.setgid(group[2])
             except Exception as exc:
                 self.log.warning(
@@ -208,7 +210,9 @@ class Core:
 
         if change_user:
             try:
-                user = self.config.get("permission", "user")
+                from pwd import getpwnam
+                
+                user = getpwnam(self.config.get("permission", "user"))
                 os.setuid(user[2])
             except Exception as exc:
                 self.log.warning(


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes


<!-- WRITE HERE -->

### Is this related to a problem?

After starting pyload, go to Settings page -> Permissions and set "Change group of running process" and "Change user of running process" to "on". After a restart of pyload-ng the following traceback is thrown:

```
Traceback (most recent call last):
  File "/opt/pyload3/lib/python3.6/site-packages/pyload/core/__init__.py", line 200, in _setup_permissions
    os.setgid(group[2])
TypeError: gid should be integer, not str

```

Reason: During refactoring the imports of grp and pwd have been removed, so setid is called with str instead of the right object. This PR fixes this.
 
### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
![grafik](https://user-images.githubusercontent.com/6438895/97083548-1bb47b00-1611-11eb-8a54-260537212c1c.png)

