### PR TITLE
[Main] Make path_prefix for webserver working

### DIFF
--- a/src/pyload/webui/app/__init__.py
+++ b/src/pyload/webui/app/__init__.py
@@ -16,7 +16,7 @@ from .blueprints import BLUEPRINTS
 from .filters import TEMPLATE_FILTERS
 from .globals import TEMPLATE_GLOBALS
 from .handlers import ERROR_HANDLERS
-from .extensions import EXTENSIONS
+from .extensions import EXTENSIONS, THEMES
 from .processors import CONTEXT_PROCESSORS
 from .config import get_default_config
 from .helpers import JSONEncoder
@@ -31,6 +31,8 @@ class App:
     FLASK_ERROR_HANDLERS = ERROR_HANDLERS
     FLASK_BLUEPRINTS = BLUEPRINTS
     FLASK_EXTENSIONS = EXTENSIONS
+    FLASK_THEMES = THEMES
+
 
     @classmethod
     def _configure_config(cls, app, develop):
@@ -38,14 +40,19 @@ class App:
         app.config.from_object(conf_obj)
 
     @classmethod
-    def _configure_blueprints(cls, app):
+    def _configure_blueprints(cls, app, path_prefix):
         for blueprint in cls.FLASK_BLUEPRINTS:
-            app.register_blueprint(blueprint)
+            app.register_blueprint(blueprint, url_prefix=path_prefix)
 
     @classmethod
     def _configure_extensions(cls, app):
         for extension in cls.FLASK_EXTENSIONS:
             extension.init_app(app)
+
+    @classmethod
+    def _configure_themes(cls, app, path_prefix=""):
+        for themes in cls.FLASK_THEMES:
+            themes.init_app(app, path_prefix)
 
     @classmethod
     def _configure_handlers(cls, app):
@@ -99,7 +106,7 @@ class App:
         # Inject our custom logger
         app.logger = pycore.log.getChild("webui")
 
-    def __new__(cls, pycore, develop=False):
+    def __new__(cls, pycore, develop=False, path_prefix=None):
         app = flask.Flask(__name__)
 
         cls._configure_logging(app, pycore)
@@ -108,8 +115,9 @@ class App:
         cls._configure_templating(app)
         cls._configure_json_encoding(app)
         cls._configure_session(app)
-        cls._configure_blueprints(app)
+        cls._configure_blueprints(app, path_prefix)
         cls._configure_extensions(app)
+        cls._configure_themes(app, path_prefix)
         cls._configure_handlers(app)
 
         return app

--- a/src/pyload/webui/app/__init__.py
+++ b/src/pyload/webui/app/__init__.py
@@ -42,7 +42,10 @@ class App:
     @classmethod
     def _configure_blueprints(cls, app, path_prefix):
         for blueprint in cls.FLASK_BLUEPRINTS:
-            app.register_blueprint(blueprint, url_prefix=path_prefix)
+            prefix = None
+            if not blueprint.url_prefix:
+                prefix = path_prefix
+            app.register_blueprint(blueprint, url_prefix=prefix)
 
     @classmethod
     def _configure_extensions(cls, app):

--- a/src/pyload/webui/app/__init__.py
+++ b/src/pyload/webui/app/__init__.py
@@ -117,7 +117,7 @@ class App:
         cls._configure_session(app)
         cls._configure_blueprints(app, path_prefix)
         cls._configure_extensions(app)
-        cls._configure_themes(app, path_prefix)
+        cls._configure_themes(app, path_prefix or "")
         cls._configure_handlers(app)
 
         return app

--- a/src/pyload/webui/app/blueprints/api_blueprint.py
+++ b/src/pyload/webui/app/blueprints/api_blueprint.py
@@ -10,15 +10,15 @@ from flask.json import jsonify
 
 from ..helpers import clear_session, login_required, set_session
 
-bp = flask.Blueprint("api", __name__, url_prefix="/api")
+bp = flask.Blueprint("api", __name__) #  url_prefix="/api")
 
 
 # accepting positional arguments, as well as kwargs via post and get
 # @bottle.route(
 # r"/api/<func><args:re:[a-zA-Z0-9\-_/\"\'\[\]%{},]*>")
 @login_required("ALL")
-@bp.route("/<func>", methods=["GET", "POST"], endpoint="rpc")
-@bp.route("/<func>/<args>", methods=["GET", "POST"], endpoint="rpc")
+@bp.route("/api/<func>", methods=["GET", "POST"], endpoint="rpc")
+@bp.route("/api/<func>/<args>", methods=["GET", "POST"], endpoint="rpc")
 # @apiver_check
 def rpc(func, args=""):
 
@@ -64,7 +64,7 @@ def call_api(func, *args, **kwargs):
     return jsonify(result or True)
 
 
-@bp.route("/login", methods=["POST"], endpoint="login")
+@bp.route("/api/login", methods=["POST"], endpoint="login")
 # @apiver_check
 def login():
     user = flask.request.form["username"]
@@ -82,7 +82,7 @@ def login():
     return jsonify(s)
 
 
-@bp.route("/logout", endpoint="logout")
+@bp.route("/api/logout", endpoint="logout")
 # @apiver_check
 def logout():
     # logout_user()

--- a/src/pyload/webui/app/blueprints/api_blueprint.py
+++ b/src/pyload/webui/app/blueprints/api_blueprint.py
@@ -10,7 +10,7 @@ from flask.json import jsonify
 
 from ..helpers import clear_session, login_required, set_session
 
-bp = flask.Blueprint("api", __name__) #  url_prefix="/api")
+bp = flask.Blueprint("api", __name__)
 
 
 # accepting positional arguments, as well as kwargs via post and get

--- a/src/pyload/webui/app/blueprints/cnl_blueprint.py
+++ b/src/pyload/webui/app/blueprints/cnl_blueprint.py
@@ -13,7 +13,7 @@ from pyload.core.utils.misc import eval_js
 
 from .app_blueprint import bp as app_bp
 
-bp = flask.Blueprint("flash", __name__, url_prefix="/flash")
+bp = flask.Blueprint("flash", __name__)
 
 
 #: decorator
@@ -34,14 +34,14 @@ def local_check(func):
     return wrapper
 
 
-@bp.route("/", methods=["GET", "POST"], endpoint="index")
-@bp.route("/<id>", methods=["GET", "POST"], endpoint="index")
+@bp.route("/flash", methods=["GET", "POST"], endpoint="index")
+@bp.route("/flash/<id>", methods=["GET", "POST"], endpoint="index")
 @local_check
 def index(id="0"):
     return "JDownloader\r\n"
 
 
