### PR TITLE
"Add Package" modal made scrollable

### DIFF
--- a/src/pyload/webui/app/themes/modern/static/css/base.css
+++ b/src/pyload/webui/app/themes/modern/static/css/base.css
@@ -154,6 +154,11 @@ textarea.form-control {
   user-select: none;
 }
 
+.modal-body,
+.modal-header {
+  overflow: auto;
+}
+
 .modal-footer {
   padding: 6px 12px;
   border-top: none;

--- a/src/pyload/webui/app/themes/pyplex/static/css/base.css
+++ b/src/pyload/webui/app/themes/pyplex/static/css/base.css
@@ -393,6 +393,7 @@ textarea.form-control:focus {
 }
 
 .modal-body {
+  overflow: auto;
   background-color: #282828;
 }
 
@@ -401,6 +402,7 @@ textarea.form-control:focus {
 }
 
 .modal-header {
+  overflow: auto;
   border-bottom: 1px solid #212121;
 }
 


### PR DESCRIPTION
### Describe the changes

I added the ability to scroll in case the "Add Package" modal is displayed larger than the device's display so that part of the modal reaches outside the screen.

### Is this related to a problem?

It is not possible to scroll when the modal "Add Package" is displayed on a mobile phone with a smaller display. This causes the "Cancel" and "Add Package" buttons to be off-screen and therefore quite challenging to press.
