### PR TITLE
[Main] Fix pyload-ng not stopping if cnl not running

### DIFF
--- a/src/pyload/plugins/addons/ClickNLoad.py
+++ b/src/pyload/plugins/addons/ClickNLoad.py
@@ -115,12 +115,13 @@ class ClickNLoad(BaseAddon):
     def _server(self):
         try:
             self.exit_done.clear()
-            self.server_running = True
 
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as dock_socket:
                 dock_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
                 dock_socket.bind((self.cnl_ip, self.cnl_port))
                 dock_socket.listen(5)
+
+                self.server_running = True
 
                 while True:
                     client_socket, client_addr = dock_socket.accept()


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

The click n' load proxy is marked as started, even if it's not started yet. By moving the server_running variable to a point, where the server is really running, the problem can be solved.

<!-- WRITE HERE -->

### Is this related to a problem?

If you start pyload-ng and the port the click n' load proxy should listen is already in use. Stopping pyload-ng by keyboard interrupt lasts forever, and pyload-ng isn't stopping quickly.

### Additional references

It's easyly reproducable by having another server listening on port 9666, start pyload-ng, wait for the following message in the log:
```
[2020-11-02 18:21:56]  INFO                pyload  ADDON ClickNLoad: Proxy listening on 0.0.0.0:9666
[2020-11-02 18:21:56]  ERROR               pyload  ADDON ClickNLoad: [Errno 98] ...
```
Then try to stop pyload-ng by pressing ctrl+c.

Tested it with python3.8 on Linux Mint running the productive (cheroot) server