### PR TITLE
[Main] Added "starting" downloads to "restart failed"

### DIFF
--- a/src/pyload/core/database/file_database.py
+++ b/src/pyload/core/database/file_database.py
@@ -407,7 +407,7 @@ class FileDatabaseMethods:
 
     @style.queue
     def restart_failed(self):
-        self.c.execute("UPDATE links SET status=3,error='' WHERE status IN (6, 8, 9)")
+        self.c.execute("UPDATE links SET status=3,error='' WHERE status IN (6, 7, 8, 9)")
 
     @style.queue
     def find_duplicates(self, id, folder, filename):


### PR DESCRIPTION
Hi, 
I made a pull request cause I often got downloads stuck in status "starting" without ever downloading them.

<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

I added status 7 (= starting) to the "restart failed" function.

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

Sometimes downloads stuck in status "starting" and wont ever start downloading. 
I changed it to restart those on "restart failed" function

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
