### PR TITLE
Changes to the HotFolder plugin

### DIFF
--- a/src/pyload/plugins/addons/HotFolder.py
+++ b/src/pyload/plugins/addons/HotFolder.py
@@ -84,7 +84,7 @@ class HotFolder(BaseAddon):
                 if extensions is not None:
                     _, extension = os.path.splitext(entry)
                     # Note that extension contains the leading dot
-                    if extension[1:] not in extensions:
+                    if len(extension) == 0 or extension[1:] not in extensions:
                         continue
 
                 new_path = os.path.join(

--- a/src/pyload/plugins/addons/HotFolder.py
+++ b/src/pyload/plugins/addons/HotFolder.py
@@ -18,7 +18,9 @@ class HotFolder(BaseAddon):
         ("watchfile", "bool", "Watch link file", False),
         ("delete", "bool", "Delete added containers", False),
         ("file", "str", "Link file", "links.txt"),
-        ("interval", "int", "File / folder check interval in seconds (minimum 20)", 60)
+        ("interval", "int", "File / folder check interval in seconds (minimum 20)", 60),
+        ("enable_extension_filter", "bool", "Extension filter", False),
+        ("extension_filter", "str", "Extensions to look for (comma separated)", "dlc"),
     ]
 
     __description__ = (
@@ -58,6 +60,12 @@ class HotFolder(BaseAddon):
 
                     self.pyload.api.add_package(name, [fp.name], 1)
 
+            extensions = None
+            if self.config.get("enable_extension_filter"):
+                extension_filter = self.config.get("extension_filter")
+                extensions = [s.strip() for s in extension_filter.split(",")]
+                self.log_debug(f"Watching only for extensions {extensions} in HotFolder")
+
             for entry in os.listdir(watch_folder):
                 entry_file = os.path.join(watch_folder, entry)
 
@@ -69,6 +77,12 @@ class HotFolder(BaseAddon):
                     or os.path.realpath(watch_file) == os.path.realpath(entry_file)
                 ):
                     continue
+
+                if extensions is not None:
+                    _, extension = os.path.splitext(entry)
+                    # Note that extension contains the leading dot
+                    if extension[1:] not in extensions:
+                        continue
 
                 new_path = os.path.join(
                     watch_folder,

--- a/src/pyload/plugins/addons/HotFolder.py
+++ b/src/pyload/plugins/addons/HotFolder.py
@@ -10,7 +10,7 @@ from ...core.datatypes.enums import Destination
 class HotFolder(BaseAddon):
     __name__ = "HotFolder"
     __type__ = "addon"
-    __version__ = "0.26"
+    __version__ = "0.27"
     __status__ = "testing"
 
     __config__ = [


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

This PR includes two small changes to the HotFolder plugin:

1. Possibility to filter extensions in the HotFolder. This way one can add (for example) their Downloads directory and only filter out dlc files in there.
2. Add the ability to add packages to the collector and not only the queue

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

Nope

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
