### PR TITLE
[FiregetCom] support https urls

### DIFF
--- a/src/pyload/plugins/downloaders/FiregetCom.py
+++ b/src/pyload/plugins/downloaders/FiregetCom.py
@@ -9,7 +9,7 @@ class FiregetCom(XFSDownloader):
     __version__ = "0.04"
     __status__ = "testing"
 
-    __pattern__ = r"http://(?:www\.)?fireget\.com/(?P<ID>\w{12})/.+"
+    __pattern__ = r"https?://(?:www\.)?fireget\.com/(?P<ID>\w{12})/.+"
     __config__ = [
         ("enabled", "bool", "Activated", True),
         ("use_premium", "bool", "Use premium account if available", True),

--- a/src/pyload/plugins/downloaders/FiregetCom.py
+++ b/src/pyload/plugins/downloaders/FiregetCom.py
@@ -6,7 +6,7 @@ from ..base.xfs_downloader import XFSDownloader
 class FiregetCom(XFSDownloader):
     __name__ = "FiregetCom"
     __type__ = "downloader"
-    __version__ = "0.04"
+    __version__ = "0.05"
     __status__ = "testing"
 
     __pattern__ = r"https?://(?:www\.)?fireget\.com/(?P<ID>\w{12})/.+"


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

updated url pattern in FiregetCom downloader

<!-- WRITE HERE -->

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

fireget.com supports https, the plugin did not assign urls starting in https to the FiregetCom downloader.
This PR fixes that.

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

Replaces https://github.com/pyload/pyload/pull/4298