### PR TITLE
[Main] Fix traceback in Uploadgig.com account

### DIFF
--- a/src/pyload/plugins/accounts/UploadgigCom.py
+++ b/src/pyload/plugins/accounts/UploadgigCom.py
@@ -14,7 +14,7 @@ from ..helpers import parse_html_form
 class UploadgigCom(BaseAccount):
     __name__ = "UploadgigCom"
     __type__ = "account"
-    __version__ = "0.04"
+    __version__ = "0.05"
     __status__ = "testing"
 
     __description__ = """UploadgigCom account plugin"""
@@ -135,6 +135,6 @@ class UploadgigCom(BaseAccount):
     def check_status(self):
         pass
 
-    def retry_captcha(self, attemps=10, wait=1, msg=_("Max captcha retries reached")):
+    def retry_captcha(self, attemps=10, wait=1, msg="Max captcha retries reached"):
         self.captcha.invalid()
-        self.fail_login(msg=_("Invalid captcha"))
+        self.fail_login(msg=self._("Invalid captcha"))


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes
Uploadgig Account function refers to non existing function "_", correct function name is be "self._". The PR does this change (and also increases version number of the account plugin)

<!-- WRITE HERE -->

### Is this related to a problem?
While downloading a file with Uploadgig a traceback is thrown.  
Example Link:
https://uploadgig.com/file/download/896377Cf57E70ecb/rk-dermowen.rar

```
[2021-08-07 08:11:14]  INFO                pyload  Download starts: https://uploadgig.com/file/download/896377Cf57E70ecb/rk-dermowen.rar
[2021-08-07 08:11:14]  DEBUG               pyload  ADDON UserAgentSwitcher: Setting connection timeout to 60 seconds
[2021-08-07 08:11:14]  DEBUG               pyload  ADDON UserAgentSwitcher: Setting maximum redirections to 10
[2021-08-07 08:11:14]  DEBUG               pyload  ADDON UserAgentSwitcher: Use custom user-agent string `Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:71.0) Gecko/20100101 Firefox/71.0`
[2021-08-07 08:11:14]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `download_preparing`
[2021-08-07 08:11:14]  DEBUG               pyload  DOWNLOADER UploadgigCom[99]: Plugin version: 0.06
[2021-08-07 08:11:14]  DEBUG               pyload  DOWNLOADER UploadgigCom[99]: Plugin status: testing
[2021-08-07 08:11:14]  WARNING             pyload  DOWNLOADER UploadgigCom[99]: Plugin ist eventuell instabil
[2021-08-07 08:11:14]  ERROR               pyload  Error importing UploadgigCom: name '_' is not defined
Traceback (most recent call last):
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/core/managers/plugin_manager.py", line 352, in load_module
    module = __import__(
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/plugins/accounts/UploadgigCom.py", line 14, in <module>
    class UploadgigCom(BaseAccount):
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/plugins/accounts/UploadgigCom.py", line 138, in UploadgigCom
    def retry_captcha(self, attemps=10, wait=1, msg=_("Max captcha retries reached")):
NameError: name '_' is not defined
Stack (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 890, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 56, in run
    pyfile.plugin.preprocessing(self)
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 300, in preprocessing
    return self._process(*args, **kwargs)
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 93, in _process
    self._setup()
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 154, in _setup
    self.load_account()  # TODO: Move to PluginThread in 0.6.x
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 85, in load_account
    super().load_account()
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 181, in load_account
    self.account = self.pyload.account_manager.get_account_plugin(
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/core/managers/account_manager.py", line 50, in get_account_plugin
    klass = self.pyload.plugin_manager.load_class("account", plugin)
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/core/managers/plugin_manager.py", line 374, in load_class
    module = self.load_module(type, name)
  File "/opt/pyload3/lib/python3.8/site-packages/pyload/core/managers/plugin_manager.py", line 361, in load_module
    self.pyload.log.error(
```

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
