### PR TITLE
[Main] Fix check errors after download from ddl

### DIFF
--- a/src/pyload/plugins/base/simple_downloader.py
+++ b/src/pyload/plugins/base/simple_downloader.py
@@ -354,6 +354,11 @@ class SimpleDownloader(BaseDownloader):
         if not self.data:
             self.log_warning(self._("No data to check"))
             return
+        else:
+            if isinstance(self.data, bytes):
+                self.log_debug(self._("No check on binary data"))
+                return
+
 
         if self.IP_BLOCKED_PATTERN and re.search(self.IP_BLOCKED_PATTERN, self.data):
             self.fail(self._("Connection from your current IP address is not allowed"))


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

After download of a link from ddl pyloadng creates a traceback. Example link: https://ddownload.com/xwp7x8o5ndqw

This is because the downloaded file (binary one is checked against str regex).
I see 2 possibilitys: 

1) Convert self.data on demand to binary .encode('utf-8') and also convert all regexes to binary regexes. A conversion of self.data to str didn't succeed for me as some binary data couldn't converted (see example link)
2) Abort check if self.data is binary, this is what this PR does

### Is this related to a problem?
```

[2020-10-25 07:07:09]  INFO                pyload  DOWNLOADER DdlTo[11]: Link status: online
[2020-10-25 07:07:09]  INFO                pyload  DOWNLOADER DdlTo[11]: Processing url: https://ddownload.com/xwp7x8o5ndqw
[2020-10-25 07:07:09]  DEBUG               pyload  DOWNLOADER DdlTo[11]: LOAD URL https://ddownload.com/xwp7x8o5ndqw | get={} | post={} | ref=False | cookies=True | just_header=False | decode=True | multipart=False | redirect=True | req=None
[2020-10-25 07:07:09]  INFO                pyload  DOWNLOADER DdlTo[11]: Checking for link errors...
[2020-10-25 07:07:09]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `download_processed`
[2020-10-25 07:07:09]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `package_processed`
[2020-10-25 07:07:09]  WARNING             pyload  Download failed: bcornwell-usaga-bd12[b].rar | cannot use a bytes pattern on a string-like object
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 56, in run
    pyfile.plugin.preprocessing(self)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 304, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 102, in _process
    self.process(self.pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/simple_downloader.py", line 297, in process
    if self.info.get("status", 7) != 2:
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/simple_downloader.py", line 363, in check_errors
    if self.PREMIUM_ONLY_PATTERN and re.search(
  File "/usr/lib/python3.8/re.py", line 201, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a bytes pattern on a string-like object

```
### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
