### PR TITLE
[Main] Added Errorhandler for Error 404

### DIFF
--- a/src/pyload/webui/app/handlers.py
+++ b/src/pyload/webui/app/handlers.py
@@ -7,6 +7,11 @@ import flask
 from .helpers import render_template
 
 
+def handle_404(exc):
+    flask.current_app.logger.debug("Error 404 - Requested URL: {}".format(flask.request.base_url))
+    messages = [f"Error {exc.code}: {exc.description}"]
+    return render_template('error.html', messages=messages), 404
+
 def handle_error(exc):
     tb = traceback.format_exc()
     try:
@@ -22,4 +27,4 @@ def handle_error(exc):
     return render_template("error.html", messages=messages), code
 
 
-ERROR_HANDLERS = [(Exception, handle_error)]
+ERROR_HANDLERS = [(Exception, handle_error), (404, handle_404)]


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Currently all calls to an not existing endpoint throw a traceback in the log:

```
[2020-10-25 08:10:23]  DEBUG         pyload.webui  404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.8/dist-packages/flask/helpers.py", line 1083, in send_static_file
    return send_from_directory(
  File "/usr/local/lib/python3.8/dist-packages/flask/helpers.py", line 767, in send_from_directory
    raise NotFound()
werkzeug.exceptions.NotFound: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
[2020-10-25 08:10:23]  DEBUG         pyload.webui  404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python3.8/dist-packages/flask/helpers.py", line 1083, in send_static_file
    return send_from_directory(
  File "/usr/local/lib/python3.8/dist-packages/flask/helpers.py", line 767, in send_from_directory
    raise NotFound()
werkzeug.exceptions.NotFound: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
[2020-10-25 08:10:23]  DEBUG         pyload.webui  404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
```

This PR adds an error handler for error 404 and logs only the wrong call:

`[2020-10-25 15:59:36]  DEBUG         pyload.webui  Error 404 - Requested URL: http://127.0.0.1:8000/queue6`

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
