### PR TITLE
Support '#' in filenames

### DIFF
--- a/src/pyload/core/utils/web/parse.py
+++ b/src/pyload/core/utils/web/parse.py
@@ -114,6 +114,8 @@ def name(url, safe_name=True):
         name = up.query.split("=", 1)[::-1][0].split("&", 1)[0]
     if not name and up.fragment:
         name = "#" + up.fragment
+    elif name and up.fragment:
+        name += "#" + up.fragment
     if not name:
         name = up.netloc.split(".", 1)[0]
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,13 @@
+import unittest
+
+from pyload.core.utils.web.parse import name
+
+
+class TestParse(unittest.TestCase):
+    def test_name_with_hash(self):
+        actual = name('Some file #3 of 5.pdf')
+        self.assertEqual(actual, 'Some file #3 of 5.pdf')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This changes the `name` function to allow for `#` in filenames, such as `graph #1 of 2.png`. There aren't any tests around what this function was supposed to be doing though, so this may need some more tweaking to make it consistently useful.

Fixes #4351