### PR TITLE
Add Python 3.9 test on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,9 @@ jobs:
 
   allow_failures:
     - name: Docker Release
-    # - python: nightly
+    - python: 3.9
     - python: pypy3
+    # - python: nightly
     - os: osx
     - os: windows
 
@@ -66,6 +67,10 @@ jobs:
     - stage: Test
       os: linux
       python: 3.8
+      
+    - stage: Test
+      os: linux
+      python: 3.9
 
     # - stage: Test
     #   os: linux


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

<!-- WRITE HERE -->
Add a Python 3.9 job to our Travis CI test pipeline.