### PR TITLE
Try literal eval

### DIFF
--- a/src/pyload/webui/app/blueprints/api_blueprint.py
+++ b/src/pyload/webui/app/blueprints/api_blueprint.py
@@ -67,11 +67,18 @@ def call_api(func, *args, **kwargs):
         return jsonify({'error': "Forbidden"}), 403
 
     result = getattr(api, func)(
-        *[literal_eval(x) for x in args],
-        **{x: literal_eval(y) for x, y in kwargs.items()},
+        *[_try_literal_eval(x) for x in args],
+        **{x: _try_literal_eval(y) for x, y in kwargs.items()},
     )
 
     return jsonify(result)
+
+
+def _try_literal_eval(val):
+    try:
+        return literal_eval(val)
+    except SyntaxError:
+        return val
 
 
 @bp.route("/api/login", methods=["POST"], endpoint="login")


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

try literal eval, and returns the origfinal content for non literals

### Is this related to a problem?

in python 3.11 ast raises a syntax error, when the literal cannot be parsed

### Additional references

https://github.com/pyload/pyload/issues/4240