### PR TITLE
UlozTo.cz duplicate HTTPS in captcha URL

### DIFF
--- a/src/pyload/plugins/downloaders/UlozTo.py
+++ b/src/pyload/plugins/downloaders/UlozTo.py
@@ -146,12 +146,6 @@ class UlozTo(SimpleDownloader):
 
                 xapca = self.load("https://ulozto.net/reloadXapca.php",
                                   get={'rnd': timestamp()})
-
-                xapca = xapca.replace(
-                    'sound":"',
-                    'sound":"https:').replace(
-                    'image":"',
-                    'image":"https:')
                 self.log_debug("xapca: %s" % xapca)
 
                 data = json.loads(xapca)

--- a/src/pyload/plugins/downloaders/UlozTo.py
+++ b/src/pyload/plugins/downloaders/UlozTo.py
@@ -24,7 +24,7 @@ def convert_decimal_prefix(m):
 class UlozTo(SimpleDownloader):
     __name__ = "UlozTo"
     __type__ = "downloader"
-    __version__ = "1.50"
+    __version__ = "1.51"
     __status__ = "testing"
 
     __pattern__ = r"https?://(?:www\.)?(uloz\.to|ulozto\.(cz|sk|net)|bagruj\.cz|zachowajto\.pl|pornfile\.cz)/(?:live/)?(?P<ID>[!\w]+/[^/?]*)"


### PR DESCRIPTION
UlozTo.cz has recently started adding "https" before its captcha URL.
In Pyload, "https:https:" now appears in the captcha URL.
I have removed one of the duplicate HTTPS.

### Describe the changes

One of the duplicate HTTPS from UlozTo.cz's captcha URL was removed.

### Is this related to a problem?

Yes. When trying to download from UlozTo.cz I was getting error messages like this

> ...
3491	2022-07-24 10:26:33	DEBUG	pyload	DOWNLOADER UlozTo[34]: LOAD URL https://ulozto.net/reloadXapca.php | get={'rnd': 1658651193505} | post={} | ref=True | cookies=True | just_header=False | decode=True | multipart=False | redirect=True | req=None
3492	2022-07-24 10:26:33	DEBUG	pyload	DOWNLOADER UlozTo[34]: xapca: {"image":"https:https:\/\/xapca.uloz.to\/36aa5f2ef0964e3af3f8669a2d6b79729fe632ef\/image.jpg","sound":"https:https:\/\/xapca.uloz.to\/36aa5f2ef0964e3af3f8669a2d6b79729fe632ef\/sound.mp3","hash":"36aa5f2ef0964e3af3f8669a2d6b79729fe632ef","timestamp":1658651193,"salt":"7263"}
3493	2022-07-24 10:26:33	DEBUG	pyload	ANTICAPTCHA UlozTo[34]: BaseCaptcha | LOAD URL https:https://xapca.uloz.to/36aa5f2ef0964e3af3f8669a2d6b79729fe632ef/image.jpg | get={} | post={} | ref=False | cookies=True | just_header=False | decode=False | multipart=False | redirect=True | req=<pyload.core.network.browser.Browser object at 0xb33e96b8>
3494	2022-07-24 10:26:33	DEBUG	pyload	ADDON ExternalScripts: No script found under folder \`download_processed\`
3495	2022-07-24 10:26:33	DEBUG	pyload	ADDON ExternalScripts: No script found under folder \`package_processed\`
3496	2022-07-24 10:26:33	WARNING	pyload	Download failed: demo test nature movie for 4k oled tv.webm | (3, '')
3497	?	?	?	Traceback (most recent call last):
3498	?	?	?	  File "/usr/lib/python3.9/site-packages/pyload/core/threads/download_thread.py", line 56, in run
3499	?	?	?	    pyfile.plugin.preprocessing(self)
3500	?	?	?	  File "/usr/lib/python3.9/site-packages/pyload/plugins/base/hoster.py", line 291, in preprocessing
3501	?	?	?	    return self._process(*args, **kwargs)
3502	?	?	?	  File "/usr/lib/python3.9/site-packages/pyload/plugins/base/downloader.py", line 103, in _process
3503	?	?	?	    self.process(self.pyfile)
3504	?	?	?	  File "/usr/lib/python3.9/site-packages/pyload/plugins/base/simple_downloader.py", line 282, in process
3505	?	?	?	    self.handle_free(pyfile)
3506	?	?	?	  File "/usr/lib/python3.9/site-packages/pyload/plugins/downloaders/UlozTo.py", line 162, in handle_free
3507	?	?	?	    captcha_value = self.captcha.decrypt(data['image'])
3508	?	?	?	  File "/usr/lib/python3.9/site-packages/pyload/plugins/base/captcha.py", line 54, in decrypt
3509	?	?	?	    img = self.load(
3510	?	?	?	  File "/usr/lib/python3.9/site-packages/pyload/plugins/base/plugin.py", line 218, in load
3511	?	?	?	    html = req.load(
3512	?	?	?	  File "/usr/lib/python3.9/site-packages/pyload/core/network/browser.py", line 127, in load
3513	?	?	?	    return self.http.load(*args, **kwargs)
3514	?	?	?	  File "/usr/lib/python3.9/site-packages/pyload/core/network/http/http_request.py", line 293, in load
3515	?	?	?	    self.c.perform()
3516	?	?	?	pycurl.error: (3, '')
3517	2022-07-24 10:26:33	INFO	pyload	Debug Report written to /tmp/pyLoad/debug_UlozTo_2022-07-24_10-26-33.zip
...
