### PR TITLE
[Main] Update wait routine (cast strings to float)

### DIFF
--- a/src/pyload/plugins/base/hoster.py
+++ b/src/pyload/plugins/base/hoster.py
@@ -351,7 +351,7 @@ class BaseHoster(BasePlugin):
             self.set_wait(seconds)
 
         if reconnect is None:
-            reconnect = seconds > self.config.get("max_wait", 10) * 60
+            reconnect = float(seconds) > self.config.get("max_wait", 10) * 60
 
         self.set_reconnect(reconnect)
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

If you try to download from e.g. turbobit, abort the download or for any other reason get turbobit to output the wait_pattern this leads to the follwing traceback. This is because in turbobit.py line             `self.retry(wait=m.group(1))` the parameter is of type string. In hoster.py set_wait routine the string is casted to float, but not in wait routine, this PR fixes this. I reported nearly the same issue for the stable branch in #3676.

```
[2020-11-08 13:27:59]  WARNING             pyload  Download failed: xxx.html | '>' not supported between instances of 'str' and 'int'
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 56, in run
    pyfile.plugin.preprocessing(self)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 306, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 102, in _process
    self.process(self.pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/simple_downloader.py", line 314, in process
    if self.link and not self.last_download:
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/downloaders/TurbobitNet.py", line 59, in handle_free
    self.retry(wait=m.group(1))
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 500, in retry
    self.wait(wait)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 356, in wait
    reconnect = seconds > self.config.get("max_wait", 10) * 60
TypeError: '>' not supported between instances of 'str' and 'int'
Stack (most recent call last):
  File "/opt/pycharm/plugins/python/helpers/pydev/_pydev_bundle/pydev_monkey.py", line 773, in __call__
    ret = self.original_func(*self.args, **self.kwargs)
  File "/usr/lib/python3.8/threading.py", line 890, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 195, in run
    self.pyload.log.warning(
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 56, in run
    pyfile.plugin.preprocessing(self)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 306, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 102, in _process
    self.process(self.pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/simple_downloader.py", line 314, in process
    if self.link and not self.last_download:
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/downloaders/TurbobitNet.py", line 59, in handle_free
    self.retry(wait=m.group(1))
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 500, in retry
    self.wait(wait)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 356, in wait
    reconnect = seconds > self.config.get("max_wait", 10) * 60
TypeError: '>' not supported between instances of 'str' and 'int'
```

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
