### PR TITLE
[Main] Fix ip address not resolvable on reconnect

### DIFF
--- a/src/pyload/core/managers/thread_manager.py
+++ b/src/pyload/core/managers/thread_manager.py
@@ -220,8 +220,8 @@ class ThreadManager:
         retrieve current ip.
         """
         services = [
-            (r"http://icanhazip.com/", r"(\S+)"),
-            ("http://checkip.dyndns.org/", r".*Current IP Address: (\S+)</body>.*"),
+            (r"http://icanhazip.com/", rb"(\S+)"),
+            ("http://checkip.dyndns.org/", rb".*Current IP Address: (\S+)</body>.*"),
         ]
 
         ip = ""

--- a/src/pyload/core/managers/thread_manager.py
+++ b/src/pyload/core/managers/thread_manager.py
@@ -220,7 +220,7 @@ class ThreadManager:
         retrieve current ip.
         """
         services = [
-            (r"http://automation.whatismyip.com/n09230945.asp", r"(\S+)"),
+            (r"http://icanhazip.com/", r"(\S+)"),
             ("http://checkip.dyndns.org/", r".*Current IP Address: (\S+)</body>.*"),
         ]
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

On every reconnect the function first tries to get the ip address from the service http://automation.whatismyip.com, this page is no longer existent, I exchanged it with a working one: icanhazip.com (using this for years now).
Second problem is that get_url returns a binary, so the following regex fails, changing the regex strings to binary ones solves this problem.

### Is this related to a problem?

On a reconnect the fields for the ip address have been empty before:
```

[2020-10-24 16:46:04]  INFO                pyload  DOWNLOADER DdlTo[1]: Waiting 1 hour, 59 minutes, 57 seconds...
[2020-10-24 16:46:04]  INFO                pyload  DOWNLOADER DdlTo[1]: Requiring reconnection...
[2020-10-24 16:46:04]  INFO                pyload  Starting reconnect
[2020-10-24 16:46:04]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `download_processed`
[2020-10-24 16:46:04]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `package_processed`
[2020-10-24 16:46:04]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `package_failed`
[2020-10-24 16:46:15]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `before_reconnect`
[2020-10-24 16:46:15]  DEBUG               pyload  Old IP: 

```
### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
