### PR TITLE
[Main] Fix ExtractArchive and related Plugins

### DIFF
--- a/src/pyload/core/managers/file_manager.py
+++ b/src/pyload/core/managers/file_manager.py
@@ -439,7 +439,7 @@ class FileManager:
         """
         restart package.
         """
-        pyfiles = self.cache.values()
+        pyfiles = list(self.cache.values())
         for pyfile in pyfiles:
             if pyfile.packageid == id:
                 self.restart_file(pyfile.id)

--- a/src/pyload/plugins/addons/ExtractArchive.py
+++ b/src/pyload/plugins/addons/ExtractArchive.py
@@ -6,7 +6,7 @@ from pyload.core.utils.old import safename
 from pyload.core.utils.purge import uniquify
 
 from ..base.addon import BaseAddon, expose, threaded
-from ..base.extractor import ArchiveError, CRCError, PasswordError
+from ..base.Extractor import ArchiveError, CRCError, PasswordError
 from ..helpers import exists
 
 try:

--- a/src/pyload/plugins/addons/ExtractArchive.py
+++ b/src/pyload/plugins/addons/ExtractArchive.py
@@ -636,7 +636,7 @@ class ExtractArchive(BaseAddon):
             self.passwords = uniquify([password] + self.passwords)
 
             file = os.fsdecode(self.config.get("passwordfile"))
-            with open(file, mode="wb") as fp:
+            with open(file, mode="w") as fp:
                 for pw in self.passwords:
                     fp.write(pw + "\n")
 

--- a/src/pyload/plugins/addons/ExtractArchive.py
+++ b/src/pyload/plugins/addons/ExtractArchive.py
@@ -352,7 +352,7 @@ class ExtractArchive(BaseAddon):
                             self.log_debug(f"Extracted files: {new_files}")
 
                             new_folders = uniquify(
-                                os.path.dirname(f) for f in new_files
+                                [os.path.dirname(f) for f in new_files]
                             )
                             for foldername in new_folders:
                                 self.set_permissions(

--- a/src/pyload/plugins/addons/ExtractArchive.py
+++ b/src/pyload/plugins/addons/ExtractArchive.py
@@ -12,7 +12,7 @@ from ..helpers import exists
 try:
     import send2trash
 except ImportError:
-    send2trash = None
+    pass
 
 
 class ArchiveQueue:
@@ -53,7 +53,7 @@ class ArchiveQueue:
 class ExtractArchive(BaseAddon):
     __name__ = "ExtractArchive"
     __type__ = "addon"
-    __version__ = "1.67"
+    __version__ = "1.69"
     __status__ = "testing"
 
     __config__ = [
@@ -100,7 +100,6 @@ class ExtractArchive(BaseAddon):
         }
 
         self.queue = ArchiveQueue(self, "Queue")
-        self.failed = ArchiveQueue(self, "Failed")
 
         self.extracting = False
         self.last_package = False
@@ -109,7 +108,7 @@ class ExtractArchive(BaseAddon):
         self.repair = False
 
     def activate(self):
-        for p in ("UnRar", "SevenZip", "UnZip", "UnTar"):
+        for p in ("HjSplit", "UnRar", "SevenZip", "UnZip", "UnTar"):
             try:
                 module = self.pyload.plugin_manager.load_module("base", p)
                 klass = getattr(module, p)
@@ -255,10 +254,11 @@ class ExtractArchive(BaseAddon):
                     extract_folder,
                     pypack.folder or safename(pypack.name.replace("http://", "")),
                 )
+            if not exists(extract_folder):
+                os.makedirs(extract_folder)
 
-            os.makedirs(extract_folder, exist_ok=True)
-            if subfolder:
-                self.set_permissions(extract_folder)
+                if subfolder:
+                    self.set_permissions(extract_folder)
 
             matched = False
             success = True
@@ -422,7 +422,6 @@ class ExtractArchive(BaseAddon):
                     failed.append(pid)
                     self.m.dispatch_event("package_extract_failed", pypack)
 
-                    self.failed.add(pid)
             else:
                 self.log_info(self._("No files found to extract"))
 
@@ -611,8 +610,8 @@ class ExtractArchive(BaseAddon):
 
         except IOError as exc:
             if exc.errno == 2:
