### PR TITLE
[Main] Add missing url_for on logout -> login redirect

### DIFF
--- a/src/pyload/webui/app/helpers.py
+++ b/src/pyload/webui/app/helpers.py
@@ -30,7 +30,7 @@ def get_redirect_url(fallback=None):
     for location in flask.request.values.get("next"), flask.request.referrer:
         if not location:
             continue
-        if location == flask.request.url:  # don't redirect to same location
+        if location == flask.request.url or flask.request.url.endswith('login'):  # don't redirect to same location
             continue
         if is_safe_url(location):
             return location

--- a/src/pyload/webui/app/templates/logout.html
+++ b/src/pyload/webui/app/templates/logout.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block head %}
-<meta http-equiv="refresh" content="3; url="{{url_for('app.dashboard')}}">
+<meta http-equiv="refresh" content='3; url="{{url_for('app.dashboard')}}"'>
 {% endblock %}
 
 {% block content %}

--- a/src/pyload/webui/app/themes/modern/templates/logout.html
+++ b/src/pyload/webui/app/themes/modern/templates/logout.html
@@ -1,7 +1,7 @@
 {% extends theme('base.html') %}
 
 {% block head %}
-<meta http-equiv="refresh" content="5; url='/'">
+<meta http-equiv="refresh" content='5; url="{{url_for('app.dashboard')}}"'>
 <link rel="stylesheet" type="text/css" href="{{theme_static('css/logout.css')}}" />
 {% endblock %}
 

--- a/src/pyload/webui/app/themes/pyplex/templates/logout.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/logout.html
@@ -1,7 +1,7 @@
 {% extends theme('base.html') %}
 
 {% block head %}
-<meta http-equiv="refresh" content="5; url='/'">
+<meta http-equiv="refresh" content="5; url="{{url_for('app.dashboard')}}">
 <link rel="stylesheet" type="text/css" href="{{theme_static('css/logout.css')}}" />
 {% endblock %}
 


### PR DESCRIPTION
### Describe the changes

On the logout template there is one redirect route, which wasn't considered with the url_for route generating change for making the path_prefix work. This PR addresses this issue. Furthermore I had a problem on login pointing next to the login path, so I excluded this usecase from the next route generation

### Is this related to a problem?

Problems on logout -> login with path_prefix

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
