### PR TITLE
[Main] Ignorecase on match plugins

### DIFF
--- a/src/pyload/core/managers/plugin_manager.py
+++ b/src/pyload/core/managers/plugin_manager.py
@@ -204,7 +204,7 @@ class PluginManager:
                     plugins[name]["pattern"] = pattern
 
                     try:
-                        plugins[name]["re"] = re.compile(pattern)
+                        plugins[name]["re"] = re.compile(pattern, re.I)
                     except Exception:
                         self.pyload.log.error(
                             self._("{} has a invalid pattern").format(name)

--- a/src/pyload/core/managers/plugin_manager.py
+++ b/src/pyload/core/managers/plugin_manager.py
@@ -278,7 +278,7 @@ class PluginManager:
                 self.container_plugins.items(),
             ):
                 if value["re"].match(url):
-                    res.append((url, name))
+                    res.append((url.lower(), name))
                     last = (name, value)
                     found = True
                     break


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Currently the regex to find the right plugin is case sensitive, so for example taking the filecrypt decrypter plugin:

`r"https?://(?:www\.)?filecrypt\.cc/Container/\w+"`

This would match: `http://filecrypt.cc/Container/64E039F859.html`
But not: `http://filecrypt.cc/container/64E039F859.html` (C in container not a capital letter)
or: `http://Filecrypt.cc/Container/64E039F859.html` (Capitalized URL)
or even: `HTTP://Filecrypt.cc/Container/64E039F859.html` (Capitalized HTTP)

I added an "ignorecase" flag to the pattern match regex in pluginmanager, this allows us to match all above examples

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
