### PR TITLE
[Main] Fix for nitroflare with hcaptcha

### DIFF
--- a/src/pyload/plugins/downloaders/NitroflareCom.py
+++ b/src/pyload/plugins/downloaders/NitroflareCom.py
@@ -5,6 +5,7 @@ import re
 
 from pyload.core.network.request_factory import get_url
 
+from ..anticaptchas.HCaptcha import HCaptcha
 from ..anticaptchas.ReCaptcha import ReCaptcha
 from ..base.simple_downloader import SimpleDownloader
 
@@ -12,7 +13,7 @@ from ..base.simple_downloader import SimpleDownloader
 class NitroflareCom(SimpleDownloader):
     __name__ = "NitroflareCom"
     __type__ = "downloader"
-    __version__ = "0.30"
+    __version__ = "0.31"
     __status__ = "testing"
 
     __pattern__ = r"https?://(?:www\.)?(?:nitro\.download|nitroflare\.com)/view/(?P<ID>[\w^_]+)"
@@ -79,6 +80,8 @@ class NitroflareCom(SimpleDownloader):
 
         recaptcha = ReCaptcha(pyfile)
         recaptcha_key = recaptcha.detect_key()
+        hcaptcha = HCaptcha(pyfile)
+        hcaptcha_key = hcaptcha.detect_key()
 
         self.data = self.load(
             "http://nitroflare.com/ajax/freeDownload.php",
@@ -95,7 +98,10 @@ class NitroflareCom(SimpleDownloader):
             self.captcha = recaptcha
             response, _ = self.captcha.challenge(recaptcha_key)
             inputs["g-recaptcha-response"] = response
-
+        elif hcaptcha_key:
+            self.captcha = hcaptcha
+            response = self.captcha.challenge(hcaptcha_key)
+            inputs["g-recaptcha-response"] = inputs["h-captcha-response"] = response
         else:
             response = self.captcha.decrypt(
                 "http://nitroflare.com/plugins/cool-captcha/captcha.php"


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

I added hcaptcha to the recognized captcha type for downloader Nitroflare.

Remark: The fallback text captcha wasn't solvable by me (or at least the download didn't work) so I don't know if there is another change in Nitroflare hoster, of if it would be better to remove this option.

<!-- WRITE HERE -->

### Is this related to a problem?

At least some (or all?) of the Nitroflare links moved to h-captcha:

![nitro](https://user-images.githubusercontent.com/6438895/128629774-a86f75b5-4349-476d-b81e-91668902c3e7.png)

The log shows the following while trying to download:
```
[2021-08-07 08:05:55]  INFO                pyload  Download starts: https://nitro.download/view/9CCAA324647A1A4/uiq68cqsf6q5.rar
[2021-08-07 08:05:55]  DEBUG               pyload  ADDON UserAgentSwitcher: Setting connection timeout to 60 seconds
[2021-08-07 08:05:55]  DEBUG               pyload  ADDON UserAgentSwitcher: Setting maximum redirections to 10
[2021-08-07 08:05:55]  DEBUG               pyload  ADDON UserAgentSwitcher: Use custom user-agent string `Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:71.0) Gecko/20100101 Firefox/71.0`
[2021-08-07 08:05:55]  DEBUG               pyload  ADDON ExternalScripts: No script found under folder `download_preparing`
[2021-08-07 08:05:55]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: Plugin version: 0.30
[2021-08-07 08:05:55]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: Plugin status: testing
[2021-08-07 08:05:55]  WARNING             pyload  DOWNLOADER NitroflareCom[97]: Plugin ist eventuell instabil
[2021-08-07 08:05:55]  INFO                pyload  DOWNLOADER NitroflareCom[97]: Suche Link info...
[2021-08-07 08:05:55]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: Link info: {'name': 'uiq68cqsf6q5.rar', 'hash': {}, 'pattern': {'ID': '9CCAA324647A1A4'}, 'size': 3683050, 'status': 2, 'url': 'https://nitroflare.com/view/9CCAA324647A>
[2021-08-07 08:05:55]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: Previous link info: {}
[2021-08-07 08:05:55]  INFO                pyload  DOWNLOADER NitroflareCom[97]: Link Name: uiq68cqsf6q5.rar
[2021-08-07 08:05:55]  INFO                pyload  DOWNLOADER NitroflareCom[97]: Link Größe: 3.51 MiB (3683050 bytes)
[2021-08-07 08:05:55]  INFO                pyload  DOWNLOADER NitroflareCom[97]: Link Status: online
[2021-08-07 08:05:55]  INFO                pyload  DOWNLOADER NitroflareCom[97]: Verarbeite Url: https://nitro.download/view/9CCAA324647A1A4/uiq68cqsf6q5.rar
[2021-08-07 08:05:55]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: LOAD URL https://nitroflare.com/view/9CCAA324647A1A4/uiq68cqsf6q5.rar | get={} | post={} | ref=False | cookies=True | just_header=False | decode=True | multipart=False >
[2021-08-07 08:05:56]  INFO                pyload  DOWNLOADER NitroflareCom[97]: Überprüfe Link auf Fehler...
[2021-08-07 08:05:56]  INFO                pyload  DOWNLOADER NitroflareCom[97]: No errors found
[2021-08-07 08:05:56]  INFO                pyload  DOWNLOADER NitroflareCom[97]: Processing as free download...
[2021-08-07 08:05:56]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: LOAD URL http://nitroflare.com/ajax/setCookie.php | get={} | post={'fileId': '9CCAA324647A1A4'} | ref=True | cookies=True | just_header=False | decode=True | multipart=>
[2021-08-07 08:05:56]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: LOAD URL https://nitroflare.com/view/9CCAA324647A1A4/uiq68cqsf6q5.rar | get={} | post={'goToFreePage': ''} | ref=True | cookies=True | just_header=False | decode=True |>
[2021-08-07 08:05:56]  DEBUG               pyload  ANTICAPTCHA NitroflareCom[97]: ReCaptcha | c38dc51d-dc74-48c0-9ce6-ad5dd86847e4 | Wrong key format, this probably because it is not a reCAPTCHA key
[2021-08-07 08:05:56]  WARNING             pyload  ANTICAPTCHA NitroflareCom[97]: ReCaptcha | Schlüssel Begriff nicht gefunden
[2021-08-07 08:05:56]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: LOAD URL http://nitroflare.com/ajax/freeDownload.php | get={} | post={'method': 'startTimer', 'fileId': '9CCAA324647A1A4'} | ref=True | cookies=True | just_header=False>
[2021-08-07 08:05:56]  INFO                pyload  DOWNLOADER NitroflareCom[97]: Überprüfe Link auf Fehler...
[2021-08-07 08:05:56]  INFO                pyload  DOWNLOADER NitroflareCom[97]: No errors found
[2021-08-07 08:05:56]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: WAIT set to timestamp 1628316477.801934 | Previous wait_until: 0
[2021-08-07 08:05:56]  DEBUG               pyload  ANTICAPTCHA NitroflareCom[97]: BaseCaptcha | LOAD URL http://nitroflare.com/plugins/cool-captcha/captcha.php | get={} | post={} | ref=False | cookies=True | just_header=False | decode=False | multip>
[2021-08-07 08:05:56]  INFO                pyload  ANTICAPTCHA NitroflareCom[97]: BaseCaptcha | Benutze OCR um Captcha zu entschlüsseln...
[2021-08-07 08:05:56]  WARNING             pyload  ANTICAPTCHA NitroflareCom[97]: BaseCaptcha | Kein OCR Ergebnis
[2021-08-07 08:06:05]  INFO                pyload  ANTICAPTCHA NitroflareCom[97]: BaseCaptcha | Captcha Ergebnis: `ifebeca'
[2021-08-07 08:06:05]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: RECONNECT not required | Previous want_reconnect: False
[2021-08-07 08:06:05]  INFO                pyload  DOWNLOADER NitroflareCom[97]: Warte 1 minute, 51 seconds...
[2021-08-07 08:07:57]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: LOAD URL http://nitroflare.com/ajax/freeDownload.php | get={} | post={'method': 'fetchDownload', 'captcha': 'ifebeca'} | ref=True | cookies=True | just_header=False | d>
[2021-08-07 08:07:58]  WARNING             pyload  ANTICAPTCHA NitroflareCom[97]: BaseCaptcha | Ungültiges Captcha |  | ifebeca
[2021-08-07 08:07:58]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: WAIT set to timestamp 1628316480.191814 | Previous wait_until: 1628316477.801934
[2021-08-07 08:07:58]  DEBUG               pyload  DOWNLOADER NitroflareCom[97]: RECONNECT not required | Previous want_reconnect: False
[2021-08-07 08:07:58]  INFO                pyload  DOWNLOADER NitroflareCom[97]: Warte 1 second...
```


<!-- WRITE HERE - OPTIONAL -->

### Additional references

Example link for checking: 

https://nitro.download/view/9CCAA324647A1A4/uiq68cqsf6q5.rar