### PR TITLE
[Main] Fix Restart of pyload-ng

### DIFF
--- a/src/pyload/core/__init__.py
+++ b/src/pyload/core/__init__.py
@@ -293,18 +293,11 @@ class Core:
             try:
                 self.log.debug("Starting core...")
 
-                if self.debug:
-                    debug_level = reversemap(self.DEBUG_LEVEL_MAP)[self.debug].upper()
-                    self.log.debug(f"Debug level: {debug_level}")
+                debug_level = reversemap(self.DEBUG_LEVEL_MAP)[self.debug].upper()
+                self.log.debug(f"Debug level: {debug_level}")
 
-        try:
-            	self.log.debug("Starting core...")
-
-            	debug_level = reversemap(self.DEBUG_LEVEL_MAP)[self.debug].upper()
-            	self.log.debug(f"Debug level: {debug_level}")
-
-            	# self.evm.fire('pyload:starting')
-            	self._running.set()
+                # self.evm.fire('pyload:starting')
+                self._running.set()
 
                 self._setup_language()
                 self._setup_permissions()

--- a/src/pyload/core/threads/database_thread.py
+++ b/src/pyload/core/threads/database_thread.py
@@ -116,7 +116,7 @@ class DatabaseThread(Thread):
             if j == "quit":
                 self.c.close()
                 self.conn.close()
-                return
+                break
             j.process_job()
 
     @style.queue

--- a/src/pyload/core/threads/database_thread.py
+++ b/src/pyload/core/threads/database_thread.py
@@ -116,7 +116,7 @@ class DatabaseThread(Thread):
             if j == "quit":
                 self.c.close()
                 self.conn.close()
-                break
+                return
             j.process_job()
 
     @style.queue

--- a/src/pyload/webui/webserver_thread.py
+++ b/src/pyload/webui/webserver_thread.py
@@ -43,20 +43,27 @@ class WebServerThread(threading.Thread):
         bind_path = self.prefix.strip("/") + "/"
         bind_addr = (self.host, self.port)
         wsgi_app = wsgi.PathInfoDispatcher({bind_path: self.app})
-
-        server = wsgi.Server(bind_addr, wsgi_app)
+        self.server = wsgi.Server(bind_addr, wsgi_app)
 
         if self.use_ssl:
-            server.ssl_adapter = BuiltinSSLAdapter(
+            self.server.ssl_adapter = BuiltinSSLAdapter(
                 self.certfile, self.keyfile, self.certchain
             )
 
         #: hack cheroot to use our custom logger
-        server.error_log = lambda *args, **kwgs: self.log.log(
+        self.server.error_log = lambda *args, **kwgs: self.log.log(
             kwgs.get("level", logging.ERROR), args[0], exc_info=self.pyload.debug
         )
 
-        server.safe_start()
+        self.server.safe_start()
+
+    def stop(self):
+        if not self.develop:
+            self.server.stop()
+        else:
+            pass
+            # ToDo: Not implemented
+
 
     def run(self):
         self.log.warning(


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

The message regarding threads can only be started once occur because the database thread and the webserver thread wheren't stopped. The PR adds a routine to stop the webserver. Furthermore it stops the database thread. The original code wasn't initalizing the core new, this caused some trouble. Now the \_\_init\_\_ routine is called on restarted, therefore the storagedir parameter is saved in a member variable, to have it available. The original code raised a exception and the called the start routine, this lead to the situation that on each restart the recursion depth was increased (start calls start calls start and so on), so I changed the start routine to a while loop. A restart now triggers after going through \_\_init\_\_ just a new iteration of the while loop.

Now the strange part: After the second restart everything was logged twice. I made the log variable a class variable, check before starting a new logger if any loggers are still assigned to the log variable, delete them and can now prevent this problem

I could not make the development webserver restart. So this might be an open topic. (My plan is to use the productive server for my server, so I won't fix this. Looks like a lot of googeling and experiments to me)

<!-- WRITE HERE -->

### Is this related to a problem?

This PR solves issue #3806

<!-- WRITE HERE - OPTIONAL -->

### Additional references

I only checked it with Linux and not with windows