### PR TITLE
Automatic addition of passwords via Click 'n' Load plugin.

### DIFF
--- a/module/web/cnl_app.py
+++ b/module/web/cnl_app.py
@@ -67,11 +67,17 @@ def addcrypted():
     dlc_file.write(dlc)
     dlc_file.close()
 
+    pw = request.POST['passwords']
+
     try:
-        PYLOAD.addPackage(package, [dlc_path], 0)
+        pack = PYLOAD.addPackage(package, [dlc_path], 0)
     except:
         return HTTPError()
     else:
+        if pw:
+            pw = pw.decode("utf8", "ignore")
+            data = {"password": pw}
+            PYLOAD.setPackageData(pack, data)
         return "success\r\n"
 
 @route("/flash/addcrypted2", method="POST")
@@ -80,6 +86,7 @@ def addcrypted2():
     package = request.forms.get("package", request.forms.get("source", request.POST.get('referer', None)))
     crypted = request.forms["crypted"]
     jk = request.forms["jk"]
+    pw = request.POST['passwords']
 
     crypted = standard_b64decode(unquote(crypted.replace(" ", "+")))
     if JS:
@@ -114,9 +121,14 @@ def addcrypted2():
 
     try:
         if package:
-            PYLOAD.addPackage(package, urls, 0)
+            pack = PYLOAD.addPackage(package, urls, 0)
         else:
-            PYLOAD.generateAndAddPackages(urls, 0)
+            pack = PYLOAD.generateAndAddPackages(urls, 0)
+
+        if pw:
+            pw = pw.decode("utf8", "ignore")
+            data = {"password": pw}
+            PYLOAD.setPackageData(pack, data)
     except:
         return "failed can't add"
     else:

--- a/module/web/cnl_app.py
+++ b/module/web/cnl_app.py
@@ -42,9 +42,17 @@ def add():
             if x.decode('latin1').strip()]
 
     if package:
-        PYLOAD.addPackage(package, urls, 0)
+        pack = PYLOAD.addPackage(package, urls, 0)
     else:
-        PYLOAD.generateAndAddPackages(urls, 0)
+        pack = PYLOAD.generateAndAddPackages(urls, 0)
+
+    pw = request.POST['passwords']
+
+    if pw:
+        pw = pw.decode("utf8", "ignore")
+        data = {"password": pw}
+        PYLOAD.setPackageData(pack, data)
+
 
     return ""
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

<!-- WRITE HERE -->

Added a method to the click 'n' load plugin that adds the password to a package, if a password was supplied for purposes such as archive extractions etc.

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

Was trying to add a bunch of archives that are password protected using a click 'n' load button. Although the links and file name was passed through perfectly fine, the password was ignored.

After looking at the `cnl_app.py` file it was clear to see that no method was implemented in dealing with passwords so I added it it.

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->

The click 'n' load data must follow the [JDownloader cnl2 standard](https://jdownloader.org/knowledge/wiki/glossary/cnl2)
