### PR TITLE
[Main] Fix mismerge file_manager

### DIFF
--- a/src/pyload/core/managers/file_manager.py
+++ b/src/pyload/core/managers/file_manager.py
@@ -439,7 +439,7 @@ class FileManager:
         """
         restart package.
         """
-        pyfiles = self.cache.values()
+        pyfiles = list(self.cache.values())
         for pyfile in pyfiles:
             if pyfile.packageid == id:
                 self.restart_file(pyfile.id)


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

In https://github.com/pyload/pyload/commit/40243ee5dfbea268dd0cea6f12aaa125e346a342
file_manager was changed to prevent a size changed during iteration bug, this was accidentally reverted during the last merges.
![grafik](https://user-images.githubusercontent.com/6438895/97101596-2c133700-169f-11eb-84d9-67e214bedf83.png)

Current version on develop:
![grafik](https://user-images.githubusercontent.com/6438895/97101639-6aa8f180-169f-11eb-9f64-8f89f8f1abcd.png)


<!-- A clear and concise description of what you've done. -->

<!-- WRITE HERE -->

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
