### PR TITLE
Don't install new versions of cryptography on pypy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,8 @@ install_requires =
     Flask-Session2~=1.3;python_version>="3.7"
     Flask-Themes2~=1.0
     bitmath~=1.3
-    cryptography>=35.0.0
+    cryptography>=35.0.0;platform_python_implementation!="PyPy"
+    cryptography>=35.0.0,<40.0.0;platform_python_implementation=='PyPy'
     filetype~=1.0
     Js2Py~=0.7
     pycurl~=7.43


### PR DESCRIPTION
Seems that a new cryptography release [disabled support for certain versions of cryptography on pypi](https://github.com/pyload/pyload/actions/runs/5805223514/job/15736016133?pr=4350). this should fix it

### Describe the changes

<!-- A clear and concise description of what you've done. -->

<!-- WRITE HERE -->

### Is this related to a problem?
```
Collecting cryptography>=35.0.0
  Downloading cryptography-41.0.3.tar.gz (630 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 630.1/630.1 kB 49.9 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'

... snipped ... 

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      Traceback (most recent call last):
        File "/home/runner/work/pyload/pyload/.tox/pypy/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/runner/work/pyload/pyload/.tox/pypy/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/runner/work/pyload/pyload/.tox/pypy/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-yfbrgrfv/overlay/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-yfbrgrfv/overlay/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-yfbrgrfv/overlay/site-packages/setuptools/build_meta.py", line 338, in run_setup
          exec(code, locals())
        File "<string>", line 47, in <module>
      RuntimeError: cryptography is not compatible with PyPy3 < 7.3.10
      [end of output]```

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
