### PR TITLE
A cleaner way to build wheels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,15 +46,14 @@ ARG APK_PACKAGES="gcc g++ musl-dev python3-dev libffi-dev openssl-dev jpeg-dev z
 
 ENV PYCURL_SSL_LIBRARY="openssl"
 
-COPY setup.cfg /source/setup.cfg
+COPY . /source
 WORKDIR /wheels
 
 RUN echo "**** install build packages ****" && \
     apk add $APK_INSTALL_OPTIONS $APK_PACKAGES && \
     \
     echo "**** build pyLoad dependencies ****" && \
-    python3 -c "import configparser as cp; c = cp.ConfigParser(); c.read('/source/setup.cfg'); plugins = '\\n'.join([l for l in c['options.extras_require']['plugins'].strip().split('\\n') if 'platform_system' not in l]); print(c['options']['install_requires'] + plugins)" | \
-    xargs pip3 wheel --wheel-dir=.
+    pip3 wheel -w /wheels /source
 
 
 FROM builder AS source_builder


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Change the way grabbing the Python dependencies when building the Docker image.

<!-- WRITE HERE -->

### Is this related to a problem?

<!-- A description of the problem you ran into. -->
The Docker image failed to build in the latest commit, after `;python_version=='3.6'` etc. markers added.
<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
