### PR TITLE
Improve docker-compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,11 @@ Please refer to [CONTRIBUTING](https://github.com/pyload/pyload/blob/main/CONTRI
 Compatible with `docker-compose` v2 schemas:
 
     ---
-    version: 2
+    version: '2'
     services:
       pyload:
-        image: pyload/pyload
+        image: pyload
+        build: <REPODIR>
         container_name: pyload
         environment:
           - PUID=1000
@@ -212,10 +213,13 @@ Compatible with `docker-compose` v2 schemas:
           - <USERDIR>:/config
           - <STORAGEDIR>:/downloads
         ports:
-          - 8000:8000
+          - 8000:8000 # Webinterface
+          - 9666:9666 # Click 'N' Load
         restart: unless-stopped
 
 > **Note**:
+>
+> Replace `<REPODIR>` with the location on the host machine where you have checked out the pyload repository.
 >
 > Replace `<STORAGEDIR>` with the location on the host machine where you want that downloads will be saved.
 >


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes
<!-- A clear and concise description of what you've done. -->

<!-- WRITE HERE -->
- Fix version string
- Added  Click 'N' Load port
- Use local Dockerfile instead of docker hub image (currently not available)

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->
- the current `version` is an integer, which prevents docker-compose from running
- there are no pyload images available on [docker hub](https://hub.docker.com/r/pyload/pyload/tags)
