### PR TITLE
Fix Flash of Unstyled Content in Firefox

### DIFF
--- a/src/pyload/webui/app/themes/modern/templates/base.html
+++ b/src/pyload/webui/app/themes/modern/templates/base.html
@@ -36,6 +36,12 @@
 {% block head %}
 {% endblock %}
 
+<script>
+  // Prevent Flash of Unstyled Content (FOUC) in Firefox
+  // see: https://bugzilla.mozilla.org/show_bug.cgi?id=1404468
+  // see: https://stackoverflow.com/a/64158043
+  let FF_FOUC_FIX;
+</script>
 </head>
 
 <body>

--- a/src/pyload/webui/app/themes/pyplex/templates/base.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/base.html
@@ -36,6 +36,12 @@
 {% block head %}
 {% endblock %}
 
+<script>
+  // Prevent Flash of Unstyled Content (FOUC) in Firefox
+  // see: https://bugzilla.mozilla.org/show_bug.cgi?id=1404468
+  // see: https://stackoverflow.com/a/64158043
+  let FF_FOUC_FIX;
+</script>
 </head>
 
 <body>


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

Adds a small workaround to the `modern` and `pyplex` themes to prevent a Flash of Unstyled Content caused by a bug in Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1404468 

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

As I tested out `pyload-ng` for the first time yesterday, I noticed that on a fresh, local install each page load started out showing unstyled content for about a second before applying the CSS themes. This behavior was already described in an issue a few years ago, which - to my understanding - was closed due to not being deemed important: https://github.com/pyload/pyload/issues/3297

However, for me it notably affected the user experience and the fix is really simple anyway. 

