### PR TITLE
[Main] Fix Crypter Chip.de

### DIFF
--- a/src/pyload/plugins/decrypters/ChipDe.py
+++ b/src/pyload/plugins/decrypters/ChipDe.py
@@ -7,10 +7,10 @@ from ..base.decrypter import BaseDecrypter
 class ChipDe(BaseDecrypter):
     __name__ = "ChipDe"
     __type__ = "decrypter"
-    __version__ = "0.16"
+    __version__ = "0.17"
     __status__ = "testing"
 
-    __pattern__ = r"http://(?:www\.)?chip\.de/video/.+\.html"
+    __pattern__ = r"https?://(?:www\.)?chip\.de/video/.+\.html"
     __config__ = [
         ("enabled", "bool", "Activated", True),
         ("use_premium", "bool", "Use premium account if available", True),
@@ -29,7 +29,7 @@ class ChipDe(BaseDecrypter):
     def decrypt(self, pyfile):
         self.data = self.load(pyfile.url)
         try:
-            f = re.search(r'"(http://video\.chip\.de/.+)"', self.data)
+            f = re.search(r'"(https?://media-video\.chip\.de/.+/MEDIA/.+)"', self.data)
 
         except Exception:
             self.fail(self._("Failed to find the URL"))


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Links from `chip.de` are no longer recognized:
Example: `https://www.chip.de/video/Google-Pixel-5-im-Test-Video_183065048.html`

Moved to https
video links moved to `video-chip` and have `MEDIA` in the link afterwards (in comparsion to the jpg links)

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
