### PR TITLE
[FiregetCom] support https urls

### DIFF
--- a/src/pyload/plugins/downloaders/FiregetCom.py
+++ b/src/pyload/plugins/downloaders/FiregetCom.py
@@ -9,7 +9,7 @@ class FiregetCom(XFSDownloader):
     __version__ = "0.04"
     __status__ = "testing"
 
-    __pattern__ = r"http://(?:www\.)?fireget\.com/(?P<ID>\w{12})/.+"
+    __pattern__ = r"https?://(?:www\.)?fireget\.com/(?P<ID>\w{12})/.+"
     __config__ = [
         ("enabled", "bool", "Activated", True),
         ("use_premium", "bool", "Use premium account if available", True),


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

updated url pattern in FiregetCom downloader

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

fireget.com supports https, the plugin did not assign urls starting in https to the FiregetCom downloader.
This PR fixes that.

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
