### PR TITLE
[Main] Fix scan_download on Filer.net plugin

### DIFF
--- a/src/pyload/plugins/downloaders/FilerNet.py
+++ b/src/pyload/plugins/downloaders/FilerNet.py
@@ -4,7 +4,7 @@ import re
 
 from ..anticaptchas.ReCaptcha import ReCaptcha
 from ..base.simple_downloader import SimpleDownloader
-
+from pyload.core.utils.convert import to_bytes
 
 class FilerNet(SimpleDownloader):
     __name__ = "FilerNet"
@@ -56,7 +56,7 @@ class FilerNet(SimpleDownloader):
             pyfile.url, post={"g-recaptcha-response": response, "hash": inputs["hash"]}
         )
 
-        if self.scan_download({"html": re.compile(r"\A\s*<!DOCTYPE html")}) == "html":
+        if self.scan_download({"html": re.compile(to_bytes(r"\A\s*<!DOCTYPE html"))}) == "html":
             with open(self.last_download, "r") as f:
                 self.data = f.read()
             os.remove(self.last_download)


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Change regex for scan_download after file download in filer.net to "bytes" one.

### Is this related to a problem?

After downloading a file with filer.net a traceback occurs.

```
[2021-05-13 08:59:50]  WARNING             pyload  Download failed: xxx.rar | cannot use a string pattern on a bytes-like object
Traceback (most recent call last):
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 56, in run
    pyfile.plugin.preprocessing(self)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 300, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 104, in _process
    self.process(self.pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/simple_downloader.py", line 307, in process
    self.handle_free(pyfile)
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/downloaders/FilerNet.py", line 59, in handle_free
    if self.scan_download({"html": re.compile(r"\A\s*<!DOCTYPE html")}) == "html":
  File "/home/ozzie/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 374, in scan_download
    m = rule.search(content)
TypeError: cannot use a string pattern on a bytes-like object
```

[debug_FilerNet_2021-05-13_08-59-50.zip](https://github.com/pyload/pyload/files/6470820/debug_FilerNet_2021-05-13_08-59-50.zip)


### Additional references

Using newest commit version from develop branch