### PR TITLE
Add SIGTERM handler for graceful shutdowns (e.g. when using Docker)

### DIFF
--- a/src/pyload/core/__init__.py
+++ b/src/pyload/core/__init__.py
@@ -195,10 +195,9 @@ class Core:
         from .managers.addon_manager import AddonManager
         from .managers.captcha_manager import CaptchaManager
         from .managers.event_manager import EventManager
+        from .managers.file_manager import FileManager
         from .managers.plugin_manager import PluginManager
         from .managers.thread_manager import ThreadManager
-        from .managers.file_manager import FileManager
-
         from .scheduler import Scheduler
 
         self.files = self.file_manager = FileManager(self)
@@ -369,6 +368,7 @@ class Core:
         try:
             try:
                 signal.signal(signal.SIGQUIT, self.sigquit)
+                signal.signal(signal.SIGTERM, self.sigterm)
             except Exception:
                 pass
 
@@ -460,6 +460,11 @@ class Core:
 
     def sigquit(self, a, b):
         self.log.info(self._("Received Quit signal"))
+        self.terminate()
+        sys.exit()
+
+    def sigterm(self, a, b):
+        self.log.info(self._("Received Terminate signal"))
         self.terminate()
         sys.exit()
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

Registers a handler for the `SIGTERM` signal that simply calls the `terminate()` function, analogous to the existing `SIGQUIT` handler. 

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

Using _Docker_ to handle the lifecycle of a _pyload-ng_ container, i.e. with `docker stop pyload-ng` or `docker restart pyload-ng`, resulted in corrupted states where on the next startup _pyload_ could not be started and an error message stating `pyLoad already running with pid 1` was shown.

This is due to _Docker_ using `kill -s SIGTERM 1` to request a graceful shutdown for the process at PID 1 when stopping a container. As this signal is currently not handled by _pyload-ng_, it waits for 10 seconds and then forcefully stops the process, which doesn't correctly remove the `pidfile`.

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

This problem was mentioned in #3277, but I don't know if it directly caused that issue. 