-                fp = open(file, mode="w")
-                fp.close()
+                with open(file, mode="wb") as f:
+                    pass
 
             else:
                 self.log_error(exc)

--- a/src/pyload/plugins/base/Extractor.py
+++ b/src/pyload/plugins/base/Extractor.py
@@ -7,27 +7,21 @@ from .plugin import BasePlugin
 
 
 class ArchiveError(Exception):
-    """
-    raised when Archive error.
-    """
+    pass
 
 
 class CRCError(Exception):
-    """
-    raised when CRC error.
-    """
+    pass
 
 
 class PasswordError(Exception):
-    """
-    raised when password error.
-    """
+    pass
 
 
 class BaseExtractor(BasePlugin):
     __name__ = "BaseExtractor"
-    __type__ = "base"
-    __version__ = "0.48"
+    __type__ = "extractor"
+    __version__ = "0.49"
     __status__ = "stable"
 
     __description__ = """Base extractor plugin"""
@@ -47,8 +41,7 @@ class BaseExtractor(BasePlugin):
     @classmethod
     def archivetype(cls, filename):
         """
-        Get archive default extension from filename.
-
+        Get archive default extension from filename
         :param filename: file name to test
         :return: Extension or None
         """
@@ -84,15 +77,14 @@ class BaseExtractor(BasePlugin):
     @classmethod
     def find(cls):
         """
-        Check if system statisfy dependencies.
+        Check if system statisfy dependencies
         """
         pass
 
     @classmethod
     def get_targets(cls, files_ids):
         """
-        Filter suited targets from list of filename id tuple list.
-
+        Filter suited targets from list of filename id tuple list
         :param files_ids: List of filepathes
         :return: List of targets, id tuple list
         """
@@ -156,7 +148,7 @@ class BaseExtractor(BasePlugin):
     def verify(self, password=None):
         """
         Testing with Extractors built-in method Raise error if password is needed,
-        integrity is questionable or else.
+        integrity is questionable or else
         """
         pass
 
@@ -165,19 +157,19 @@ class BaseExtractor(BasePlugin):
 
     def extract(self, password=None):
         """
-        Extract the archive Raise specific errors in case of failure.
+        Extract the archive Raise specific errors in case of failure
         """
         raise NotImplementedError
 
     def chunks(self):
         """
-        Return list of archive parts.
+        Return list of archive parts
         """
         return [self.filename]
 
     def list(self, password=None):
         """
-        Return list of archive files.
+        Return list of archive files
         """
         raise NotImplementedError
 

