### PR TITLE
Fix #4122, the Docker build error that failed on Jinja2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN echo "**** install build packages ****" && \
 
 FROM builder AS source_builder
 
-ARG PIP_PACKAGES="Babel Jinja2"
+ARG PIP_PACKAGES="Babel Jinja2==3.0.3"
 
 COPY . /source
 WORKDIR /source


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

<!-- WRITE HERE -->
The latest Jinja2 raises the following error:
AttributeError: module 'jinja2.ext' has no attribute 'autoescape'

This change set Jinja2 to 3.0.3

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
