### PR TITLE
[Main] Fix pathchooser abs/rel change on linux

### DIFF
--- a/src/pyload/webui/app/filters.py
+++ b/src/pyload/webui/app/filters.py
@@ -5,12 +5,13 @@ import os
 
 from pyload.core.utils import format
 
-_QUOTECHAR = "::%2F"
+_QUOTECHAR = "::"
+_ESCAPED_SLASH = "%2F"
 
 
 def quotepath(path):
     try:
-        return path.replace(".." + os.path.sep, _QUOTECHAR)
+        return path.replace("..", _QUOTECHAR).replace("/", _ESCAPED_SLASH)
     except AttributeError:
         return path
     except Exception:
@@ -19,7 +20,7 @@ def quotepath(path):
 
 def unquotepath(path):
     try:
-        return path.replace(_QUOTECHAR, ".." + os.path.sep)
+        return path.replace(_QUOTECHAR, "..").replace(_ESCAPED_SLASH, "/")
     except AttributeError:
         return path
     except Exception:

--- a/src/pyload/webui/app/themes/modern/templates/pathchooser.html
+++ b/src/pyload/webui/app/themes/modern/templates/pathchooser.html
@@ -61,7 +61,7 @@
     }
     function setFile(fullpath, name)
     {
-        cwd = fullpath;
+        cwd = fullpath.replace("%2F", "/");
         {% if type == "file" %} {# browsing for file #}
           abspath = "{{'/filechooser/' + cwd|abspath|quotepath|replace('\\', '\\\\')}}" + name;
           relpath = "{{'/filechooser/' + cwd|relpath|quotepath|replace('\\', '\\\\')}}" + name;

--- a/src/pyload/webui/app/themes/modern/templates/pathchooser.html
+++ b/src/pyload/webui/app/themes/modern/templates/pathchooser.html
@@ -5,10 +5,10 @@
   <script class="javascript">
     var submit = true;
     {% if absolute %}
-      var cwd = "{{oldfile|default(cwd, True)|abspath|quotepath|replace('\\', '\\\\')}}";
+      var cwd = "{{oldfile|default(cwd, True)|abspath|unquotepath|replace('\\', '\\\\')}}";
       var isabsolute = true;
     {% else %}
-      var cwd = "{{oldfile|default(cwd, True)|relpath|quotepath|replace('\\', '\\\\')}}";
+      var cwd = "{{oldfile|default(cwd, True)|relpath|unquotepath|replace('\\', '\\\\')}}";
       var isabsolute = false;
     {% endif %}
 
@@ -61,7 +61,7 @@
     }
     function setFile(fullpath, name)
     {
-        cwd = fullpath.replace("%2F", "/");
+        cwd = fullpath;
         {% if type == "file" %} {# browsing for file #}
           abspath = "{{'/filechooser/' + cwd|abspath|quotepath|replace('\\', '\\\\')}}" + name;
           relpath = "{{'/filechooser/' + cwd|relpath|quotepath|replace('\\', '\\\\')}}" + name;

--- a/src/pyload/webui/app/themes/pyplex/templates/pathchooser.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/pathchooser.html
@@ -61,7 +61,7 @@
     }
     function setFile(fullpath, name)
     {
-        cwd = fullpath;
+        cwd = fullpath.replace("%2F", "/");
         {% if type == "file" %} {# browsing for file #}
           abspath = "{{'/filechooser/' + cwd|abspath|quotepath|replace('\\', '\\\\')}}" + name;
           relpath = "{{'/filechooser/' + cwd|relpath|quotepath|replace('\\', '\\\\')}}" + name;

--- a/src/pyload/webui/app/themes/pyplex/templates/pathchooser.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/pathchooser.html
@@ -5,10 +5,10 @@
   <script class="javascript">
     var submit = true;
     {% if absolute %}
-      var cwd = "{{oldfile|default(cwd, True)|abspath|quotepath|replace('\\', '\\\\')}}";
+      var cwd = "{{oldfile|default(cwd, True)|abspath|unquotepath|replace('\\', '\\\\')}}";
       var isabsolute = true;
     {% else %}
-      var cwd = "{{oldfile|default(cwd, True)|relpath|quotepath|replace('\\', '\\\\')}}";
+      var cwd = "{{oldfile|default(cwd, True)|relpath|unquotepath|replace('\\', '\\\\')}}";
       var isabsolute = false;
     {% endif %}
 
@@ -61,7 +61,7 @@
     }
     function setFile(fullpath, name)
     {
-        cwd = fullpath.replace("%2F", "/");
+        cwd = fullpath;
         {% if type == "file" %} {# browsing for file #}
           abspath = "{{'/filechooser/' + cwd|abspath|quotepath|replace('\\', '\\\\')}}" + name;
           relpath = "{{'/filechooser/' + cwd|relpath|quotepath|replace('\\', '\\\\')}}" + name;


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Currently change between abs and relative path is not possible in the pathchooser dialog, it stucks always with relative. (At least on Linux with forward slash as path serperator)

![grafik](https://user-images.githubusercontent.com/6438895/98469226-8acbcb00-21de-11eb-9a00-18737e10e4c1.png)

This is caused by flask/cheroot redirecting the generated "//" starting route to a single "/", as can be seen in the next Screenshot (checked with Firefox 82.0.2 (64-Bit) on Linux)
![grafik](https://user-images.githubusercontent.com/6438895/98469307-f44bd980-21de-11eb-97ab-d00f7a2738b1.png)

This PR fixes this problem by escaping the "/" in the url, additionally to the ".." escape sequence

Edit: Flask/cheroot/werkzeug are on the currently newest available versions

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

Checked with python 3.8 on Linux Mint 20