### PR TITLE
[Main] Fix storagedir not persistent after restart

### DIFF
--- a/src/pyload/__main__.py
+++ b/src/pyload/__main__.py
@@ -95,7 +95,7 @@ def _parse_args(cmd_args):
     parser.add_argument(
         "--storagedir",
         help="use this location to save downloads",
-        default=Core.DEFAULT_STORAGEDIR,
+        default=None, # Core.DEFAULT_STORAGEDIR,
     )
     parser.add_argument("--daemon", action="store_true", help="run as daemon")
     parser.add_argument(

--- a/src/pyload/__main__.py
+++ b/src/pyload/__main__.py
@@ -95,7 +95,7 @@ def _parse_args(cmd_args):
     parser.add_argument(
         "--storagedir",
         help="use this location to save downloads",
-        default=None, # Core.DEFAULT_STORAGEDIR,
+        default=None,
     )
     parser.add_argument("--daemon", action="store_true", help="run as daemon")
     parser.add_argument(

--- a/src/pyload/core/__init__.py
+++ b/src/pyload/core/__init__.py
@@ -115,8 +115,12 @@ class Core:
         else:
             self._debug = max(0, int(debug))
 
+        # If no argument set, read storage dir from config file, otherwise save setting to config dir
+        if storagedir == None:
+            storagedir = self.config.get("general", "storage_folder")
+        else:
+            self.config.set("general", "storage_folder", storagedir)
         os.makedirs(storagedir, exist_ok=True)
-        self.config.set("general", "storage_folder", storagedir)
 
         self.config.save()  #: save so config files gets filled
 
@@ -272,6 +276,11 @@ class Core:
             return
         self.webserver.start()
 
+    def _stop_webserver(self):
+        if not self.config.get("webui", "enabled"):
+            return
+        self.webserver.stop()
+
     def _get_args_for_reloading(self):
         """Determine how the script was executed, and return the args needed
         to execute it again in a new process.
@@ -341,8 +350,9 @@ class Core:
         try:
             self.log.debug("Starting core...")
 
-            debug_level = reversemap(self.DEBUG_LEVEL_MAP)[self.debug].upper()
-            self.log.debug(f"Debug level: {debug_level}")
+            if self.debug:
+                debug_level = reversemap(self.DEBUG_LEVEL_MAP)[self.debug].upper()
+                self.log.debug(f"Debug level: {debug_level}")
 
             # self.evm.fire('pyload:starting')
             self._running.set()

--- a/src/pyload/core/__init__.py
+++ b/src/pyload/core/__init__.py
@@ -115,8 +115,9 @@ class Core:
         else:
             self._debug = max(0, int(debug))
 
-        # If no argument set, read storage dir from config file, otherwise save setting to config dir
-        if storagedir == None:
+        # If no argument set, read storage dir from config file,
+        # otherwise save setting to config dir
+        if storagedir is None:
             storagedir = self.config.get("general", "storage_folder")
         else:
             self.config.set("general", "storage_folder", storagedir)


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

If you change the download directory on the web UI and afterwards restart pyload-ng the setting is reset to default. This is caused by the arg parser giving the default storage dir as parameter to the core init function. In the first step the storage dir is saved to the config file. The patch sets the default argument to none and checking in init if some argument is present, if not, the storagedir is loaded from the config file  

### Is this related to a problem?
Storage dir is not persitant across restarts

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
