### PR TITLE
Premium download failed, not mentioning the real cause

### DIFF
--- a/module/plugins/internal/Hoster.py
+++ b/module/plugins/internal/Hoster.py
@@ -297,7 +297,7 @@ class Hoster(Base):
                 os.makedirs(dl_dir)
 
             except Exception, e:
-                self.fail(str(e))
+                self.fail(e.args[0])
 
         self.set_permissions(dl_dir)
 

--- a/module/plugins/internal/Hoster.py
+++ b/module/plugins/internal/Hoster.py
@@ -33,7 +33,7 @@ if not hasattr(__builtin__.property, "setter"):
 class Hoster(Base):
     __name__ = "Hoster"
     __type__ = "hoster"
-    __version__ = "0.80"
+    __version__ = "0.81"
     __status__ = "stable"
 
     __pattern__ = r'^unmatchable$'

--- a/module/plugins/internal/Hoster.py
+++ b/module/plugins/internal/Hoster.py
@@ -297,7 +297,7 @@ class Hoster(Base):
                 os.makedirs(dl_dir)
 
             except Exception, e:
-                self.fail(e.message)
+                self.fail(str(e))
 
         self.set_permissions(dl_dir)
 


### PR DESCRIPTION
The creation of the download folder was not working, because of missing permissions.

But, this was not mentioned in the log.

The try-except clause was passing the Exception.message property to self.fail(), which was empty in that case, as not all exception subclasses, like OSError, have that defined.

<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

To solve this the exception is passed calling str() before. Thus it just creates a string out of the exception's arguments.

<!-- WRITE HERE -->

### Is this related to a problem?

The (premium) download failed, as stated on the log page of pyload, with the following line:
`HOSTER DdlTo[6207]: Premium download failed | downloading`

As you can see, the cause for the failure is not mentioned, as the current status line is printed there ("downloading")

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
