### PR TITLE
[Main] Fix turbobit (cookies, link, redirects)

### DIFF
--- a/src/pyload/core/managers/file_manager.py
+++ b/src/pyload/core/managers/file_manager.py
@@ -439,7 +439,7 @@ class FileManager:
         """
         restart package.
         """
-        pyfiles = self.cache.values()
+        pyfiles = list(self.cache.values())
         for pyfile in pyfiles:
             if pyfile.packageid == id:
                 self.restart_file(pyfile.id)

--- a/src/pyload/core/network/cookie_jar.py
+++ b/src/pyload/core/network/cookie_jar.py
@@ -33,11 +33,11 @@ class CookieJar:
         name,
         value,
         path="/",
-        exp=time.time() + timedelta(hours=744).seconds,  #: 31 days retention
+        exp=time.time() + timedelta(hours=744).total_seconds(),  #: 31 days retention
     ):
         self.cookies[
             name
-        ] = f".{domain}    TRUE    {path}    FALSE    {exp}    {name}    {value}"
+        ] = f".{domain}\tTRUE\t{path}\tFALSE\t{exp}\t{name}\t{value}"
 
     def clear(self):
         self.cookies = {}

--- a/src/pyload/plugins/base/plugin.py
+++ b/src/pyload/plugins/base/plugin.py
@@ -200,7 +200,7 @@ class BasePlugin:
             # NOTE: req can be a HTTPRequest or a Browser object
             http_req.c.setopt(pycurl.FOLLOWLOCATION, 0)
 
-        elif isinstance(redirect, int):
+        elif type(redirect) is int:
             # NOTE: req can be a HTTPRequest or a Browser object
             http_req.c.setopt(pycurl.MAXREDIRS, redirect)
 
@@ -224,7 +224,7 @@ class BasePlugin:
             # NOTE: req can be a HTTPRequest or a Browser object
             http_req.c.setopt(pycurl.FOLLOWLOCATION, 1)
 
