### PR TITLE
[Main] Fix jdcheck.js with cript.to

### DIFF
--- a/src/pyload/plugins/addons/ClickNLoad.py
+++ b/src/pyload/plugins/addons/ClickNLoad.py
@@ -91,7 +91,7 @@ class ClickNLoad(BaseAddon):
 
     @lock
     @threaded
-    def forward(self, source, destination, queue=False):
+    def forward(self, source, destination, queue=False, thread=None):
         if queue:
             old_ids = set(pack.pid for pack in self.pyload.api.get_collector())
 
@@ -103,7 +103,7 @@ class ClickNLoad(BaseAddon):
                 self.pyload.api.push_to_queue(id)
 
     @threaded
-    def proxy(self):
+    def proxy(self, thread):
         self.log_info(
             self._("Proxy listening on {}:{}").format(
                 self.cnl_ip or "0.0.0.0", self.cnl_port
@@ -112,7 +112,7 @@ class ClickNLoad(BaseAddon):
         self._server()
 
     @threaded
-    def _server(self):
+    def _server(self, thread):
         try:
             self.exit_done.clear()
 

--- a/src/pyload/plugins/helpers.py
+++ b/src/pyload/plugins/helpers.py
@@ -537,8 +537,11 @@ def forward(source, destination):
         bufsize = 1 << 10
         bufdata = source.recv(bufsize)
         while bufdata:
-            destination.sendall(bufdata)
-            bufdata = source.recv(bufsize)
+            try:
+                destination.sendall(bufdata)
+                bufdata = source.recv(bufsize)
+            except BaseException:
+                pass
     finally:
         try:
             destination.shutdown(socket.SHUT_WR)

--- a/src/pyload/plugins/helpers.py
+++ b/src/pyload/plugins/helpers.py
@@ -540,7 +540,10 @@ def forward(source, destination):
             destination.sendall(bufdata)
             bufdata = source.recv(bufsize)
     finally:
-        destination.shutdown(socket.SHUT_WR)
+        try:
+            destination.shutdown(socket.SHUT_WR)
+        except BaseException:
+            pass
 
 
 def compute_checksum(filename, hashtype):

--- a/src/pyload/webui/app/blueprints/cnl_blueprint.py
+++ b/src/pyload/webui/app/blueprints/cnl_blueprint.py
@@ -169,6 +169,14 @@ def checksupport():
 @app_bp.route("/jdcheck.js", endpoint="jdcheck")
 @local_check
 def jdcheck():
-    rep = "jdownloader=true;\n"
-    rep += "var version='9.581;'"
-    return rep
+    rep = "jdownloader=true;\r\n"
+    rep += "var version='42707';\r\n"
+    resp = flask.make_response(rep)
+    resp.headers['Server'] = 'AppWork GmbH HttpServer'
+    resp.headers['Connection'] = 'close'
+    resp.headers['Content-Type'] = 'text/html'
+    resp.headers['Access-Control-Max-Age'] = '1800'
+    resp.headers['Access-Control-Allow-Origin'] = '*'
+    resp.headers['Access-Control-Allow-Methods'] = 'OPTIONS, GET, POST'
+
+    return resp


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Add the expected header to the jdcheck.js response (copied from current jdownloader responses). Furthermore added catch exceptions on forwarded cnl packets.

To make this PR working PR #3803 has to be merged to (otherwise the data can't be decrypted and pyload errors out)

<!-- WRITE HERE -->

### Is this related to a problem?

Using cript.to to add links via click n' load leads to an error (on cript.to side). 
This can be checked with this link: `https://cript.to/folder/PD0ps4u4`
Cript seems to check not only the content of the response but also the header (and stopping transfer if the header isn't as expected):
![grafik](https://user-images.githubusercontent.com/6438895/98392359-2ed73a00-2058-11eb-98fe-19ff7b627134.png)

![grafik](https://user-images.githubusercontent.com/6438895/98392489-562e0700-2058-11eb-9677-c38cdd7d193c.png)

Cript.to also seems not to complete the transfer, but just interrupts the connection after sending the payload -> traceback in debugger (Datatransfer interrupted and socket not connected are the error messages)

```
python-BaseException
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/helpers.py", line 541, in forward
    destination.sendall(bufdata)
BrokenPipeError: [Errno 32] Datenübergabe unterbrochen (broken pipe)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/addon_thread.py", line 50, in run
    self.f(*self.args, **self.kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/addons/ClickNLoad.py", line 98, in forward
    forward(source, destination)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/helpers.py", line 547, in forward
    destination.shutdown(socket.SHUT_WR)
OSError: [Errno 107] Der Socket ist nicht verbunden
```


### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