--- a/src/pyload/plugins/base/HjSplit.py
+++ b/src/pyload/plugins/base/HjSplit.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import with_statement
+
+import os
+import re
+
+from .Extractor import ArchiveError, Extractor
+from .misc import exists, fsjoin
+
+
+class HjSplit(Extractor):
+    __name__ = "HjSplit"
+    __type__ = "extractor"
+    __version__ = "0.02"
+    __status__ = "testing"
+
+    __description__ = """HJSPLIT extractor plugin"""
+    __license__ = "GPLv3"
+    __authors__ = [("GammaC0de", "nitzo2001[AT]yahoo[DOT]com")]
+
+    VERSION = __version__
+
+    EXTENSIONS = [("001", r'(?<!7z\.)001')]
+
+    _RE_PART = re.compile(r'(?<!\.7z)\.\d{3}$')
+
+    BUFFER_SIZE = 4096
+
+    @classmethod
+    def find(cls):
+        return True
+
+    @classmethod
+    def ismultipart(cls, filename):
+        return True if cls._RE_PART.search(filename) else False
+
+    def chunks(self):
+        files = []
+        dir, name = os.path.split(self.filename)
+
+        #: eventually Multipart Files
+        files.extend(fsjoin(dir, os.path.basename(_f))
+                     for _f in filter(self.ismultipart, [_x[1]['name'] for _x in self.pyfile.package().getChildren().items()])
+                     if self._RE_PART.sub("", name) == self._RE_PART.sub("", _f))
+
+        #: Actually extracted file
+        if self.filename not in files:
+            files.append(self.filename)
+
+        return files
+
+    def list(self, password=None):
+        return [self.filename[:-4]]
+
+    def extract(self, password=None):
+        file_list = []
+        size_total = 0
+        name = os.path.basename(self.filename)[:-4]
+
+        chunks = sorted(self.chunks())
+        num_chunks = len(chunks)
+
+        #: Verify HjSplit consistency
+        if len(chunks) == 1:
+            raise ArchiveError("Cannot merge just one chunk '%s'" % chunks[0])
+
+        for i in range(0, num_chunks):
+            if not exists(chunks[i]):
+                raise ArchiveError("Chunk '%s' not found" % chunks[i])
+
+            if i == 0:
+                chunk_size = os.path.getsize(chunks[i])
+
+            else:
+                if int(chunks[i][-3:]) != i + 1:
+                    missing_chunk = "%s.%03d" %(os.path.splitext(chunks[i])[0], i + 1)
+                    raise ArchiveError("Chunk '%s' is missing" % missing_chunk)
+
+                if i < num_chunks - 1:
+                    if os.path.getsize(chunks[i]) != chunk_size:
+                        raise ArchiveError("Invalid chunk size for chunk '%s'" % chunks[i])
+
+                    size_total += chunk_size
+
+                else:
+                    size_total += os.path.getsize(chunks[i])
+
+        #: Now do the actual merge
+        with open(fsjoin(self.dest, name), "wb") as output_file:
+            size_written = 0
+            for part_filename in chunks:
+                self.log_debug("Merging part", part_filename)
+
+                with open(part_filename, "rb") as part_file:
+                    while True:
+                        f_buffer = part_file.read(self.BUFFER_SIZE)
+                        if f_buffer:
+                            output_file.write(f_buffer)
+                            size_written += len(f_buffer)
+                            self.pyfile.setProgress((size_written * 100) / size_total)
+                        else:
+                            break
+
+                self.log_debug("Finished merging part", part_filename)
+
+            self.pyfile.setProgress(100)

--- a/src/pyload/plugins/base/SevenZip.py
+++ b/src/pyload/plugins/base/SevenZip.py
@@ -75,7 +75,7 @@ class SevenZip(BaseExtractor):
     )
     _RE_BADCRC = re.compile(r"CRC Failed|Can not open file", re.I)
     _RE_VERSION = re.compile(
-        r"7-Zip\s(?:\(\w+\)\s)?(?:\[(?:32|64)\]\s)?(\d+\.\d+)", re.I
+        rb"7-Zip\s(?:\(\w+\)\s)?(?:\[(?:32|64)\]\s)?(\d+\.\d+)", re.I
     )
 
     @classmethod
@@ -194,7 +194,7 @@ class SevenZip(BaseExtractor):
             f = groups[-1].strip()
             if not self.fullpath:
                 f = os.path.basename(f)
-            files.add(fsjoin(self.dest, f))
+            files.add(os.path.join(self.dest, f))
 
         self.files = list(files)
 

--- a/src/pyload/plugins/base/SevenZip.py
+++ b/src/pyload/plugins/base/SevenZip.py
@@ -7,7 +7,7 @@ import subprocess
 from pyload import PKGDIR
 
 from ..helpers import renice
-from .extractor import ArchiveError, BaseExtractor, CRCError, PasswordError
+from .Extractor import ArchiveError, BaseExtractor, CRCError, PasswordError
 
 
 class SevenZip(BaseExtractor):

--- a/src/pyload/plugins/base/UnRar.py
+++ b/src/pyload/plugins/base/UnRar.py
@@ -88,7 +88,7 @@ class UnRar(BaseExtractor):
 
         m = cls._RE_VERSION.search(out)
         if m is not None:
-            cls.VERSION = m.group(1)
+            cls.VERSION = to_str(m.group(1))
             cls._RE_FILES = cls._RE_FILES_V4 if float(cls.VERSION) < 5 else cls._RE_FILES_V5
 
         return True
@@ -101,6 +101,7 @@ class UnRar(BaseExtractor):
         p = self.call_cmd("l", "-v", self.filename, password=password)
         out, err = (r.strip() if r else "" for r in p.communicate())
 
