### PR TITLE
[Main] Fix error 500 on delete finished

### DIFF
--- a/src/pyload/core/managers/file_manager.py
+++ b/src/pyload/core/managers/file_manager.py
@@ -623,8 +623,8 @@ class FileManager:
         """
         deletes finished links and packages, return deleted packages.
         """
-        old_packs = self.get_info_data(0)
-        old_packs.update(self.get_info_data(1))
+        old_packs = self.get_info_data(Destination.QUEUE)
+        old_packs.update(self.get_info_data(Destination.COLLECTOR))
 
         self.pyload.db.delete_finished()
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Changed the parameter of the calls to `get_info_data()` in file_manager.py to the Destination enum to prevent the error below.

### Is this related to a problem?

Pressing the "delete finished packages", results in error 500:
![grafik](https://user-images.githubusercontent.com/6438895/97811378-894c5100-1c7a-11eb-8a66-20f7bcf5b97f.png)

The follwing traceback is output:

```
[2020-11-01 19:25:52]  DEBUG         pyload.webui  Object of type AttributeError is not JSON serializable
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/api_blueprint.py", line 44, in rpc
    response = call_api(func, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/api_blueprint.py", line 58, in call_api
    result = getattr(api, func)(
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/api/__init__.py", line 80, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/api/__init__.py", line 1000, in delete_finished
    return self.pyload.files.delete_finished_links()
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/utils/old/__init__.py", line 144, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/managers/file_manager.py", line 16, in new
    return func(self, *args)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/managers/file_manager.py", line 626, in delete_finished_links
    old_packs = self.get_info_data(0)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/utils/old/__init__.py", line 144, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/managers/file_manager.py", line 115, in get_info_data
    queue = queue.value
AttributeError: 'int' object has no attribute 'value'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.8/dist-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/api_blueprint.py", line 46, in rpc
    response = jsonify(error=exc, traceback=traceback.format_exc()), 500
  File "/usr/local/lib/python3.8/dist-packages/flask/json/__init__.py", line 370, in jsonify
    dumps(data, indent=indent, separators=separators) + "\n",
  File "/usr/local/lib/python3.8/dist-packages/flask/json/__init__.py", line 211, in dumps
    rv = _json.dumps(obj, **kwargs)
  File "/usr/lib/python3/dist-packages/simplejson/__init__.py", line 385, in dumps
    return cls(
  File "/usr/lib/python3/dist-packages/simplejson/encoder.py", line 296, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3/dist-packages/simplejson/encoder.py", line 378, in iterencode
    return _iterencode(o, 0)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/helpers.py", line 18, in default
    return super().default(obj)
  File "/usr/local/lib/python3.8/dist-packages/flask/json/__init__.py", line 100, in default
    return _json.JSONEncoder.default(self, o)
  File "/usr/lib/python3/dist-packages/simplejson/encoder.py", line 272, in default
    raise TypeError('Object of type %s is not JSON serializable' %
TypeError: Object of type AttributeError is not JSON serializable
[2020-11-01 19:25:52]  DEBUG         pyload.webui  Object of type AttributeError is not JSON serializable
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/api_blueprint.py", line 44, in rpc
    response = call_api(func, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/webui/app/blueprints/api_blueprint.py", line 58, in call_api
    result = getattr(api, func)(
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/api/__init__.py", line 80, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/api/__init__.py", line 1000, in delete_finished
    return self.pyload.files.delete_finished_links()
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/utils/old/__init__.py", line 144, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/managers/file_manager.py", line 16, in new
    return func(self, *args)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/managers/file_manager.py", line 626, in delete_finished_links
    old_packs = self.get_info_data(0)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/utils/old/__init__.py", line 144, in wrapper
    return func(self, *args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/managers/file_manager.py", line 115, in get_info_data
    queue = queue.value
AttributeError: 'int' object has no attribute 'value'

During handling of the above exception, another exception occurred:
...
```


<!-- WRITE HERE -->


<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
