### PR TITLE
[Main] Revert binary regex on get_ip during reconnect

### DIFF
--- a/src/pyload/core/managers/thread_manager.py
+++ b/src/pyload/core/managers/thread_manager.py
@@ -220,9 +220,9 @@ class ThreadManager:
         retrieve current ip.
         """
         services = [
-            ("http://icanhazip.com/", rb"(\S+)"),
-            ("http://checkip.dyndns.org/", rb".*Current IP Address: (\S+)</body>.*"),
-            ("http://ifconfig.io/ip", rb"(\S+)"),
+            ("http://icanhazip.com/", r"(\S+)"),
+            ("http://checkip.dyndns.org/", r".*Current IP Address: (\S+)</body>.*"),
+            ("http://ifconfig.io/ip", r"(\S+)"),
         ]
 
         ip = ""


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

With https://github.com/pyload/pyload/commit/b4e23f06b84600ab5d186afbc39d5889dd7d9431 get_url now returns a str instead of bytes, so the patch to make the get_ip address work, works no longer, this PR reverts the binary regex and makes it back to a normal "str" regex

Sorry, was my fault not to find the root cause

<!-- WRITE HERE -->

### Is this related to a problem?

Get_ip address is again not working

<!-- WRITE HERE - OPTIONAL -->

### Additional references

PR:  #3819

<!-- WRITE HERE - OPTIONAL -->
