### PR TITLE
Google drive multi-user regex fix

### DIFF
--- a/src/pyload/plugins/downloaders/GoogledriveCom.py
+++ b/src/pyload/plugins/downloaders/GoogledriveCom.py
@@ -20,7 +20,7 @@ from ..base.downloader import BaseDownloader
 class GoogledriveCom(BaseDownloader):
     __name__ = "GoogledriveCom"
     __type__ = "downloader"
-    __version__ = "0.34"
+    __version__ = "0.35"
     __status__ = "testing"
 
     __pattern__ = r"https?://(?:www\.)?(?:drive|docs)\.google\.com/(?:file/d/|uc\?.*id=)(?P<ID>[-\w]+)"

--- a/src/pyload/plugins/downloaders/GoogledriveCom.py
+++ b/src/pyload/plugins/downloaders/GoogledriveCom.py
@@ -3,6 +3,8 @@
 #
 # Test links:
 #   https://drive.google.com/file/d/0B6RNTe4ygItBQm15RnJiTmMyckU/view?pli=1
+#   https://drive.google.com/file/u/0/d/0B6RNTe4ygItBQm15RnJiTmMyckU/view?usp=share_link
+#   https://drive.google.com/u/0/uc?id=0B6RNTe4ygItBQm15RnJiTmMyckU&export=download
 
 
 import json
@@ -21,7 +23,7 @@ class GoogledriveCom(BaseDownloader):
     __version__ = "0.34"
     __status__ = "testing"
 
-    __pattern__ = r"https?://(?:www\.)?(?:drive|docs)\.google\.com/(?:u/[0-9]/)?(?:file/)?(?:u/[0-9]/)?(?:d/|uc\?.*id=)(?P<ID>[-\w]+)"
+    __pattern__ = r"https?://(?:www\.)?(?:drive|docs)\.google\.com/(?:file/d/|uc\?.*id=)(?P<ID>[-\w]+)"
     __config__ = [
         ("enabled", "bool", "Activated", True),
         ("use_premium", "bool", "Use premium account if available", True),

--- a/src/pyload/plugins/downloaders/GoogledriveCom.py
+++ b/src/pyload/plugins/downloaders/GoogledriveCom.py
@@ -21,7 +21,7 @@ class GoogledriveCom(BaseDownloader):
     __version__ = "0.34"
     __status__ = "testing"
 
-    __pattern__ = r"https?://(?:www\.)?(?:drive|docs)\.google\.com/(?:file/d/|uc\?.*id=)(?P<ID>[-\w]+)"
+    __pattern__ = r"https?://(?:www\.)?(?:drive|docs)\.google\.com/(?:u/[0-9]/)?(?:file/)?(?:u/[0-9]/)?(?:d/|uc\?.*id=)(?P<ID>[-\w]+)"
     __config__ = [
         ("enabled", "bool", "Activated", True),
         ("use_premium", "bool", "Use premium account if available", True),


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Google drive links can sometimes contain a user indicator if you are logged into multiple accounts in the browser where the link is generated.

<!-- WRITE HERE -->

### Is this related to a problem?

#4282 

<!-- WRITE HERE - OPTIONAL -->

### Additional references

I'm not sure if this an issue which needs fixing, as it can be worked around by the user. However, supporting the URLs is not a massive change to the regex.