### PR TITLE
hoster.py: Set the "status" in the info dict to "waiting" upon wait()

### DIFF
--- a/src/pyload/plugins/base/hoster.py
+++ b/src/pyload/plugins/base/hoster.py
@@ -347,8 +347,9 @@ class BaseHoster(BasePlugin):
         self.set_reconnect(reconnect)
 
         self.waiting = True
+        
+        self.info["status"] = 5 # waiting
 
-        status = self.pyfile.status  # NOTE: Recheck in 0.6.x
         self.pyfile.set_status("waiting")
 
         self.log_info(self._("Waiting {}...").format(format.time(wait_time)))
@@ -378,7 +379,6 @@ class BaseHoster(BasePlugin):
                 time.sleep(2)
 
         self.waiting = False
-        self.pyfile.status = status  # NOTE: Recheck in 0.6.x
 
     def skip(self, msg=""):
         """


### PR DESCRIPTION
### Describe the changes
This will help to clearly identify the current hoster state and to grab the general infos of the link again since these could have changed.

### Is this related to a problem?
fixes #4214

### Additional references
N/A