### PR TITLE
Fix extracting packages in DownsterNet

### DIFF
--- a/src/pyload/plugins/downloaders/DownsterNet.py
+++ b/src/pyload/plugins/downloaders/DownsterNet.py
@@ -24,8 +24,6 @@ class DownsterNet(MultiDownloader):
     __license__ = "GPLv3"
     __authors__ = [(None, None)]
 
-    FILE_ERRORS = [("Error", r'{"state":"error"}'), ("Retry", r'{"state":"retry"}')]
-
     def setup(self):
         self.api = DownsterApi(self)
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Currently there is a bug in this hoster which prevents extracting packages after download.
This fixes it. The listed file errors anyways doesn't match the response content.
```
Traceback (most recent call last):
  File "/home/user/.local/lib/python3.8/site-packages/pyload/core/threads/download_thread.py", line 56, in run
    pyfile.plugin.preprocessing(self)
  File "/home/user/.local/lib/python3.8/site-packages/pyload/plugins/base/hoster.py", line 291, in preprocessing
    return self._process(*args, **kwargs)
  File "/home/user/.local/lib/python3.8/site-packages/pyload/plugins/base/multi_downloader.py", line 76, in _process
    super()._process(thread)
  File "/home/user/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 106, in _process
    self._check_download()
  File "/home/user/.local/lib/python3.8/site-packages/pyload/plugins/base/simple_downloader.py", line 290, in _check_download
    self.check_download()
  File "/home/user/.local/lib/python3.8/site-packages/pyload/plugins/base/simple_downloader.py", line 295, in check_download
    errmsg = self.scan_download({r: re.compile(p)})
  File "/home/user/.local/lib/python3.8/site-packages/pyload/plugins/base/downloader.py", line 373, in scan_download
    m = rule.search(content)
TypeError: cannot use a string pattern on a bytes-like object
```

