### PR TITLE
SevenZip: fix encrypted header error message

### DIFF
--- a/module/plugins/internal/SevenZip.py
+++ b/module/plugins/internal/SevenZip.py
@@ -30,7 +30,7 @@ class SevenZip(Extractor):
 
     _RE_PART = re.compile(r'\.7z\.\d{3}|\.(part|r)\d+(\.rar|\.rev)?(\.bad)?|\.rar$', re.I)
     _RE_FILES = re.compile(r'([\d\-]+)\s+([\d:]+)\s+([RHSA.]+)\s+(\d+)\s+(?:(\d+)\s+)?(.+)')
-    _RE_ENCRYPTED_HEADER = re.compile(r'Headers Error')
+    _RE_ENCRYPTED_HEADER = re.compile(r'encrypted archive')
     _RE_ENCRYPTED_FILES = re.compile(r'Encrypted\s+=\s+\+')
     _RE_BADPWD = re.compile(r"Wrong password", re.I)
     _RE_BADCRC = re.compile(r'CRC Failed|Can not open file', re.I)


### PR DESCRIPTION
Will be a solution for #4161 once merged to main.

SevenZip output (16.04 and 21.07) if archive header is encrypted

```bash
# 7z l -scsUTF-8 -sccUTF-8 -bso0 -bsp1 -aos -p- -slt "/downloads/xxxxx/TW1-5X01.part1.rar"
                                                                        
Listing archive: /downloads/xxxxx/TW1-5X01.part1.rar


ERROR: /downloads/xxxxx/TW1-5X01.part1.rar : Can not open encrypted archive. Wrong password?



Errors: 1

```

i hope this is a correct way for a fix in pyload-ng, or do i need to create an extra PR?
anyway issue is in 0.4 and 0.5