### PR TITLE
Fix externalscripts

### DIFF
--- a/src/pyload/plugins/addons/ExternalScripts.py
+++ b/src/pyload/plugins/addons/ExternalScripts.py
@@ -87,7 +87,7 @@ class ExternalScripts(BaseAddon):
 
         for folder in self.folders:
             scripts = []
-            dirname = os.path.join("scripts", folder)
+            dirname = os.path.join(self.pyload.userdir, "scripts", folder)
 
             if folder not in self.scripts:
                 self.scripts[folder] = []

--- a/src/pyload/plugins/addons/ExternalScripts.py
+++ b/src/pyload/plugins/addons/ExternalScripts.py
@@ -134,7 +134,7 @@ class ExternalScripts(BaseAddon):
             self.scripts[folder] = scripts
 
     def call_cmd(self, command, *args, **kwargs):
-        call = (str(cmd) for cmd in [command] + list(args))
+        call = [str(cmd) for cmd in [command] + list(args)]
 
         self.log_debug(
             "EXECUTE "


### PR DESCRIPTION
### Describe the changes

Added `self.pyload.userdir` directory prefix when searching scripts and changed `Popen` argument from generator to list.

I'm have little knowledge of Python and don't no if this is the correct solution, but it works for me.

### Is this related to a problem?

ExternalScripts did not work for me on Ubuntu 20.04 with Python 3.8

The scripts were searched in ~/scripts instead of ~/.pyload/scripts.
After fixing that, the addon logged "list index out of range" when trying to run the script.