-@bp.route("/add", methods=["POST"], endpoint="add")
+@bp.route("/flash/add", methods=["POST"], endpoint="add")
 @local_check
 def add():
     package = flask.request.form.get(
@@ -64,7 +64,7 @@ def add():
     return "success\r\n"
 
 
-@bp.route("/addcrypted", methods=["POST"], endpoint="addcrypted")
+@bp.route("/flash/addcrypted", methods=["POST"], endpoint="addcrypted")
 @local_check
 def addcrypted():
     api = flask.current_app.config["PYLOAD_API"]
@@ -88,7 +88,7 @@ def addcrypted():
         return "success\r\n"
 
 
-@bp.route("/addcrypted2", methods=["POST"], endpoint="addcrypted2")
+@bp.route("/flash/addcrypted2", methods=["POST"], endpoint="addcrypted2")
 @local_check
 def addcrypted2():
     package = flask.request.form.get(
@@ -121,8 +121,8 @@ def addcrypted2():
         return "success\r\n"
 
 
-@app_bp.route("/flashgot", methods=["POST"], endpoint="flashgot")
-@app_bp.route("/flashgot_pyload", methods=["POST"], endpoint="flashgot")
+@app_bp.route("/flash/flashgot", methods=["POST"], endpoint="flashgot")
+@app_bp.route("/flash/flashgot_pyload", methods=["POST"], endpoint="flashgot")
 @local_check
 def flashgot():
     if flask.request.referrer not in (
@@ -143,7 +143,7 @@ def flashgot():
         api.generate_and_add_packages(urls, autostart)
 
 
-@app_bp.route("/crossdomain.xml", endpoint="crossdomain")
+@app_bp.route("/flash/crossdomain.xml", endpoint="crossdomain")
 @local_check
 def crossdomain():
     rep = '<?xml version="1.0"?>\n'
@@ -154,7 +154,7 @@ def crossdomain():
     return rep
 
 
-@bp.route("/check_support_for_url", methods=["POST"], endpoint="checksupport")
+@bp.route("/flash/check_support_for_url", methods=["POST"], endpoint="checksupport")
 @local_check
 def checksupport():
     api = flask.current_app.config["PYLOAD_API"]
@@ -166,7 +166,7 @@ def checksupport():
     return str(supported).lower()
 
 
-@app_bp.route("/jdcheck.js", endpoint="jdcheck")
+@app_bp.route("/flash/jdcheck.js", endpoint="jdcheck")
 @local_check
 def jdcheck():
     rep = "jdownloader=true;\n"

--- a/src/pyload/webui/app/blueprints/cnl_blueprint.py
+++ b/src/pyload/webui/app/blueprints/cnl_blueprint.py
@@ -13,7 +13,7 @@ from pyload.core.utils.misc import eval_js
 
 from .app_blueprint import bp as app_bp
 
-bp = flask.Blueprint("flash", __name__)
+bp = flask.Blueprint("flash", __name__, url_prefix="/flash")
 
 
 #: decorator
@@ -34,14 +34,14 @@ def local_check(func):
     return wrapper
 
 
-@bp.route("/flash", methods=["GET", "POST"], endpoint="index")
-@bp.route("/flash/<id>", methods=["GET", "POST"], endpoint="index")
+@bp.route("/", methods=["GET", "POST"], endpoint="index")
+@bp.route("/<id>", methods=["GET", "POST"], endpoint="index")
 @local_check
 def index(id="0"):
     return "JDownloader\r\n"
 
 
-@bp.route("/flash/add", methods=["POST"], endpoint="add")
+@bp.route("/add", methods=["POST"], endpoint="add")
 @local_check
 def add():
     package = flask.request.form.get(
@@ -64,7 +64,7 @@ def add():
     return "success\r\n"
 
 
-@bp.route("/flash/addcrypted", methods=["POST"], endpoint="addcrypted")
+@bp.route("/addcrypted", methods=["POST"], endpoint="addcrypted")
 @local_check
 def addcrypted():
     api = flask.current_app.config["PYLOAD_API"]
@@ -88,7 +88,7 @@ def addcrypted():
         return "success\r\n"
 
 
-@bp.route("/flash/addcrypted2", methods=["POST"], endpoint="addcrypted2")
+@bp.route("/addcrypted2", methods=["POST"], endpoint="addcrypted2")
 @local_check
 def addcrypted2():
     package = flask.request.form.get(
@@ -121,8 +121,8 @@ def addcrypted2():
         return "success\r\n"
 
 
-@app_bp.route("/flash/flashgot", methods=["POST"], endpoint="flashgot")
-@app_bp.route("/flash/flashgot_pyload", methods=["POST"], endpoint="flashgot")
+@app_bp.route("/flashgot", methods=["POST"], endpoint="flashgot")
+@app_bp.route("/flashgot_pyload", methods=["POST"], endpoint="flashgot")
 @local_check
 def flashgot():
     if flask.request.referrer not in (
@@ -143,7 +143,7 @@ def flashgot():
         api.generate_and_add_packages(urls, autostart)
 
 
-@app_bp.route("/flash/crossdomain.xml", endpoint="crossdomain")
+@app_bp.route("/crossdomain.xml", endpoint="crossdomain")
 @local_check
 def crossdomain():
     rep = '<?xml version="1.0"?>\n'
@@ -154,7 +154,7 @@ def crossdomain():
     return rep
 
 
-@bp.route("/flash/check_support_for_url", methods=["POST"], endpoint="checksupport")
+@bp.route("/check_support_for_url", methods=["POST"], endpoint="checksupport")
 @local_check
 def checksupport():
     api = flask.current_app.config["PYLOAD_API"]
@@ -166,7 +166,7 @@ def checksupport():
     return str(supported).lower()
 
 
-@app_bp.route("/flash/jdcheck.js", endpoint="jdcheck")
+@app_bp.route("/jdcheck.js", endpoint="jdcheck")
 @local_check
 def jdcheck():
     rep = "jdownloader=true;\n"

--- a/src/pyload/webui/app/blueprints/json_blueprint.py
+++ b/src/pyload/webui/app/blueprints/json_blueprint.py
@@ -9,10 +9,10 @@ from pyload.core.utils import format
 
 from ..helpers import login_required, render_template
 
-bp = flask.Blueprint("json", __name__, url_prefix="/json")
+bp = flask.Blueprint("json", __name__)
 
 
-@bp.route("/status", methods=["GET", "POST"], endpoint="status")
+@bp.route("/json/status", methods=["GET", "POST"], endpoint="status")
 # @apiver_check
 @login_required("LIST")
 def status():
@@ -21,7 +21,7 @@ def status():
     return jsonify(data)
 
 
-@bp.route("/links", methods=["GET", "POST"], endpoint="links")
+@bp.route("/json/links", methods=["GET", "POST"], endpoint="links")
 # @apiver_check
 @login_required("LIST")
 def links():
@@ -53,7 +53,7 @@ def links():
     return jsonify(False)
 
 
-@bp.route("/packages", endpoint="packages")
+@bp.route("/json/packages", endpoint="packages")
 # @apiver_check
 @login_required("LIST")
 def packages():
@@ -74,7 +74,7 @@ def packages():
     return jsonify(False)
 
 
-@bp.route("/package/<int:id>", endpoint="package")
+@bp.route("/json/package/<int:id>", endpoint="package")
 # @apiver_check
 @login_required("LIST")
 def package(id):
@@ -93,7 +93,7 @@ def package(id):
     return jsonify(False)
 
 
-@bp.route("/package_order/<int:pid>|<int:pos>", endpoint="package_order")
+@bp.route("/json/package_order/<int:pid>|<int:pos>", endpoint="package_order")
 # @apiver_check
 @login_required("ADD")
 def package_order(pid, pos):
@@ -107,7 +107,7 @@ def package_order(pid, pos):
     return jsonify(False)
 
 
-@bp.route("/abort_link/<int:id>", endpoint="abort_link")
+@bp.route("/json/abort_link/<int:id>", endpoint="abort_link")
 # @apiver_check
 @login_required("DELETE")
 def abort_link(id):
@@ -121,7 +121,7 @@ def abort_link(id):
     return jsonify(False)
 
 
-@bp.route("/link_order/<int:fid>|<int:pos>", endpoint="link_order")
+@bp.route("/json/link_order/<int:fid>|<int:pos>", endpoint="link_order")
 # @apiver_check
 @login_required("ADD")
 def link_order(fid, pos):
@@ -135,7 +135,7 @@ def link_order(fid, pos):
     return jsonify(False)
 
 
-@bp.route("/add_package", methods=["POST"], endpoint="add_package")
+@bp.route("/json/add_package", methods=["POST"], endpoint="add_package")
 # @apiver_check
 @login_required("ADD")
 def add_package():
@@ -170,7 +170,7 @@ def add_package():
     return jsonify(True)
 
 
-@bp.route("/move_package/<int:dest>|<int:id>", endpoint="move_package")
+@bp.route("/json/move_package/<int:dest>|<int:id>", endpoint="move_package")
 # @apiver_check
 @login_required("MODIFY")
 def move_package(dest, id):
@@ -184,7 +184,7 @@ def move_package(dest, id):
     return jsonify(False)
 
 
-@bp.route("/edit_package", methods=["POST"], endpoint="edit_package")
+@bp.route("/json/edit_package", methods=["POST"], endpoint="edit_package")
 # @apiver_check
 @login_required("MODIFY")
 def edit_package():
@@ -206,7 +206,7 @@ def edit_package():
     return jsonify(False)
 
 
-@bp.route("/set_captcha", methods=["GET", "POST"], endpoint="set_captcha")
+@bp.route("/json/set_captcha", methods=["GET", "POST"], endpoint="set_captcha")
 # @apiver_check
 @login_required("ADD")
 def set_captcha():
@@ -231,7 +231,7 @@ def set_captcha():
     return jsonify(data)
 
 
-@bp.route("/load_config/<category>/<section>", endpoint="load_config")
+@bp.route("/json/load_config/<category>/<section>", endpoint="load_config")
 # @apiver_check
 # @login_required("SETTINGS")
 def load_config(category, section):
@@ -252,7 +252,7 @@ def load_config(category, section):
     return render_template("settings_item.html", skey=section, section=conf[section])
 
 
-@bp.route("/save_config/<category>", methods=["POST"], endpoint="save_config")
+@bp.route("/json/save_config/<category>", methods=["POST"], endpoint="save_config")
 # @apiver_check
 @login_required("SETTINGS")
 def save_config(category):
@@ -271,7 +271,7 @@ def save_config(category):
     return jsonify(True)
 
 
-@bp.route("/add_account", methods=["POST"], endpoint="add_account")
+@bp.route("/json/add_account", methods=["POST"], endpoint="add_account")
 # @apiver_check
 @login_required("ACCOUNTS")
 # @fresh_login_required
@@ -286,7 +286,7 @@ def add_account():
     return jsonify(True)
 
 
-@bp.route("/update_accounts", methods=["POST"], endpoint="update_accounts")
+@bp.route("/json/update_accounts", methods=["POST"], endpoint="update_accounts")
 # @apiver_check
 @login_required("ACCOUNTS")
 # @fresh_login_required
@@ -318,7 +318,7 @@ def update_accounts():
     return jsonify(True)
 
 
-@bp.route("/change_password", methods=["POST"], endpoint="change_password")
+@bp.route("/json/change_password", methods=["POST"], endpoint="change_password")
 # @apiver_check
 # @fresh_login_required
 @login_required("ACCOUNTS")

--- a/src/pyload/webui/app/extensions.py
+++ b/src/pyload/webui/app/extensions.py
@@ -8,12 +8,14 @@ from pyload import APPID
 
 
 class Themes(_Themes):
-    def init_app(self, app):
-        return super().init_themes(app, app_identifier=APPID)
+    def init_app(self, app, path_prefix=""):
+        return super().init_themes(app, app_identifier=APPID, theme_url_prefix=path_prefix + "/_themes")
 
 
 babel = Babel()
 cache = Cache()
 themes = Themes()
 
-EXTENSIONS = [babel, cache, themes]
+EXTENSIONS = [babel, cache]
+
+THEMES = [themes]

--- a/src/pyload/webui/app/extensions.py
+++ b/src/pyload/webui/app/extensions.py
@@ -9,7 +9,9 @@ from pyload import APPID
 
 class Themes(_Themes):
     def init_app(self, app, path_prefix=""):
-        return super().init_themes(app, app_identifier=APPID, theme_url_prefix=path_prefix + "/_themes")
+        return super().init_themes(app,
+                                   app_identifier=APPID,
+                                   theme_url_prefix=path_prefix + "/_themes")
 
 
 babel = Babel()

--- a/src/pyload/webui/app/templates/admin.html
+++ b/src/pyload/webui/app/templates/admin.html
@@ -63,7 +63,7 @@
 {% endblock %}
 {% block hidden %}
     <div id="password_box" class="window_box" style="z-index: 2">
-        <form id="password_form" action="/json/change_password" method="POST" enctype="multipart/form-data">
+        <form id="password_form" action="{{url_for('json.change_password')}}" method="POST" enctype="multipart/form-data">
             <h1>{{ _("Change Password") }}</h1>
 
             <p>{{ _("Enter your current and desired Password.") }}</p>

--- a/src/pyload/webui/app/templates/base.html
+++ b/src/pyload/webui/app/templates/base.html
@@ -51,11 +51,11 @@
 
     <img src="{{url_for('static', filename='img/head-login.png')}}" alt="User:" style="vertical-align:middle; margin:2px" /><span style="padding-right: 2px;">{{user.name}}</span>
     <ul id="user-actions">
-        <li><a href="/logout" class="action logout" rel="nofollow">{{_("Logout")}}</a></li>
+        <li><a href="{{url_for('app.logout')}}" class="action logout" rel="nofollow">{{_("Logout")}}</a></li>
         {% if user.is_admin %}
-        <li><a href="/admin" class="action profile" rel="nofollow">{{_("Profile")}}</a></li>
+        <li><a href="{{url_for('app.admin')}}" class="action profile" rel="nofollow">{{_("Profile")}}</a></li>
         {% endif %}
-        <li><a href="/info" class="action info" rel="nofollow">{{_("Status")}}</a></li>
+        <li><a href="{{url_for('app.info')}}" class="action info" rel="nofollow">{{_("Status")}}</a></li>
 
     </ul>
 {% else %}
@@ -65,7 +65,7 @@
     {% endblock %}
     </div>
 
-    <a href="{{'dashboard'}}"><img id="head-logo" src="{{url_for('static', filename='img/pyload-logo.png')}}" alt="pyLoad" /></a>
+    <a href="{{url_for('app.dashboard')}}"><img id="head-logo" src="{{url_for('static', filename='img/pyload-logo.png')}}" alt="pyLoad" /></a>
 
     <div id="head-menu">
         <ul>
@@ -77,25 +77,25 @@
 
         {% block menu %}
         <li>
-            <a href="{{'dashboard'}}" title=""><img src="{{url_for('static', filename='img/head-menu-home.png')}}" alt="" /> {{_("Dashboard")}}</a>
+            <a href="{{url_for('app.dashboard')}}" title=""><img src="{{url_for('static', filename='img/head-menu-home.png')}}" alt="" /> {{_("Dashboard")}}</a>
         </li>
         <li {{ selected('queue') }}>
-            <a href="/queue" title=""><img src="{{url_for('static', filename='img/head-menu-queue.png')}}" alt="" /> {{_("Queue")}}</a>
+            <a href="{{url_for('app.queue')}}" title=""><img src="{{url_for('static', filename='img/head-menu-queue.png')}}" alt="" /> {{_("Queue")}}</a>
         </li>
         <li {{ selected('collector') }}>
-            <a href="/collector" title=""><img src="{{url_for('static', filename='img/head-menu-collector.png')}}" alt="" /> {{_("Packages")}}</a>
+            <a href="{{url_for('app.collector')}}" title=""><img src="{{url_for('static', filename='img/head-menu-collector.png')}}" alt="" /> {{_("Packages")}}</a>
         </li>
         <li {{ selected('files') }}>
-            <a href="/files" title=""><img src="{{url_for('static', filename='img/head-menu-development.png')}}" alt="" /> {{_("Files")}}</a>
+            <a href="{{url_for('app.files')}}" title=""><img src="{{url_for('static', filename='img/head-menu-development.png')}}" alt="" /> {{_("Files")}}</a>
         </li>
         <!-- <li {{ selected('filemanager') }}> -->
             <!-- <a href="/filemanager" title=""><img src="{{url_for('static', filename='img/head-menu-download.png')}}" alt="" /> {{_("File Manager")}}</a> -->
         <!-- </li> -->
         <li {{ selected('logs', True) }}>
-            <a href="/logs"  class="action index" accesskey="x" rel="nofollow"><img src="{{url_for('static', filename='img/head-menu-index.png')}}" alt="" />{{_("Logs")}}</a>
+            <a href="{{url_for('app.logs')}}"  class="action index" accesskey="x" rel="nofollow"><img src="{{url_for('static', filename='img/head-menu-index.png')}}" alt="" />{{_("Logs")}}</a>
         </li>
         <li {{ selected('settings', True) }}>
-            <a href="/settings"  class="action index" accesskey="x" rel="nofollow"><img src="{{url_for('static', filename='img/head-menu-config.png')}}" alt="" />{{_("Settings")}}</a>
+            <a href="{{url_for('app.settings')}}"  class="action index" accesskey="x" rel="nofollow"><img src="{{url_for('static', filename='img/head-menu-config.png')}}" alt="" />{{_("Settings")}}</a>
         </li>
         {% endblock %}
 

--- a/src/pyload/webui/app/templates/captcha.html
+++ b/src/pyload/webui/app/templates/captcha.html
@@ -1,6 +1,6 @@
 <!-- Captcha box -->
 <div id="cap_box" class="window_box">
-    <form id="cap_form" action="/json/set_captcha" method="POST" enctype="multipart/form-data" onsubmit="return false;">
+    <form id="cap_form" action="{{url_for('json.set_captcha')}}" method="POST" enctype="multipart/form-data" onsubmit="return false;">
         <h1>{{_("Captcha reading")}}</h1>
         <p id="cap_title">{{_("Please read the text on the captcha.")}}</p>
 

--- a/src/pyload/webui/app/templates/dashboard.html
+++ b/src/pyload/webui/app/templates/dashboard.html
@@ -6,7 +6,7 @@
 {% endblock %} {% block subtitle %} {{_("Active Connections")}} {% endblock %}
 {% block menu %}
 <li class="selected">
-  <a href="{{'dashboard'}}" title=""
+  <a href="{{url_for('app.dashboard')}}" title=""
     ><img
       src="{{url_for('static', filename='img/head-menu-home.png')}}"
       alt=""
@@ -15,7 +15,7 @@
   >
 </li>
 <li>
-  <a href="/queue" title=""
+  <a href="{{url_for('app.queue')}}" title=""
     ><img
       src="{{url_for('static', filename='img/head-menu-queue.png')}}"
       alt=""
@@ -24,7 +24,7 @@
   >
 </li>
 <li>
-  <a href="/collector" title=""
+  <a href="{{url_for('app.collector')}}" title=""
     ><img
       src="{{url_for('static', filename='img/head-menu-collector.png')}}"
       alt=""
@@ -33,7 +33,7 @@
   >
 </li>
 <li>
-  <a href="/files" title=""
+  <a href="{{url_for('app.files')}}" title=""
     ><img
       src="{{url_for('static', filename='img/head-menu-development.png')}}"
       alt=""
@@ -45,7 +45,7 @@
 <!-- <a href="/filemanager" title=""><img src="{{url_for('static', filename='img/head-menu-download.png')}}" alt="" /> {{_("File Manager")}}</a> -->
 <!-- </li> -->
 <li class="right">
-  <a href="/logs" class="action index" accesskey="x" rel="nofollow"
+  <a href="{{url_for('app.logs')}}" class="action index" accesskey="x" rel="nofollow"
     ><img
       src="{{url_for('static', filename='img/head-menu-index.png')}}"
       alt=""
@@ -53,7 +53,7 @@
   >
 </li>
 <li class="right">
-  <a href="/settings" class="action index" accesskey="x" rel="nofollow"
+  <a href="{{url_for('app.settings')}}" class="action index" accesskey="x" rel="nofollow"
     ><img
       src="{{url_for('static', filename='img/head-menu-config.png')}}"
       alt=""

--- a/src/pyload/webui/app/templates/js/admin.js
+++ b/src/pyload/webui/app/templates/js/admin.js
@@ -56,7 +56,7 @@ document.addEvent("domready", function() {
     $('quit-pyload').addEvent("click", function(e) {
         new MooDialog.Confirm("{{_('You are really sure you want to quit pyLoad?')}}", function() {
             return new Request.JSON({
-                url: '/api/kill',
+                url: "{{url_for('api.rpc', func='kill')}}",
                 method: 'get'
             }).send();
         }
@@ -67,7 +67,7 @@ document.addEvent("domready", function() {
     return $('restart-pyload').addEvent("click", function(e) {
         new MooDialog.Confirm("{{_('Are you sure you want to restart pyLoad?')}}", function() {
             return new Request.JSON({
-                  url: '/api/restart',
+                  url: "{{url_for('api.rpc', func='restart')}}",
                   method: 'get',
                   onSuccess(data) { return alert("{{_('pyLoad restarted')}}"); }
             }).send();

--- a/src/pyload/webui/app/templates/js/base.js
+++ b/src/pyload/webui/app/templates/js/base.js
@@ -89,9 +89,9 @@ document.addEvent("domready", function() {
     $('add_reset').addEvent('click', () => root.addBox.close());
 
     $('action_add').addEvent('click', function() { $("add_form").reset(); return root.addBox.open(); });
-    $('action_play').addEvent('click', () => new Request({method: 'get', url: '/api/unpause_server'}).send());
-    $('action_cancel').addEvent('click', () => new Request({method: 'get', url: '/api/stop_all_downloads'}).send());
-    $('action_stop').addEvent('click', () => new Request({method: 'get', url: '/api/pause_server'}).send());
+    $('action_play').addEvent('click', () => new Request({method: 'get', url: "{{url_for('api.rpc', func='unpause_server')}}"}).send());
+    $('action_cancel').addEvent('click', () => new Request({method: 'get', url: "{{url_for('api.rpc', func='stop_all_downloads')}}"}).send());
+    $('action_stop').addEvent('click', () => new Request({method: 'get', url: "{{url_for('api.rpc', func='pause_server')}}"}).send());
 
 
     // captcha events
@@ -109,7 +109,7 @@ document.addEvent("domready", function() {
     $('cap_positional').addEvent('click', on_captcha_click);
 
     return new Request.JSON({
-        url: '/json/status',
+        url: "{{url_for('json.status')}}",
         onSuccess: LoadJsonToContent,
         secure: false,
         async: true,
@@ -178,7 +178,7 @@ const set_captcha = function(data) {
 
 var load_captcha = (method, post) =>
     new Request.JSON({
-        url: '/json/set_captcha',
+        url: "{{url_for('json.set_captcha')}}",
         onSuccess(data) { if (data.captcha) { return set_captcha(data); } else { return clear_captcha(); } },
         secure: false,
         async: true,

--- a/src/pyload/webui/app/templates/js/dashboard.js
+++ b/src/pyload/webui/app/templates/js/dashboard.js
@@ -10,7 +10,7 @@ document.addEvent("domready", function(){
 var EntryManager = new Class({
     initialize: function(){
         this.json = new Request.JSON({
-            url: "{{url_for("json.links")}}",
+            url: "{{url_for('json.links')}}",
             secure: false,
             async: true,
             onSuccess: this.update.bind(this),
@@ -163,7 +163,7 @@ var LinkEntry = new Class({
 
         this.elements.remove.addEvent('click', function(){
             new Request({
-                method: 'get', url: '/json/abort_link/' + this.id
+                method: 'get', url: window.location.pathname + "/../json/abort_link/" + this.id
             }).send();
         }.bind(this));
 

--- a/src/pyload/webui/app/templates/js/dashboard.js
+++ b/src/pyload/webui/app/templates/js/dashboard.js
@@ -10,7 +10,7 @@ document.addEvent("domready", function(){
 var EntryManager = new Class({
     initialize: function(){
         this.json = new Request.JSON({
-            url: "/json/links",
+            url: "{{url_for("json.links")}}",
             secure: false,
             async: true,
             onSuccess: this.update.bind(this),

--- a/src/pyload/webui/app/templates/js/filemanager.js
+++ b/src/pyload/webui/app/templates/js/filemanager.js
@@ -170,7 +170,7 @@ var Item = new Class({
         hide_confirm_box();
         new Request.JSON({
             method: 'POST',
-            url: '/json/filemanager_delete',
+            url: "{{url_for('json.filemanager_delete')}}",
             data: {"path": this.path, "name": this.name},
             onSuccess: function(data) {
                 if(data.response == "success")
@@ -213,7 +213,7 @@ var Item = new Class({
         hide_rename_box();
         new Request.JSON({
             method: 'POST',
-            url: '/json/filemanager_rename',
+            url: "{{url_for('json.filemanager_rename')}}",
             onSuccess: function(data) {
                 if(data.response == "success")
                 {
@@ -235,13 +235,13 @@ var Item = new Class({
     mkdir: function(event) {
         new Request.JSON({
             method: 'POST',
-            url: '/json/filemanager_mkdir',
+            url: "{{url_for('json.filemanager_mkdir')}}",
             data: {"path": this.path + "/" + this.name, "name": '{{_("New folder")}}'},
             onSuccess: function(data) {
                 if(data.response == "success") {
                     new Request.HTML({
                         method: 'POST',
-                        url: '/json/filemanager_get_dir',
+                        url: "{{url_for('json.filemanager_get_dir')}}",
                         data: {"path": data.path, "name": data.name},
                         onSuccess: function(li) {
                             //add node as first child of ul

--- a/src/pyload/webui/app/templates/js/packages.js
+++ b/src/pyload/webui/app/templates/js/packages.js
@@ -281,7 +281,7 @@ var Package = new Class({
         indicateLoad();
         new Request({
             method: 'get',
-            url: window.location.pathname + "/../json/delete_packages/[" + this.id + ']',
+            url: "{{url_for('api.rpc', func='delete_packages')}}/[" + this.id + ']',
             onSuccess: function() {
                 this.ele.nix();
                 indicateFinish();

--- a/src/pyload/webui/app/templates/js/packages.js
+++ b/src/pyload/webui/app/templates/js/packages.js
@@ -66,7 +66,7 @@ var PackageUI = new Class({
         indicateLoad();
         new Request.JSON({
             method: 'get',
-            url: '/api/delete_finished',
+            url: "{{url_for('api.rpc', func='delete_finished')}}",
             onSuccess: function(data) {
                 if (data.length > 0) {
                     window.location.reload()
@@ -84,7 +84,7 @@ var PackageUI = new Class({
         indicateLoad();
         new Request.JSON({
             method: 'get',
-            url: '/api/restart_failed',
+            url: "{{url_for('api.rpc', func='restart_failed')}}",
             onSuccess: function(data) {
                 this.packages.each(function(pack) {
                     pack.close();
@@ -107,7 +107,7 @@ var PackageUI = new Class({
             indicateLoad();
             new Request.JSON({
                 method: 'get',
-                url: '/json/package_order/' + order[0],
+                url: window.location.pathname + "/../json/package_order/" + order[0],
                 onSuccess: indicateFinish,
                 onFailure: indicateFail
             }).send();
@@ -158,7 +158,7 @@ var Package = new Class({
         indicateLoad();
         new Request.JSON({
             method: 'get',
-            url: '/json/package/' + this.id,
+            url: window.location.pathname + "/../json/package/" + this.id,
             onSuccess: this.createLinks.bind(this),
             onFailure: indicateFail
         }).send();
@@ -241,7 +241,7 @@ var Package = new Class({
             imgs[0].addEvent('click', function(e) {
                 new Request({
                     method: 'get',
-                    url: '/api/delete_files/[' + this + ']',
+                    url: "{{url_for('api.rpc', func='delete_files')}}/[" + this + ']',
                     onSuccess: function() {
                         $('file_' + this).nix()
                     }.bind(this),
@@ -251,7 +251,7 @@ var Package = new Class({
             imgs[1].addEvent('click', function(e) {
                 new Request({
                     method: 'get',
-                    url: '/api/restart_file/' + this,
+                    url: "{{url_for('api.rpc', func='restart_file')}}/" + this,
                     onSuccess: function() {
                         var ele = $('file_' + this);
                         var imgs = ele.getElements("img");
@@ -281,7 +281,7 @@ var Package = new Class({
         indicateLoad();
         new Request({
             method: 'get',
-            url: '/api/delete_packages/[' + this.id + ']',
+            url: window.location.pathname + "/../json/delete_packages/[" + this.id + ']',
             onSuccess: function() {
                 this.ele.nix();
                 indicateFinish();
@@ -294,7 +294,7 @@ var Package = new Class({
         indicateLoad();
         new Request({
             method: 'get',
-            url: '/api/restart_package/' + this.id,
+            url: "{{url_for('api.rpc', func='restart_package')}}/" + this.id,
             onSuccess: function() {
                 this.close();
                 indicateSuccess();
@@ -318,7 +318,7 @@ var Package = new Class({
         indicateLoad();
         new Request({
             method: 'get',
-            url: '/json/move_package/' + ((this.ui.type + 1) % 2) + '|' + this.id,
+            url: window.location.pathname + "/../json/move_package/" + ((this.ui.type + 1) % 2) + '/' + this.id,
             onSuccess: function() {
                 this.ele.nix();
                 indicateFinish();
@@ -357,7 +357,7 @@ var Package = new Class({
             indicateLoad();
             new Request.JSON({
                 method: 'get',
-                url: '/json/link_order/' + order[0],
+                url: window.location.pathname + "/../json/link_order/" + order[0],
                 onSuccess: indicateFinish,
                 onFailure: indicateFail
             }).send();

--- a/src/pyload/webui/app/templates/js/settings.js
+++ b/src/pyload/webui/app/templates/js/settings.js
@@ -63,7 +63,7 @@ class SettingsUI {
 
     return new Request({
       "method" : "get",
-      "url" : `/json/load_config/${category}/${section}`,
+      "url" : window.location.pathname + "/../json/load_config//${category}/${section}",
       'onSuccess': data => {
         target.set("html", data);
         target.reveal();
@@ -79,7 +79,7 @@ class SettingsUI {
 
     form.set("send", {
       'method': "post",
-      'url': `/json/save_config/${category}`,
+      'url': window.location.pathname + "/../json/save_config/${category}",
       "onSuccess"() {
         return root.notify.alert('{{ _("Settings saved")}}', {
               'className': 'success'

--- a/src/pyload/webui/app/templates/logout.html
+++ b/src/pyload/webui/app/templates/logout.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head %}
-<meta http-equiv="refresh" content="3; url={{'dashboard'}}">
+<meta http-equiv="refresh" content="3; url="{{url_for('app.dashboard')}}">
 {% endblock %}
 
 {% block content %}

--- a/src/pyload/webui/app/templates/logs.html
+++ b/src/pyload/webui/app/templates/logs.html
@@ -9,7 +9,7 @@
 {% block content %}
 <div style="clear: both;"></div>
 
-<div class="logpaginator"><a href="/logs/1">&lt;&lt; {{_("Start")}}</a>  <a href="/logs/{{iprev|int}}">&lt; {{_("prev")}}</a>  <a href="/logs/{{inext|int}}">{{_("next")}} &gt;</a> <a href="/logs">{{_("End")}} &gt;&gt;</a></div>
+<div class="logpaginator"><a href={{url_for('app.logs', start_line=1)}}>&lt;&lt; {{_("Start")}}</a>  <a href="{{url_for('app.logs')}}/{{iprev|int}}">&lt; {{_("prev")}}</a>  <a href="{{url_for('app.logs')}}/{{inext|int}}">{{_("next")}} &gt;</a> <a href="{{url_for('app.logs')}}">{{_("End")}} &gt;&gt;</a></div>
 <div class="logperpage">
     <form id="logform1" action="" method="POST">
         <label for="reversed">Reversed:</label>

--- a/src/pyload/webui/app/templates/packages.html
+++ b/src/pyload/webui/app/templates/packages.html
@@ -76,7 +76,7 @@
 {% endblock %}
 {% block hidden %}
 <div id="pack_box" class="window_box" style="z-index: 2;">
-  <form id="pack_form" action="/json/edit_package" method="POST" enctype="multipart/form-data">
+  <form id="pack_form" action="{{url_for('json.edit_package')}}" method="POST" enctype="multipart/form-data">
     <h1>{{_("Edit Package")}}</h1>
     <p>{{_("Edit the package detais below.")}}</p>
     <input name="pack_id" id="pack_id" type="hidden" value="" />

--- a/src/pyload/webui/app/templates/settings.html
+++ b/src/pyload/webui/app/templates/settings.html
@@ -79,7 +79,7 @@
 
             <!-- Accounts -->
             <span id="accounts" class="tabContent">
-            <form id="account_form" action="/json/update_accounts" method="POST">
+            <form id="account_form" action="{{url_for('json.update_accounts')}}" method="POST">
 
                         <table class="settable wide">
 
@@ -170,7 +170,7 @@
 {% endblock %}
 {% block hidden %}
 <div id="account_box" class="window_box" style="z-index: 2">
-<form id="add_account_form" action="/json/add_account" method="POST" enctype="multipart/form-data">
+<form id="add_account_form" action="{{url_for('json.add_account')}}" method="POST" enctype="multipart/form-data">
 <h1>{{_("Add Account")}}</h1>
 <p>{{_("Enter your account data to use premium features.")}}</p>
 <label for="account_login">{{_("Login")}}

--- a/src/pyload/webui/app/templates/window.html
+++ b/src/pyload/webui/app/templates/window.html
@@ -8,7 +8,7 @@
 <div id="add_box" class="window_box">
   <form
     id="add_form"
-    action="/json/add_package"
+    action="{{url_for('json.add_package')}}"
     method="POST"
     enctype="multipart/form-data"
   >

--- a/src/pyload/webui/app/themes/modern/templates/admin.html
+++ b/src/pyload/webui/app/themes/modern/templates/admin.html
@@ -66,7 +66,7 @@
     <div class="modal-content">
       <div class="modal-header bg-info navbar-inverse text-center" style="padding: 5px" >{{_('Change Password')}}</div>
         <div class="modal-body" style="margin-bottom: 30px;">
-        <form id="password_form" class="from-group" action="/json/change_password" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
+        <form id="password_form" class="from-group" action="{{url_for('json.change_password')}}" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
           <p>{{_('Enter your current and desired Password.')}}</p>
           <div class="form-group">
             <label for="user_login">{{_('User')}}</label>

--- a/src/pyload/webui/app/themes/modern/templates/base.html
+++ b/src/pyload/webui/app/themes/modern/templates/base.html
@@ -48,26 +48,26 @@
 <nav id="sticky-nav" class="navbar navbar-default navbar-fixed-top hidden-xs hidden-sm" style="display: none; border-bottom: 1px solid rgba(0,0,0,.15); box-shadow: 0 1px 6px 0 rgba(32,33,36,0.28); min-height: 45px;">
   <ul  class="nav navbar-nav">
     <li ondragstart="return false;" {{selected('dashboard')}}>
-      <a href="/dashboard" title="{{_('Dashboard')}}"><span class="glyphicon glyphicon-home"></span></a>
+      <a href="{{url_for('app.dashboard')}}" title="{{_('Dashboard')}}"><span class="glyphicon glyphicon-home"></span></a>
     </li>
     <li ondragstart="return false;" {{selected('queue')}}>
-      <a href="/queue" title="{{_('Queue')}}"><span class="glyphicon glyphicon-tasks"></span></a>
+      <a href="{{url_for('app.queue')}}" title="{{_('Queue')}}"><span class="glyphicon glyphicon-tasks"></span></a>
     </li>
     <li ondragstart="return false;" {{selected('collector')}}>
-      <a href="/collector" title="{{_('Packages')}}"><span class="glyphicon glyphicon-magnet"></span></a>
+      <a href="{{url_for('app.collector')}}" title="{{_('Packages')}}"><span class="glyphicon glyphicon-magnet"></span></a>
     </li>
     <li ondragstart="return false;" {{selected('files')}}>
-      <a href="/files" title="{{_('Files')}}"><span class="glyphicon glyphicon-file"></span></a>
+      <a href="{{url_for('app.files')}}" title="{{_('Files')}}"><span class="glyphicon glyphicon-file"></span></a>
     </li>
     <li ondragstart="return false;" {{selected('logs')}}>
-      <a href="/logs" title="{{_('Logs')}}"><span class="glyphicon glyphicon-list-alt"></span></a>
+      <a href="{{url_for('app.logs')}}" title="{{_('Logs')}}"><span class="glyphicon glyphicon-list-alt"></span></a>
     </li>
     <li ondragstart="return false;" {{selected('settings', True)}}>
-      <a href="/settings"  title="{{_('Settings')}}"><span class="glyphicon glyphicon-cog"></span></a>
+      <a href="{{url_for('app.settings')}}"  title="{{_('Settings')}}"><span class="glyphicon glyphicon-cog"></span></a>
     </li>
     {% if user.is_admin %}
     <li ondragstart="return false;" {{selected('admin')}}>
-      <a href="/admin" title="{{_('Users')}}"><span class="glyphicon glyphicon-flag"></span></a>
+      <a href="{{url_for('app.admin')}}" title="{{_('Users')}}"><span class="glyphicon glyphicon-flag"></span></a>
     </li>
     {% endif %}
   </ul>
@@ -115,29 +115,29 @@
         {% block menu %}
          {% if user.is_authenticated %}
           <li ondragstart="return false;" {{selected('dashboard')}}>
-              <a href="/dashboard" title=""><span class="glyphicon glyphicon-home"></span><span class="hidden-sm"> {{_('Dashboard')}}</span></a>
+              <a href="{{url_for('app.dashboard')}}" title=""><span class="glyphicon glyphicon-home"></span><span class="hidden-sm"> {{_('Dashboard')}}</span></a>
           </li>
           <li ondragstart="return false;" {{selected('queue')}}>
-              <a href="/queue" title=""><span class="glyphicon glyphicon-tasks"></span><span class="hidden-sm"> {{_('Queue')}}</span></a>
+              <a href="{{url_for('app.queue')}}" title=""><span class="glyphicon glyphicon-tasks"></span><span class="hidden-sm"> {{_('Queue')}}</span></a>
           </li>
           <li ondragstart="return false;" {{selected('collector')}}>
-              <a href="/collector" title=""><span class="glyphicon glyphicon-magnet"></span><span class="hidden-sm"> {{_('Packages')}}</span></a>
+              <a href="{{url_for('app.collector')}}" title=""><span class="glyphicon glyphicon-magnet"></span><span class="hidden-sm"> {{_('Packages')}}</span></a>
           </li>
           <li ondragstart="return false;" {{selected('files')}}>
-              <a href="/files" title=""> <span class="glyphicon glyphicon-file"></span><span class="hidden-sm"> {{_('Files')}}</span></a>
+              <a href="{{url_for('app.files')}}" title=""> <span class="glyphicon glyphicon-file"></span><span class="hidden-sm"> {{_('Files')}}</span></a>
           </li>
     {#  <li ondragstart="return false;" {{selected('filemanager')}}>#}
     {#      <a href="/filemanager" title=""><span class="glyphicon glyphicon-magnet"></span><span class="hidden-sm"> {{_('FileManager')}}</span></a>#}
     {#  </li>#}
           <li ondragstart="return false;" {{selected('logs')}}>
-              <a href="/logs" title=""><span class="glyphicon glyphicon-list-alt"></span><span class="hidden-sm"> {{_('Logs')}}</span></a>
+              <a href="{{url_for('app.logs')}}" title=""><span class="glyphicon glyphicon-list-alt"></span><span class="hidden-sm"> {{_('Logs')}}</span></a>
           </li>
           <li ondragstart="return false;" {{selected('settings', True)}}>
-              <a href="/settings"  title=""><span class="glyphicon glyphicon-cog"></span><span class="hidden-sm"> {{_('Settings')}}</span></a>
+              <a href="{{url_for('app.settings')}}"  title=""><span class="glyphicon glyphicon-cog"></span><span class="hidden-sm"> {{_('Settings')}}</span></a>
           </li>
           {% if user.is_admin %}
           <li ondragstart="return false;" {{selected('admin')}}>
-              <a href="/admin" title=""><span class="glyphicon glyphicon-flag"></span><span class="hidden-sm"> {{_('Users')}}</span></a>
+              <a href="{{url_for('app.admin')}}" title=""><span class="glyphicon glyphicon-flag"></span><span class="hidden-sm"> {{_('Users')}}</span></a>
           </li>
           {% endif %}
          {% endif %}
@@ -147,8 +147,8 @@
         {% if user.is_authenticated %}
           <ul class="nav navbar-nav navbar-right">
             <li><span class="navbar-text"><span class="glyphicon glyphicon-user"></span><span class="hidden-sm hidden-md"> {{user.name}}</span></span></li>
-            <li><a href="/logout" class="action logout" rel="nofollow"><span class="glyphicon glyphicon-log-out"></span><span class="hidden-sm hidden-md">  {{_('Logout')}}</span></a></li>
-            <li ondragstart="return false;" {{selected('info')}}><a href="/info"  class="action info" rel="nofollow"><span class="glyphicon glyphicon-info-sign"></span><span class="hidden-sm hidden-md">  {{_('Info')}}</span></a></li>
+            <li><a href="{{url_for('app.logout')}}" class="action logout" rel="nofollow"><span class="glyphicon glyphicon-log-out"></span><span class="hidden-sm hidden-md">  {{_('Logout')}}</span></a></li>
+            <li ondragstart="return false;" {{selected('info')}}><a href="{{url_for('app.info')}}"  class="action info" rel="nofollow"><span class="glyphicon glyphicon-info-sign"></span><span class="hidden-sm hidden-md">  {{_('Info')}}</span></a></li>
           </ul>
         {% endif %}
       </div><!-- /.navbar-collapse -->

--- a/src/pyload/webui/app/themes/modern/templates/captcha.html
+++ b/src/pyload/webui/app/themes/modern/templates/captcha.html
@@ -7,7 +7,7 @@
       <div class="modal-header bg-info text-center" style="padding: 5px" >{{_('Captcha reading')}}</div>
       <div class="modal-body text-left">
         <div id="cap_title"></div>
-        <form id="cap_form" class="form-group" action="/json/set_captcha" method="POST" enctype="multipart/form-data" onsubmit="return false;" autocomplete="off" style="margin-bottom: 40px;">
+        <form id="cap_form" class="form-group" action="{{url_for('json.set_captcha')}}" method="POST" enctype="multipart/form-data" onsubmit="return false;" autocomplete="off" style="margin-bottom: 40px;">
           <input id="cap_id" name="cap_id" type="hidden" value=""/>
           <div id="cap_textual" style="display: none;">
             <div class="form-group">

--- a/src/pyload/webui/app/themes/modern/templates/js/admin.js
+++ b/src/pyload/webui/app/themes/modern/templates/js/admin.js
@@ -7,7 +7,7 @@ $(function() {
         if (passwd === passwdConfirm) {
             $.ajax({
                 method: "post",
-                url: "/json/change_password",
+                url: "{{url_for('json.change_password')}}",
                 data: $("#password_form").serialize(),
                 async: true,
                 success: function () {

--- a/src/pyload/webui/app/themes/modern/templates/js/base.js
+++ b/src/pyload/webui/app/themes/modern/templates/js/base.js
@@ -232,7 +232,7 @@ $(function() {
             return false;
         } else {
             $.ajax({
-                url: "/json/add_package",
+                url: "{{url_for('json.add_package')}}",
                 method: "POST",
                 data: formData,
                 processData: false,
@@ -258,10 +258,10 @@ $(function() {
     });
 
     $("#action_play").click(function() {
-        $.get("/api/unpause_server", function () {
+        $.get("{{url_for('api.rpc', func='unpause_server')}}", function () {
             $.ajax({
                 method: "post",
-                url: "/json/status",
+                url: "{{url_for('json.status')}}",
                 async: true,
                 timeout: 3000,
                 success: LoadJsonToContent
@@ -270,14 +270,14 @@ $(function() {
     });
 
     $("#action_cancel").click(function() {
-        $.get("/api/stop_all_downloads");
+        $.get("{{url_for('api.rpc', func='stop_all_downloads')}}");
     });
 
     $("#action_stop").click(function() {
-        $.get("/api/pause_server", function () {
+        $.get("{{url_for('api.rpc', func='pause_server')}}", function () {
             $.ajax({
                 method: "post",
-                url: "/json/status",
+                url: "{{url_for('json.status')}}",
                 async: true,
                 timeout: 3000,
                 success: LoadJsonToContent
@@ -298,7 +298,7 @@ $(function() {
 
     $.ajax({
         method:"post",
-        url: "/json/status",
+        url: "{{url_for('json.status')}}",
         async: true,
         timeout: 3000,
         success:LoadJsonToContent
@@ -307,7 +307,7 @@ $(function() {
     setInterval(function() {
         $.ajax({
             method:"post",
-            url: "/json/status",
+            url: "{{url_for('json.status')}}",
             async: true,
             timeout: 3000,
             success:LoadJsonToContent
@@ -396,7 +396,7 @@ function set_captcha(a) {
 
 function load_captcha(b, a) {
     $.ajax({
-            url: "/json/set_captcha",
+            url: "{{url_for('json.set_captcha')}}",
             async: true,
             method: b,
             data: a,

--- a/src/pyload/webui/app/themes/modern/templates/js/dashboard.js
+++ b/src/pyload/webui/app/themes/modern/templates/js/dashboard.js
@@ -30,7 +30,7 @@ function EntryManager(){
         thisObject=this;
         $.ajax({
             method:"post",
-            url: "/json/links",
+            url: "{{url_for('json.links')}}",
             async: true,
             timeout: 30000,
             success: thisObject.update
@@ -38,7 +38,7 @@ function EntryManager(){
         setInterval(function() {
         $.ajax({
             method:"post",
-            url: "/json/links",
+            url: "{{url_for('json.links')}}",
             async: true,
             timeout: 30000,
             success: thisObject.update
@@ -244,7 +244,7 @@ function LinkEntry(id){
         this.fadeBar = this.elements.pgbTr;
 
         $(this.elements.remove).click(function(){
-            $.get("/json/abort_link/" + id)});
+            $.get(window.location.pathname + "/../json/abort_link/" + id)});
     };
     this.update = function(item){
             $(this.elements.name).text(item.name);

--- a/src/pyload/webui/app/themes/modern/templates/js/packages.js
+++ b/src/pyload/webui/app/themes/modern/templates/js/packages.js
@@ -35,7 +35,7 @@ function PackageUI (type){
                 }
                 let order = ui.item.data('pid') + '|' + newIndex;
                 indicateLoad();
-                $.get("/json/package_order/" + order, function () {
+                $.get(window.location.pathname + "/../json/package_order/" + order, function () {
                     indicateFinish();
                     return true;
                 }).fail(function () {
@@ -48,7 +48,7 @@ function PackageUI (type){
 
     this.deleteFinished = function () {
         indicateLoad();
-        $.get("/api/delete_finished", function(data) {
+        $.get("{{url_for('api.rpc', func='delete_finished')}}", function(data) {
             if (data.length > 0) {
                 window.location.reload();
             } else {
@@ -64,7 +64,7 @@ function PackageUI (type){
 
     this.restartFailed = function () {
         indicateLoad();
-        $.get("/api/restart_failed", function(data) {
+        $.get("{{url_for('api.rpc', func='restart_failed')}}", function(data) {
             if (data.length > 0) {
                 $.each(packages,function(pack) {
                     this.close();
@@ -133,7 +133,7 @@ function Package (ui, id, ele){
 
     this.loadLinks = function () {
         indicateLoad();
-        $.get("/json/package/" + id, thisObject.createLinks)
+        $.get(window.location.pathname + "/../json/package/" + id, thisObject.createLinks)
         .fail(function () {
             indicateFail();
             return false;
@@ -201,7 +201,7 @@ function Package (ui, id, ele){
             var lid = $(this).find('.child').attr('id').match(/[0-9]+/);
             var imgs = $(this).find('.child_secrow span');
             $(imgs[3]).bind('click',{ lid: lid}, function(e) {
-                $.get("/api/delete_files/[" + lid + "]", function () {
+                $.get("{{url_for('api.rpc', func='delete_files')}}/[" + lid + "]", function () {
                     $('#file_' + lid).remove()
                 }).fail(function () {
                     indicateFail();
@@ -209,7 +209,7 @@ function Package (ui, id, ele){
             });
 
             $(imgs[4]).bind('click',{ lid: lid},function(e) {
-                $.get("/api/restart_file/" + lid, function () {
+                $.get("{{url_for('api.rpc', func='restart_file')}}/" + lid, function () {
                     var ele1 = $('#file_' + lid);
                     var imgs1 = $(ele1).find(".glyphicon");
                     $(imgs1[0]).attr( "class", "glyphicon glyphicon-time text-info");
@@ -239,7 +239,7 @@ function Package (ui, id, ele){
                 }
                 var order = ui.item.data('lid') + '|' + newIndex;
                 indicateLoad();
-                $.get("/json/link_order/" + order, function () {
+                $.get(window.location.pathname + "/../json/link_order/" + order, function () {
                     indicateFinish();
                     return true;
                 } ).fail(function () {
@@ -272,7 +272,7 @@ function Package (ui, id, ele){
 
     this.deletePackage = function(event) {
         indicateLoad();
-        $.get("/api/delete_packages/[" + id + "]", function () {
+        $.get(window.location.pathname + "/../json/delete_packages/[" + id + "]", function () {
             $(ele).remove();
             indicateFinish();
         }).fail(function () {
@@ -285,7 +285,7 @@ function Package (ui, id, ele){
 
     this.restartPackage = function(event) {
         indicateLoad();
-        $.get("/api/restart_package/" + id, function () {
+        $.get("{{url_for('api.rpc', func='restart_package')}}/" + id, function () {
             thisObject.close();
             indicateSuccess();
         }).fail(function () {
@@ -310,7 +310,7 @@ function Package (ui, id, ele){
 
     this.movePackage = function(event) {
         indicateLoad();
-        $.get("/json/move_package/" + ((ui.type + 1) % 2) + '|' + id, function () {
+        $.get(window.location.pathname + "/../json/move_package/" + ((ui.type + 1) % 2) + '|' + id, function () {
             $(ele).remove();
             indicateFinish();
         }).fail(function () {
@@ -322,11 +322,11 @@ function Package (ui, id, ele){
 
     this.editOrder = function(event) {
         indicateLoad();
-        $.get("/json/package/" + id, function(data){
+        $.get(window.location.pathname + "/../json/package/" + id, function(data){
             length = data.links.length;
             for (i = 1; i <= length/2; i++){
                 order = data.links[length-i].fid + '|' + (i-1);
-                $.get("/json/link_order/" + order).fail(function () {
+                $.get(window.location.pathname + "/../json/link_order/" + order).fail(function () {
                     indicateFail();
                 });
             }
@@ -352,7 +352,7 @@ function Package (ui, id, ele){
 
     this.savePackage = function(event) {
         $.ajax({
-            url: "/json/edit_package",
+            url: "{{url_for('json.edit_package')}}",
             type: 'post',
             dataType: 'json',
             data: $('#pack_form').serialize()

--- a/src/pyload/webui/app/themes/modern/templates/js/packages.js
+++ b/src/pyload/webui/app/themes/modern/templates/js/packages.js
@@ -272,7 +272,7 @@ function Package (ui, id, ele){
 
     this.deletePackage = function(event) {
         indicateLoad();
-        $.get(window.location.pathname + "/../json/delete_packages/[" + id + "]", function () {
+        $.get("{{url_for('api.rpc', func='delete_packages')}}/[" + id + "]", function () {
             $(ele).remove();
             indicateFinish();
         }).fail(function () {

--- a/src/pyload/webui/app/themes/modern/templates/js/settings.js
+++ b/src/pyload/webui/app/themes/modern/templates/js/settings.js
@@ -18,7 +18,7 @@ SettingsUI = (function() {
         let c, e, b, d;
 
         $("#quit_box").on('click', '#quit_button', function () {
-            $.get("/api/kill", function() {
+            $.get("{{url_for('api.rpc', func='kill')}}", function() {
                 $('#quit_box').modal('hide');
                 $('#content').addClass("hidden");
                 $('#shutdown_msg').removeClass("hidden");
@@ -29,12 +29,12 @@ SettingsUI = (function() {
         });
 
         $("#restart_box").on('click', '#restart_button', function () {
-            $.get("/api/restart", function() {
+            $.get("{{url_for('api.rpc', func='restart')}}", function() {
                 $('#restart_box').modal('hide');
                 $('#content').addClass("hidden");
                 $('#restart_msg').removeClass("hidden");
                 setTimeout(function() {
-                    window.location = "/dashboard";
+                    window.location = "{{url_for('app.dashboard')}}";
                 }, 10000);
             })
             .fail(function () {
@@ -124,7 +124,7 @@ SettingsUI = (function() {
         d = $(this).attr('id').split('|'), c = d[0], g = d[1];
         b = $(this).text();
         f = c === 'general' ? generalPanel : pluginPanel;
-        $.get( "/json/load_config/" + c + '/' + g, function(e) {
+        $.get( window.location.pathname + "/../json/load_config/" + c + '/' + g, function(e) {
                 f.html(e);
             });
     };
@@ -133,7 +133,7 @@ SettingsUI = (function() {
         c = $(this).attr('id').split("_")[0];
         $.ajax({
             method: "post",
-            url: "/json/save_config/" + c,
+            url: window.location.pathname + "/../json/save_config/" + c,
             data: $("#" + c + "_form").serialize(),
             async: true,
             success: function () {
@@ -150,7 +150,7 @@ SettingsUI = (function() {
         $(this).addClass("disabled");
         $.ajax({
             method: "post",
-            url: "/json/add_account",
+            url: "{{url_for('json.add_account')}}",
             async: true,
             data: $("#add_account_form").serialize(),
             success: function () {
@@ -167,7 +167,7 @@ SettingsUI = (function() {
         indicateLoad();
         $.ajax({
             method: "post",
-            url: "/json/update_accounts",
+            url: "{{url_for('json.update_accounts')}}",
             data: $("#account_form").serialize(),
             async: true,
             success: function () {

--- a/src/pyload/webui/app/themes/modern/templates/logs.html
+++ b/src/pyload/webui/app/themes/modern/templates/logs.html
@@ -10,7 +10,7 @@
 {% block content %}
 <div class="clear"></div>
 
-<div class="logpaginator"><a href="/logs/1"><span class="glyphicon glyphicon-fast-backward"></span></a> <a href="/logs/{{iprev}}"><span class="glyphicon glyphicon-step-backward"></span></a>  <a href="/logs/{{inext}}"><span class="glyphicon glyphicon-step-forward"></span></a> <a href="/logs"><span class="glyphicon glyphicon-fast-forward"></span></a></div>
+<div class="logpaginator"><a href="{{url_for('app.logs', start_line=1)}}"><span class="glyphicon glyphicon-fast-backward"></span></a> <a href="{{url_for('app.logs'}}/{{iprev}}"><span class="glyphicon glyphicon-step-backward"></span></a>  <a href="{{url_for('app.logs'}}/{{inext}}"><span class="glyphicon glyphicon-step-forward"></span></a> <a href="/logs"><span class="glyphicon glyphicon-fast-forward"></span></a></div>
 <div class="logperpage" style="float: right;">
   <form id="logform1" action="" method="POST">
     <label for="reversed">{{_('Reversed')}}:</label>

--- a/src/pyload/webui/app/themes/modern/templates/packages.html
+++ b/src/pyload/webui/app/themes/modern/templates/packages.html
@@ -73,7 +73,7 @@
     <div class="modal-content">
       <div class="modal-header bg-info text-center" style="padding: 5px" >{{_('Edit Package')}}</div>
         <div class="modal-body" style="margin-bottom: 30px;">
-        <form id="pack_form" class="from-group" action="/json/edit_package" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
+        <form id="pack_form" class="from-group" action="{{url_for('json.edit_package')}}" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
           <p>{{_('Edit the package detais below')}}</p>
             <input name="pack_id" id="pack_id" type="hidden" value=""/>
             <div class="form-group">

--- a/src/pyload/webui/app/themes/modern/templates/settings.html
+++ b/src/pyload/webui/app/themes/modern/templates/settings.html
@@ -81,7 +81,7 @@
     </form>
   </div>
   <div id="accounts" class="tab-pane fade">
-    <form id="account_form" action="/json/update_accounts" method="POST">
+    <form id="account_form" action="{{url_for('json.update_accounts')}}" method="POST">
       <table class="settable wide table">
         <thead>
         <tr>
@@ -150,7 +150,7 @@
     <div class="modal-content">
       <div class="modal-header bg-info text-center" style="padding: 5px"> {{_('Add Account')}}</div>
       <div class="modal-body" style="margin-bottom: 30px;">
-        <form id="add_account_form" action="/json/add_account" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
+        <form id="add_account_form" action="{{url_for('json.add_account')}}" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
           <p>{{_('Enter your account data to use premium features')}}</p>
           <div class="form-group">
             <label for="account_login">{{_('Login')}}</label>

--- a/src/pyload/webui/app/themes/modern/templates/window.html
+++ b/src/pyload/webui/app/themes/modern/templates/window.html
@@ -5,7 +5,7 @@
       <div class="modal-header bg-info text-center" style="cursor: move; padding: 5px">{{_('Add Package')}}</div>
       <div class="modal-body text-left" style="cursor: move;">
         <div id="cap_title">{{_('Paste your links or upload a container.')}}</div>
-        <form id="add_form" class="form-group" action="/json/add_package" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
+        <form id="add_form" class="form-group" action="{{url_for('json.add_package')}}" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
           <div class="form-group">
             <label for="add_name">{{_('Name')}}</label>
             <input id="add_name" class="form-control" name="add_name" type="text"/>

--- a/src/pyload/webui/app/themes/pyplex/templates/admin.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/admin.html
@@ -66,7 +66,7 @@
     <div class="modal-content">
       <div class="modal-header bg-info navbar-inverse text-center" style="padding: 5px" >{{_('Change Password')}}</div>
         <div class="modal-body" style="margin-bottom: 30px;">
-        <form id="password_form" class="from-group" action="/json/change_password" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
+        <form id="password_form" class="from-group" action="{{url_for("json.change_password")}}" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
           <p>{{_('Enter your current and desired Password.')}}</p>
           <div class="form-group">
             <label for="user_login">{{_('User')}}</label>

--- a/src/pyload/webui/app/themes/pyplex/templates/base.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/base.html
@@ -48,26 +48,26 @@
 <nav id="sticky-nav" class="navbar navbar-inverse navoben navbar-fixed-top hidden-sm hidden-xs" style="display: none; border-bottom: 1px solid rgba(255,255,255,.15); box-shadow: 0 1px 6px 0 rgba(111,114,125,0.28); min-height: 45px;">
   <ul  class="nav navbar-nav">
     <li ondragstart="return false;" {{selected('dashboard')}}>
-      <a href="/dashboard" title="{{_('Dashboard')}}"><span class="glyphicon glyphicon-home"></span></a>
+      <a href="{{url_for("app.dashboard")}}" title="{{_('Dashboard')}}"><span class="glyphicon glyphicon-home"></span></a>
     </li>
     <li ondragstart="return false;" {{selected('queue')}}>
-      <a href="/queue" title="{{_('Queue')}}"><span class="glyphicon glyphicon-tasks"></span></a>
+      <a href="{{url_for("app.queue")}}" title="{{_('Queue')}}"><span class="glyphicon glyphicon-tasks"></span></a>
     </li>
     <li ondragstart="return false;" {{selected('collector')}}>
-      <a href="/collector" title="{{_('Packages')}}"><span class="glyphicon glyphicon-magnet"></span></a>
+      <a href="{{url_for("app.collector")}}" title="{{_('Packages')}}"><span class="glyphicon glyphicon-magnet"></span></a>
     </li>
     <li ondragstart="return false;" {{selected('files')}}>
-      <a href="/files" title="{{_('Files')}}"><span class="glyphicon glyphicon-file"></span></a>
+      <a href="{{url_for("app.files")}}" title="{{_('Files')}}"><span class="glyphicon glyphicon-file"></span></a>
     </li>
     <li ondragstart="return false;" {{selected('logs')}}>
-      <a href="/logs" title="{{_('Logs')}}"><span class="glyphicon glyphicon-list-alt"></span></a>
+      <a href="{{url_for("app.logs")}}" title="{{_('Logs')}}"><span class="glyphicon glyphicon-list-alt"></span></a>
     </li>
     <li ondragstart="return false;" {{selected('settings', True)}}>
-      <a href="/settings"  title="{{_('Settings')}}"><span class="glyphicon glyphicon-cog"></span></a>
+      <a href="{{url_for("app.settings")}}"  title="{{_('Settings')}}"><span class="glyphicon glyphicon-cog"></span></a>
     </li>
     {% if user.is_admin %}
     <li ondragstart="return false;" {{selected('admin')}}>
-      <a href="/admin" title="{{_('Users')}}"><span class="glyphicon glyphicon-flag"></span></a>
+      <a href="{{url_for("app.admin")}}" title="{{_('Users')}}"><span class="glyphicon glyphicon-flag"></span></a>
     </li>
     {% endif %}
   </ul>
@@ -115,29 +115,29 @@
         {% block menu %}
          {% if user.is_authenticated %}
           <li ondragstart="return false;" {{selected('dashboard')}}>
-              <a href="/dashboard" title=""><span class="glyphicon glyphicon-home"></span><span class="hidden-sm"> {{_('Dashboard')}}</span></a>
+              <a href="{{url_for("app.dashboard")}}" title=""><span class="glyphicon glyphicon-home"></span><span class="hidden-sm"> {{_('Dashboard')}}</span></a>
           </li>
           <li ondragstart="return false;" {{selected('queue')}}>
-              <a href="/queue" title=""><span class="glyphicon glyphicon-tasks"></span><span class="hidden-sm"> {{_('Queue')}}</span></a>
+              <a href="{{url_for("app.queue")}}" title=""><span class="glyphicon glyphicon-tasks"></span><span class="hidden-sm"> {{_('Queue')}}</span></a>
           </li>
           <li ondragstart="return false;" {{selected('collector')}}>
-              <a href="/collector" title=""><span class="glyphicon glyphicon-magnet"></span><span class="hidden-sm"> {{_('Packages')}}</span></a>
+              <a href="{{url_for("app.collector")}}" title=""><span class="glyphicon glyphicon-magnet"></span><span class="hidden-sm"> {{_('Packages')}}</span></a>
           </li>
           <li ondragstart="return false;" {{selected('files')}}>
-              <a href="/files" title=""> <span class="glyphicon glyphicon-file"></span><span class="hidden-sm"> {{_('Files')}}</span></a>
+              <a href="{{url_for("app.files")}}" title=""> <span class="glyphicon glyphicon-file"></span><span class="hidden-sm"> {{_('Files')}}</span></a>
           </li>
     {#  <li ondragstart="return false;" {{selected('filemanager')}}>#}
     {#      <a href="/filemanager" title=""><span class="glyphicon glyphicon-magnet"></span><span class="hidden-sm"> {{_('FileManager')}}</span></a>#}
     {#  </li>#}
           <li ondragstart="return false;" {{selected('logs')}}>
-              <a href="/logs" title=""><span class="glyphicon glyphicon-list-alt"></span><span class="hidden-sm"> {{_('Logs')}}</span></a>
+              <a href="{{url_for("app.logs")}}" title=""><span class="glyphicon glyphicon-list-alt"></span><span class="hidden-sm"> {{_('Logs')}}</span></a>
           </li>
           <li ondragstart="return false;" {{selected('settings', True)}}>
-              <a href="/settings"  title=""><span class="glyphicon glyphicon-cog"></span><span class="hidden-sm"> {{_('Settings')}}</span></a>
+              <a href="{{url_for("app.settings")}}"  title=""><span class="glyphicon glyphicon-cog"></span><span class="hidden-sm"> {{_('Settings')}}</span></a>
           </li>
           {% if user.is_admin %}
           <li ondragstart="return false;" {{selected('admin')}}>
-              <a href="/admin" title=""><span class="glyphicon glyphicon-flag"></span><span class="hidden-sm"> {{_('Users')}}</span></a>
+              <a href="{{url_for("app.admin")}}" title=""><span class="glyphicon glyphicon-flag"></span><span class="hidden-sm"> {{_('Users')}}</span></a>
           </li>
           {% endif %}
          {% endif %}
@@ -147,8 +147,8 @@
         {% if user.is_authenticated %}
           <ul class="nav navbar-nav navbar-right">
             <li><span class="navbar-text"><span class="glyphicon glyphicon-user"></span><span class="hidden-sm hidden-md"> {{user.name}}</span></span></li>
-            <li><a href="/logout" class="action logout" rel="nofollow"><span class="glyphicon glyphicon-log-out"></span><span class="hidden-sm hidden-md">  {{_('Logout')}}</span></a></li>
-            <li ondragstart="return false;" {{selected('info')}}><a href="/info"  class="action info" rel="nofollow"><span class="glyphicon glyphicon-info-sign"></span><span class="hidden-sm hidden-md">  {{_('Info')}}</span></a></li>
+            <li><a href="{{url_for("app.logout")}}" class="action logout" rel="nofollow"><span class="glyphicon glyphicon-log-out"></span><span class="hidden-sm hidden-md">  {{_('Logout')}}</span></a></li>
+            <li ondragstart="return false;" {{selected('info')}}><a href="{{url_for("app.info")}}"  class="action info" rel="nofollow"><span class="glyphicon glyphicon-info-sign"></span><span class="hidden-sm hidden-md">  {{_('Info')}}</span></a></li>
           </ul>
         {% endif %}
       </div><!-- /.navbar-collapse -->

--- a/src/pyload/webui/app/themes/pyplex/templates/captcha.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/captcha.html
@@ -7,7 +7,7 @@
       <div class="modal-header bg-info navbar-inverse text-center" style="padding: 5px" >{{_('Captcha reading')}}</div>
       <div class="modal-body text-left">
         <div id="cap_title"></div>
-        <form id="cap_form" class="form-group" action="/json/set_captcha" method="POST" enctype="multipart/form-data" onsubmit="return false;" autocomplete="off" style="margin-bottom: 40px;">
+        <form id="cap_form" class="form-group" action="{{url_for('json.set_captcha')}}" method="POST" enctype="multipart/form-data" onsubmit="return false;" autocomplete="off" style="margin-bottom: 40px;">
           <input id="cap_id" name="cap_id" type="hidden" value=""/>
           <div id="cap_textual" style="display: none;">
             <div class="form-group">

--- a/src/pyload/webui/app/themes/pyplex/templates/js/admin.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/admin.js
@@ -7,7 +7,7 @@ $(function() {
         if (passwd === passwdConfirm) {
             $.ajax({
                 method: "post",
-                url: "/json/change_password",
+                url: "{{url_for('json.change_password')}}",
                 data: $("#password_form").serialize(),
                 async: true,
                 success: function () {

--- a/src/pyload/webui/app/themes/pyplex/templates/js/base.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/base.js
@@ -258,10 +258,10 @@ $(function() {
     });
 
     $("#action_play").click(function() {
-        $.get("/api/unpause_server", function () {
+        $.get(window.location.pathname + "/../api/unpause_server", function () {
             $.ajax({
                 method: "post",
-                url: "/json/status",
+                url: "{{url_for("json.status")}}",
                 async: true,
                 timeout: 3000,
                 success: LoadJsonToContent
@@ -270,14 +270,14 @@ $(function() {
     });
 
     $("#action_cancel").click(function() {
-        $.get("/api/stop_all_downloads");
+        $.get(window.location.pathname + "/../api/stop_all_downloads");
     });
 
     $("#action_stop").click(function() {
-        $.get("/api/pause_server", function () {
+        $.get(window.location.pathname + "/../api/pause_server", function () {
             $.ajax({
                 method: "post",
-                url: "/json/status",
+                url: "{{url_for("json.status")}}",
                 async: true,
                 timeout: 3000,
                 success: LoadJsonToContent
@@ -298,7 +298,7 @@ $(function() {
 
     $.ajax({
         method:"post",
-        url: "/json/status",
+        url: "{{url_for("json.status")}}",
         async: true,
         timeout: 3000,
         success:LoadJsonToContent
@@ -307,7 +307,7 @@ $(function() {
     setInterval(function() {
         $.ajax({
             method:"post",
-            url: "/json/status",
+            url: "{{url_for("json.status")}}",
             async: true,
             timeout: 3000,
             success:LoadJsonToContent
@@ -396,7 +396,7 @@ function set_captcha(a) {
 
 function load_captcha(b, a) {
     $.ajax({
-            url: "/json/set_captcha",
+            url: "{{url_for("json.set_captcha")}}",
             async: true,
             method: b,
             data: a,

--- a/src/pyload/webui/app/themes/pyplex/templates/js/base.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/base.js
@@ -232,7 +232,7 @@ $(function() {
             return false;
         } else {
             $.ajax({
-                url: "/json/add_package",
+                url: "{{url_for('json.add_package')}}",
                 method: "POST",
                 data: formData,
                 processData: false,
@@ -258,10 +258,10 @@ $(function() {
     });
 
     $("#action_play").click(function() {
-        $.get("{{url_for("api.rpc", func="unpause_server")}}", function () {
+        $.get("{{url_for('api.rpc', func='unpause_server')}}", function () {
             $.ajax({
                 method: "post",
-                url: "{{url_for("json.status")}}",
+                url: "{{url_for('json.status')}}",
                 async: true,
                 timeout: 3000,
                 success: LoadJsonToContent
@@ -270,14 +270,14 @@ $(function() {
     });
 
     $("#action_cancel").click(function() {
-        $.get("{{url_for("api.rpc", func="stop_all_downloads")}}");
+        $.get("{{url_for('api.rpc', func='stop_all_downloads')}}");
     });
 
     $("#action_stop").click(function() {
-        $.get("{{url_for("api.rpc", func="pause_server")}}", function () {
+        $.get("{{url_for('api.rpc', func='pause_server')}}", function () {
             $.ajax({
                 method: "post",
-                url: "{{url_for("json.status")}}",
+                url: "{{url_for('json.status')}}",
                 async: true,
                 timeout: 3000,
                 success: LoadJsonToContent
@@ -298,7 +298,7 @@ $(function() {
 
     $.ajax({
         method:"post",
-        url: "{{url_for("json.status")}}",
+        url: "{{url_for('json.status')}}",
         async: true,
         timeout: 3000,
         success:LoadJsonToContent
@@ -307,7 +307,7 @@ $(function() {
     setInterval(function() {
         $.ajax({
             method:"post",
-            url: "{{url_for("json.status")}}",
+            url: "{{url_for('json.status')}}",
             async: true,
             timeout: 3000,
             success:LoadJsonToContent
@@ -396,7 +396,7 @@ function set_captcha(a) {
 
 function load_captcha(b, a) {
     $.ajax({
-            url: "{{url_for("json.set_captcha")}}",
+            url: "{{url_for('json.set_captcha')}}",
             async: true,
             method: b,
             data: a,

--- a/src/pyload/webui/app/themes/pyplex/templates/js/base.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/base.js
@@ -258,7 +258,7 @@ $(function() {
     });
 
     $("#action_play").click(function() {
-        $.get(window.location.pathname + "/../api/unpause_server", function () {
+        $.get("{{url_for("api.rpc", func="unpause_server")}}", function () {
             $.ajax({
                 method: "post",
                 url: "{{url_for("json.status")}}",
@@ -270,11 +270,11 @@ $(function() {
     });
 
     $("#action_cancel").click(function() {
-        $.get(window.location.pathname + "/../api/stop_all_downloads");
+        $.get("{{url_for("api.rpc", func="stop_all_downloads")}}");
     });
 
     $("#action_stop").click(function() {
-        $.get(window.location.pathname + "/../api/pause_server", function () {
+        $.get("{{url_for("api.rpc", func="pause_server")}}", function () {
             $.ajax({
                 method: "post",
                 url: "{{url_for("json.status")}}",

--- a/src/pyload/webui/app/themes/pyplex/templates/js/dashboard.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/dashboard.js
@@ -30,7 +30,7 @@ function EntryManager(){
         thisObject=this;
         $.ajax({
             method:"post",
-            url: "/json/links",
+            url: "{{url_for("json.links")}}",
             async: true,
             timeout: 30000,
             success: thisObject.update
@@ -38,7 +38,7 @@ function EntryManager(){
         setInterval(function() {
         $.ajax({
             method:"post",
-            url: "/json/links",
+            url: "{{url_for("json.links")}}",
             async: true,
             timeout: 30000,
             success: thisObject.update

--- a/src/pyload/webui/app/themes/pyplex/templates/js/dashboard.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/dashboard.js
@@ -30,7 +30,7 @@ function EntryManager(){
         thisObject=this;
         $.ajax({
             method:"post",
-            url: "{{url_for("json.links")}}",
+            url: "{{url_for('json.links')}}",
             async: true,
             timeout: 30000,
             success: thisObject.update
@@ -38,7 +38,7 @@ function EntryManager(){
         setInterval(function() {
         $.ajax({
             method:"post",
-            url: "{{url_for("json.links")}}",
+            url: "{{url_for('json.links')}}",
             async: true,
             timeout: 30000,
             success: thisObject.update
@@ -244,7 +244,7 @@ function LinkEntry(id){
         this.fadeBar = this.elements.pgbTr;
 
         $(this.elements.remove).click(function(){
-            $.get("/json/abort_link/" + id)});
+            $.get(window.location.pathname + "/../json/abort_link/" + id)});
     };
     this.update = function(item){
             $(this.elements.name).text(item.name);

--- a/src/pyload/webui/app/themes/pyplex/templates/js/packages.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/packages.js
@@ -272,7 +272,7 @@ function Package (ui, id, ele){
 
     this.deletePackage = function(event) {
         indicateLoad();
-        $.get(window.location.pathname + "/../json/delete_packages/[" + id + "]", function () {
+        $.get("{{url_for('api.rpc', func='delete_packages')}}/[" + id + "]", function () {
             $(ele).remove();
             indicateFinish();
         }).fail(function () {

--- a/src/pyload/webui/app/themes/pyplex/templates/js/packages.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/packages.js
@@ -35,7 +35,7 @@ function PackageUI (type){
                 }
                 let order = ui.item.data('pid') + '|' + newIndex;
                 indicateLoad();
-                $.get("/json/package_order/" + order, function () {
+                $.get(window.location.pathname + "/../json/package_order/" + order, function () {
                     indicateFinish();
                     return true;
                 }).fail(function () {
@@ -48,7 +48,7 @@ function PackageUI (type){
 
     this.deleteFinished = function () {
         indicateLoad();
-        $.get("/api/delete_finished", function(data) {
+        $.get("{{url_for('api.rpc', func='delete_finished')}}", function(data) {
             if (data.length > 0) {
                 window.location.reload();
             } else {
@@ -64,7 +64,7 @@ function PackageUI (type){
 
     this.restartFailed = function () {
         indicateLoad();
-        $.get("/api/restart_failed", function(data) {
+        $.get("{{url_for('api.rpc', func='restart_failed')}}", function(data) {
             if (data.length > 0) {
                 $.each(packages,function(pack) {
                     this.close();
@@ -133,7 +133,7 @@ function Package (ui, id, ele){
 
     this.loadLinks = function () {
         indicateLoad();
-        $.get("/json/package/" + id, thisObject.createLinks)
+        $.get(window.location.pathname + "/../json/package/" + id, thisObject.createLinks)
         .fail(function () {
             indicateFail();
             return false;
@@ -201,7 +201,7 @@ function Package (ui, id, ele){
             var lid = $(this).find('.child').attr('id').match(/[0-9]+/);
             var imgs = $(this).find('.child_secrow span');
             $(imgs[3]).bind('click',{ lid: lid}, function(e) {
-                $.get("/api/delete_files/[" + lid + "]", function () {
+                $.get("{{url_for('api.rpc', func='delete_files')}}/[" + lid + "]", function () {
                     $('#file_' + lid).remove()
                 }).fail(function () {
                     indicateFail();
@@ -209,7 +209,7 @@ function Package (ui, id, ele){
             });
 
             $(imgs[4]).bind('click',{ lid: lid},function(e) {
-                $.get("/api/restart_file/" + lid, function () {
+                $.get("{{url_for('api.rpc', func='restart_file')}}/" + lid, function () {
                     var ele1 = $('#file_' + lid);
                     var imgs1 = $(ele1).find(".glyphicon");
                     $(imgs1[0]).attr( "class", "glyphicon glyphicon-time text-info");
@@ -239,10 +239,10 @@ function Package (ui, id, ele){
                 }
                 var order = ui.item.data('lid') + '|' + newIndex;
                 indicateLoad();
-                $.get("/json/link_order/" + order, function () {
+                $.get(window.location.pathname + "/../json/link_order/" + order, function () {
                     indicateFinish();
                     return true;
-                } ).fail(function () {
+                }).fail(function () {
                     indicateFail();
                     return false;
                 });
@@ -272,7 +272,7 @@ function Package (ui, id, ele){
 
     this.deletePackage = function(event) {
         indicateLoad();
-        $.get("/api/delete_packages/[" + id + "]", function () {
+        $.get(window.location.pathname + "/../json/delete_packages/[" + id + "]", function () {
             $(ele).remove();
             indicateFinish();
         }).fail(function () {
@@ -285,7 +285,7 @@ function Package (ui, id, ele){
 
     this.restartPackage = function(event) {
         indicateLoad();
-        $.get("/api/restart_package/" + id, function () {
+        $.get("{{url_for('api.rpc', func='restart_package')}}/" + id, function () {
             thisObject.close();
             indicateSuccess();
         }).fail(function () {
@@ -310,7 +310,7 @@ function Package (ui, id, ele){
 
     this.movePackage = function(event) {
         indicateLoad();
-        $.get("/json/move_package/" + ((ui.type + 1) % 2) + '|' + id, function () {
+        $.get(window.location.pathname + "/../json/move_package/" + ((ui.type + 1) % 2) + '|' + id, function () {
             $(ele).remove();
             indicateFinish();
         }).fail(function () {
@@ -322,11 +322,11 @@ function Package (ui, id, ele){
 
     this.editOrder = function(event) {
         indicateLoad();
-        $.get("/json/package/" + id, function(data){
+        $.get(window.location.pathname + "/../json/package/" + id, function(data){
             length = data.links.length;
             for (i = 1; i <= length/2; i++){
                 order = data.links[length-i].fid + '|' + (i-1);
-                $.get("/json/link_order/" + order).fail(function () {
+                $.get(window.location.pathname + "/../json/link_order/" + order).fail(function () {
                     indicateFail();
                 });
             }
@@ -352,7 +352,7 @@ function Package (ui, id, ele){
 
     this.savePackage = function(event) {
         $.ajax({
-            url: "/json/edit_package",
+            url: "{{url_for('json.edit_package')}}",
             type: 'post',
             dataType: 'json',
             data: $('#pack_form').serialize()

--- a/src/pyload/webui/app/themes/pyplex/templates/js/settings.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/settings.js
@@ -18,7 +18,7 @@ SettingsUI = (function() {
         let c, e, b, d;
 
         $("#quit_box").on('click', '#quit_button', function () {
-            $.get("/api/kill", function() {
+            $.get("{{url_for('api.rpc', func='kill')}}", function() {
                 $('#quit_box').modal('hide');
                 $('#content').addClass("hidden");
                 $('#shutdown_msg').removeClass("hidden");
@@ -29,12 +29,12 @@ SettingsUI = (function() {
         });
 
         $("#restart_box").on('click', '#restart_button', function () {
-            $.get("/api/restart", function() {
+            $.get("{{url_for('api.rpc', func='restart')}}", function() {
                 $('#restart_box').modal('hide');
                 $('#content').addClass("hidden");
                 $('#restart_msg').removeClass("hidden");
                 setTimeout(function() {
-                    window.location = "/dashboard";
+                    window.location = "{{url_for('app.dashboard')}}";
                 }, 10000);
             })
             .fail(function () {
@@ -124,7 +124,7 @@ SettingsUI = (function() {
         d = $(this).attr('id').split('|'), c = d[0], g = d[1];
         b = $(this).text();
         f = c === 'general' ? generalPanel : pluginPanel;
-        $.get( "/json/load_config/" + c + '/' + g, function(e) {
+        $.get( window.location.pathname + "/../json/load_config/" + c + '/' + g, function(e) {
                 f.html(e);
             });
     };
@@ -133,7 +133,7 @@ SettingsUI = (function() {
         c = $(this).attr('id').split("_")[0];
         $.ajax({
             method: "post",
-            url: "/json/save_config/" + c,
+            url: window.location.pathname + "/../json/save_config/" + c,
             data: $("#" + c + "_form").serialize(),
             async: true,
             success: function () {
@@ -150,7 +150,7 @@ SettingsUI = (function() {
         $(this).addClass("disabled");
         $.ajax({
             method: "post",
-            url: "/json/add_account",
+            url: "{{url_for('json.add_account')}}",
             async: true,
             data: $("#add_account_form").serialize(),
             success: function () {
@@ -167,7 +167,7 @@ SettingsUI = (function() {
         indicateLoad();
         $.ajax({
             method: "post",
-            url: "/json/update_accounts",
+            url: "{{url_for('json.update_accounts')}}",
             data: $("#account_form").serialize(),
             async: true,
             success: function () {

--- a/src/pyload/webui/app/themes/pyplex/templates/logs.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/logs.html
@@ -10,7 +10,7 @@
 {% block content %}
 <div class="clear"></div>
 
-<div class="logpaginator"><a href="/logs/1"><span class="glyphicon glyphicon-fast-backward"></span></a> <a href="/logs/{{iprev}}"><span class="glyphicon glyphicon-step-backward"></span></a>  <a href="/logs/{{inext}}"><span class="glyphicon glyphicon-step-forward"></span></a> <a href="/logs"><span class="glyphicon glyphicon-fast-forward"></span></a></div>
+<div class="logpaginator"><a href="{{url_for('app.logs', start_line=1)}}"><span class="glyphicon glyphicon-fast-backward"></span></a> <a href="{{url_for('app.logs')}}/{{iprev}}"><span class="glyphicon glyphicon-step-backward"></span></a>  <a href="{{url_for('app.logs')}}/{{inext}}"><span class="glyphicon glyphicon-step-forward"></span></a> <a href="/logs"><span class="glyphicon glyphicon-fast-forward"></span></a></div>
 <div class="logperpage" style="float: right;">
   <form id="logform1" action="" method="POST">
     <label for="reversed">{{_('Reversed')}}:</label>

--- a/src/pyload/webui/app/themes/pyplex/templates/packages.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/packages.html
@@ -73,7 +73,7 @@
     <div class="modal-content">
       <div class="modal-header bg-info navbar-inverse text-center" style="padding: 5px" >{{_('Edit Package')}}</div>
         <div class="modal-body" style="margin-bottom: 30px;">
-        <form id="pack_form" class="from-group" action="/json/edit_package" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
+        <form id="pack_form" class="from-group" action="{{url_for('json.edit_package')}}" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
           <p>{{_('Edit the package detais below')}}</p>
             <input name="pack_id" id="pack_id" type="hidden" value=""/>
             <div class="form-group">

--- a/src/pyload/webui/app/themes/pyplex/templates/settings.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/settings.html
@@ -81,7 +81,7 @@
     </form>
   </div>
   <div id="accounts" class="tab-pane fade">
-    <form id="account_form" action="/json/update_accounts" method="POST">
+    <form id="account_form" action="{{url_for("json.update_accounts")}}" method="POST">
       <table class="settable wide table">
         <thead>
         <tr>
@@ -150,7 +150,7 @@
     <div class="modal-content">
       <div class="modal-header bg-info navbar-inverse text-center" style="padding: 5px"> {{_('Add Account')}}</div>
       <div class="modal-body" style="margin-bottom: 30px;">
-        <form id="add_account_form" action="/json/add_account" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
+        <form id="add_account_form" action="{{url_for("json.add_account")}}" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
           <p>{{_('Enter your account data to use premium features')}}</p>
           <div class="form-group">
             <label for="account_login">{{_('Login')}}</label>

--- a/src/pyload/webui/app/themes/pyplex/templates/window.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/window.html
@@ -5,7 +5,7 @@
       <div class="modal-header bg-info navbar-inverse text-center" style="cursor: move; padding: 5px">{{_('Add Package')}}</div>
       <div class="modal-body text-left" style="cursor: move;">
         <div id="cap_title">{{_('Paste your links or upload a container.')}}</div>
-        <form id="add_form" class="form-group" action="/json/add_package" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
+        <form id="add_form" class="form-group" action="{{url_for("json.add_package")}}" method="POST" enctype="multipart/form-data" style="margin-bottom: 40px;">
           <div class="form-group">
             <label for="add_name">{{_('Name')}}</label>
             <input id="add_name" class="form-control" name="add_name" type="text"/>

--- a/src/pyload/webui/webserver_thread.py
+++ b/src/pyload/webui/webserver_thread.py
@@ -31,7 +31,7 @@ class WebServerThread(threading.Thread):
 
         # NOTE: Is really the right choice pass the pycore obj directly to app?!
         #       Or should we pass just core.api and server.logger instead?
-        self.app = App(self.pyload, self.develop)
+        self.app = App(self.pyload, self.develop, self.prefix)
         self.log = self.app.logger
 
     def _run_develop(self):

--- a/src/pyload/webui/webserver_thread.py
+++ b/src/pyload/webui/webserver_thread.py
@@ -40,7 +40,7 @@ class WebServerThread(threading.Thread):
         self.app.run(self.host, self.port, use_reloader=False)
 
     def _run_produc(self):
-        bind_path = self.prefix.strip("/") + "/"
+        bind_path = "/"
         bind_addr = (self.host, self.port)
         wsgi_app = wsgi.PathInfoDispatcher({bind_path: self.app})
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

The current implementation for the webserver path_prefix isn't working at all. To make it work with cheroot the pathprefix should be "/path_prefix" and not "path_prefix/" as now. Doing so would create problems, as the jinja templating engine isn't aware of where it is currently sitting ("/" or "/path_prefix"), so all links from the html and js files are pointing to the wrong location. All of the links are hardcoded, which is alos not a good idea.
This PR adds a url_prefix parameter for all blueprints upon registering. The current url_prefix in the blueprints are moved to the route decorator (e.g. "/json/status" instead of "/status"). The theme init is seperated from the other extension to also add a ulr_prefix in the form of "/url_prefix/_theme")
All routes in the html fies are generated using the "url_for" function. The json and api routes in the js files are now also generated using url_for. 

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

I only did it for the pyplex theme, the other themes have to be done if you are agree to this change