### PR TITLE
[Main] Fix decode header

### DIFF
--- a/src/pyload/plugins/helpers.py
+++ b/src/pyload/plugins/helpers.py
@@ -434,7 +434,7 @@ def set_cookies(cj, cookies):
 
 
 def parse_html_header(header):
-    header = str(header)
+    header = header.decode('utf-8')
 
     hdict = {}
     _re = r"[ ]*(?P<key>.+?)[ ]*:[ ]*(?P<value>.+?)[ ]*\r?\n"


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

The header is decoded from a binary header variable by casting the variable to str. This creates a scrappy header variable with content like:
`b'HTTP/2 302 \r\ndate: Sat...PRG\r\n\r\n'`

where the header variables can't be extracted from. The PR uses a .decode('utf-8')  Instead.

The behavior can be observed by using this download link:

https://ddownload.com/w14i1dpjtnay

(The captcha is requested, the link is also retrieved, but not recognized, therefore pyload tries to reload the link, the website knows that we are having the link and let's us 2 hours wait..)


<!-- WRITE HERE -->
### Is this related to a problem?

Download with ddownload.org not working.

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