-        elif isinstance(redirect, int):
+        elif type(redirect) is int:
             maxredirs = (
                 int(
                     self.pyload.api.get_config_value(

--- a/src/pyload/plugins/base/simple_downloader.py
+++ b/src/pyload/plugins/base/simple_downloader.py
@@ -354,11 +354,6 @@ class SimpleDownloader(BaseDownloader):
         if not self.data:
             self.log_warning(self._("No data to check"))
             return
-        else:
-            if isinstance(self.data, bytes):
-                self.log_debug(self._("No check on binary data"))
-                return
-
 
         if self.IP_BLOCKED_PATTERN and re.search(self.IP_BLOCKED_PATTERN, self.data):
             self.fail(self._("Connection from your current IP address is not allowed"))

--- a/src/pyload/plugins/base/simple_downloader.py
+++ b/src/pyload/plugins/base/simple_downloader.py
@@ -354,6 +354,11 @@ class SimpleDownloader(BaseDownloader):
         if not self.data:
             self.log_warning(self._("No data to check"))
             return
+        else:
+            if isinstance(self.data, bytes):
+                self.log_debug(self._("No check on binary data"))
+                return
+
 
         if self.IP_BLOCKED_PATTERN and re.search(self.IP_BLOCKED_PATTERN, self.data):
             self.fail(self._("Connection from your current IP address is not allowed"))

--- a/src/pyload/plugins/downloaders/TurbobitNet.py
+++ b/src/pyload/plugins/downloaders/TurbobitNet.py
@@ -48,7 +48,7 @@ class TurbobitNet(SimpleDownloader):
     LIMIT_WAIT_PATTERN = r"<div id=\'timeout\'>(\d+)<"
 
     def handle_free(self, pyfile):
-        self.free_url = "http://turbobit.net/download/free/{}".format(
+        self.free_url = "https://turbobit.net/download/free/{}".format(
             self.info["pattern"]["ID"]
         )
         self.data = self.load(self.free_url)

--- a/src/pyload/plugins/downloaders/TurbobitNet.py
+++ b/src/pyload/plugins/downloaders/TurbobitNet.py
@@ -12,10 +12,10 @@ from ..base.simple_downloader import SimpleDownloader
 class TurbobitNet(SimpleDownloader):
     __name__ = "TurbobitNet"
     __type__ = "downloader"
-    __version__ = "0.33"
+    __version__ = "0.37"
     __status__ = "testing"
 
-    __pattern__ = r"http://(?:www\.)?turbobit\.net/(?:download/free/)?(?P<ID>\w+)"
+    __pattern__ = r'https?://(?:(?:www|m)\.)?(?:turbobit\.net|turbo?\.(?:to|cc))/(?:download/free/)?(?P<ID>\w+)'
     __config__ = [
         ("enabled", "bool", "Activated", True),
         ("use_premium", "bool", "Use premium account if available", True),
@@ -33,6 +33,7 @@ class TurbobitNet(SimpleDownloader):
     ]
 
     URL_REPLACEMENTS = [(__pattern__ + ".*", r"https://turbobit.net/\g<ID>.html")]
+    SIZE_REPLACEMENTS = [(r' ', "")]
 
     COOKIES = [("turbobit.net", "user_lang", "en")]
 
@@ -40,7 +41,7 @@ class TurbobitNet(SimpleDownloader):
         r"<title>\s*Download file (?P<N>.+?) \((?P<S>[\d.,]+) (?P<U>[\w^_]+)\)"
     )
     OFFLINE_PATTERN = r"<h2>File Not Found</h2>|html\(\'File (?:was )?not found"
-    TEMP_OFFLINE_PATTERN = r""
+    TEMP_OFFLINE_PATTERN = r'^unmatchable$'
 
     LINK_FREE_PATTERN = r'(/download/redirect/[^"\']+)'
     LINK_PREMIUM_PATTERN = r'<a href=[\'"](.+?/download/redirect/[^"\']+)'
@@ -68,7 +69,7 @@ class TurbobitNet(SimpleDownloader):
 
         self.req.http.c.setopt(pycurl.HTTPHEADER, ["X-Requested-With: XMLHttpRequest"])
         self.data = self.load(
-            "http://turbobit.net/download/getLinkTimeout/{}".format(
+            "https://turbobit.net/download/getLinkTimeout/{}".format(
                 self.info["pattern"]["ID"]
             ),
             ref=self.free_url,
@@ -77,14 +78,14 @@ class TurbobitNet(SimpleDownloader):
 
         if "/download/started/" in self.data:
             self.data = self.load(
-                "http://turbobit.net/download/started/{}".format(
+                "https://turbobit.net/download/started/{}".format(
                     self.info["pattern"]["ID"]
                 )
             )
 
             m = re.search(self.LINK_FREE_PATTERN, self.data)
             if m is not None:
-                self.link = "http://turbobit.net{}".format(m.group(1))
+                self.link = "https://turbobit.net{}".format(m.group(1))
 
     def solve_captcha(self):
         action, inputs = self.parse_html_form("action='#'")

--- a/src/pyload/plugins/helpers.py
+++ b/src/pyload/plugins/helpers.py
@@ -418,7 +418,7 @@ def replace_patterns(value, rules):
 
 # TODO: Remove in 0.6.x and fix exp in CookieJar.set_cookie
 def set_cookie(
-    cj, domain, name, value, path="/", exp=time.time() + timedelta(hours=744).seconds
+    cj, domain, name, value, path="/", exp=time.time() + timedelta(hours=744).total_seconds()
 ):  #: 31 days retention
     args = [domain, name, value, path, int(exp)]
     return cj.set_cookie(*args)


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Trying to download a link from turbobit.com, e.g.: https://turbobit.net/bggojpnkq4pt.html

Several changes were needed to make this work:

1) plugin.py the checks for redirect beeing an int is done with isinstance, this also returns true if the class is a derived class, this is the case for int and bool, so I changed it back to type(..) is (chnaged behavior for pyload-ng and pyload, I don't know if this might be intentionally

2) The calls to  set_cookie set the parameter exp with ..timedelta().seconds, this only returns the modulo of minutes/hours/days in seconds, right would be `.total_seconds()`. Currently the cookie expieres instantly, as the timedelta has no left seconds for exactly 31 days timeoffset. This caused turbobit not to accept the cookie as it is expired.

3) In set cookie the original code put \t as delimiter between the single elements, now it's spaces, I reverted it to \t and put \t in the code instead of the invisible tabs, which might get converted to spaces at one time

4) self.free_url in Plugin Turbobit.net is wrong merged from stable should be http**s**://.. instaed of http://..

<!-- WRITE HERE -->

Downloads from turbobit don't work.

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

No debug logs are written, just the download after solving the captcha returns a webpage with capcha in it, instaed of the page with the wait pattern