+        err = to_str(err)
         if self._RE_BADPWD.search(err):
             raise PasswordError
 
@@ -109,7 +110,7 @@ class UnRar(BaseExtractor):
 
         #: Output only used to check if passworded files are present
         for groups in self._RE_FILES.findall(out):
-            if groups[0] == "*":
+            if groups[0] == b"*":
                 raise PasswordError
 
     def repair(self):
@@ -119,6 +120,7 @@ class UnRar(BaseExtractor):
         self.progress(p)
         out, err = (r.strip() if r else "" for r in p.communicate())
 
+        err = to_str(err)
         if err or p.returncode:
             p = self.call_cmd("r", self.filename)
 
@@ -145,7 +147,7 @@ class UnRar(BaseExtractor):
             if not c:
                 break
             #: Reading a percentage sign -> set progress and restart
-            if c == "%" and s:
+            if c == b"%" and s:
                 self.pyfile.set_progress(int(s))
                 s = ""
             #: Not reading a digit -> therefore restart
@@ -164,6 +166,7 @@ class UnRar(BaseExtractor):
         self.progress(p)
         out, err = (r.strip() if r else "" for r in p.communicate())
 
+        err=to_str(err)
         if err:
             if self._RE_BADPWD.search(err):
                 raise PasswordError

--- a/src/pyload/plugins/base/UnRar.py
+++ b/src/pyload/plugins/base/UnRar.py
@@ -7,7 +7,7 @@ import subprocess
 from pyload import PKGDIR
 
 from ..helpers import renice
-from .extractor import ArchiveError, BaseExtractor, CRCError, PasswordError
+from .Extractor import ArchiveError, BaseExtractor, CRCError, PasswordError
 
 
 class UnRar(BaseExtractor):

--- a/src/pyload/plugins/base/UnTar.py
+++ b/src/pyload/plugins/base/UnTar.py
@@ -4,7 +4,7 @@ import os
 import sys
 import tarfile
 
-from .extractor import ArchiveError, BaseExtractor, CRCError
+from .Extractor import ArchiveError, BaseExtractor, CRCError
 
 
 class UnTar(BaseExtractor):

--- a/src/pyload/plugins/base/UnTar.py
+++ b/src/pyload/plugins/base/UnTar.py
@@ -10,7 +10,7 @@ from .extractor import ArchiveError, BaseExtractor, CRCError
 class UnTar(BaseExtractor):
     __name__ = "UnTar"
     __type__ = "extractor"
-    __version__ = "0.04"
+    __version__ = "0.05"
     __status__ = "stable"
 
     __description__ = """TAR extractor plugin"""
@@ -34,7 +34,7 @@ class UnTar(BaseExtractor):
 
     def list(self, password=None):
         with tarfile.open(self.filename) as t:
-            self.files = t.getnames()
+            self.files = [os.path.join(self.dest, f) for f in t.getnames()]
         return self.files
 
     def verify(self, password=None):

--- a/src/pyload/plugins/base/UnZip.py
+++ b/src/pyload/plugins/base/UnZip.py
@@ -33,7 +33,7 @@ class UnZip(BaseExtractor):
     def isarchive(cls, filename):
         #: zipfile only checks for 'End of archive' so we have to check ourselves for 'start of archive'
         try:
-            with open(fs_encode(filename), "rb") as f:
+            with open(os.fsdecode(filename), "rb") as f:
                 data = f.read(4)
                 if data != "PK\003\004":
                     return False

--- a/src/pyload/plugins/base/UnZip.py
+++ b/src/pyload/plugins/base/UnZip.py
@@ -4,7 +4,7 @@ import os
 import sys
 import zipfile
 
-from .extractor import ArchiveError, BaseExtractor, CRCError, PasswordError
+from .Extractor import ArchiveError, BaseExtractor, CRCError, PasswordError
 
 
 class UnZip(BaseExtractor):


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

This PR makes the ExtractArchive plugin working:
Rename unrar.py, unzip.py, extractor ...  to UnRar, UnZip, Extractor .. because otherwise the plugins haven't been found
Updated the relevant Plugins to the least recent version on stable
Added HJSplit Plugin from stable

<!-- WRITE HERE -->

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
