### PR TITLE
Update AUTHORS

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,7 +19,7 @@
 - Walter Purcaro (vuolter) <vuolter@gmail.com>
 - himbrr <himbrr@himbrr.ws>
 - sebnapi
-- spoob <spoob@gmx.de>
+- Paul Spooren (spoob) <mail@aparcar.org>
 
 ### Developers
 


### PR DESCRIPTION
Some 11 years ago I started pyLoad (initially written in shell) and
posted it on the gulli.com board (down). RaNaN, sebnapi, mkaay and a few
more joined early on and basically taught me how to Python & *open
source*, I was 15 by that time.  I think Jonn3y came up with the name
and logo, maybe someone else, sorry.

We started at BitBucket and later went on to GitHub. Using the wayback
machine this is the oldest version I could find is from 27th May 2009.
Even earlier versions are lost, but it's nothing to brag with anyway.

At some point the jDownloader people gave us a DLC decryption key which
we (me) accidentally pushed as an unobfuscated `pyc`, so within 24 hours
a website appeared using our keys to decryption DLC to plaintext on
demand.

Also there was this guy *jbauer* who did some developing at the
beginning but then turned evil and screw our entire infrastructure, I
never understood why.

Looking at the log I stopped my pyLoad career with a rather uncool
commit (a4c306cb). Last thing I remember that we were just about to
release pyLoad 0.5...

Back in the day it was really important to stay somewhat anonymous, so
my name appears nowhere in those old sources, I think.

Signed-off-by: Paul Spooren <mail@aparcar.org>