### PR TITLE
use pyLoad Stable function getAccountData instead get_account_data

### DIFF
--- a/module/ThreadManager.py
+++ b/module/ThreadManager.py
@@ -306,7 +306,7 @@ class ThreadManager:
         if thread.active.plugin.account:
             account_limit = max(
                 int(
-                    thread.active.plugin.account.get_account_data(
+                    thread.active.plugin.account.getAccountData(
                         thread.active.plugin.account.user
                     )["options"].get("limitDL", ["0"])[0]
                 ),


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

After commit https://github.com/pyload/pyload/commit/da6d442a6370634b9452ae92c23259e456c5d221 pyLoad crashes on start of downloading files. This patch introduced ` get_account_data ` which is a pyLoad Next function name.

https://github.com/pyload/pyload/blob/b9cb4372267fa34d9a1146fe4738dc8c5b053962/module/ThreadManager.py#L309
` get_account_data `  should be  ` getAccountData ` 

<!-- A clear and concise description of what you've done. -->

