### PR TITLE
 [Main] Fix rename Package

### DIFF
--- a/src/pyload/webui/app/blueprints/json_blueprint.py
+++ b/src/pyload/webui/app/blueprints/json_blueprint.py
@@ -193,7 +193,7 @@ def edit_package():
         id = int(flask.request.form["pack_id"])
         data = {
             "name": flask.request.form["pack_name"],
-            "folder": flask.request.form["pack_folder"],
+            "_folder": flask.request.form["pack_folder"],
             "password": flask.request.form["pack_pws"],
         }
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Changing package name lead to a traceback. I changed "folder to "_folder" in /edit_package routine

### Is this related to a problem?

```
[2020-10-24 16:32:36]  DEBUG         pyload.webui  500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/json_blueprint.py", line 201, in edit_package
    api.set_package_data(id, data)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/api/__init__.py", line 80, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/api/__init__.py", line 987, in set_package_data
    setattr(p, key, value)
AttributeError: can't set attribute

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/helpers.py", line 181, in wrapper
    response = func(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/json_blueprint.py", line 205, in edit_package
    flask.abort(500)
  File "/usr/local/lib/python3.8/dist-packages/werkzeug/exceptions.py", line 822, in abort
    return _aborter(status, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/werkzeug/exceptions.py", line 807, in __call__
    raise self.mapping[code](*args, **kwargs)
werkzeug.exceptions.InternalServerError: 500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.

```
### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
