### PR TITLE
[UlozTo] Fix account info pattern

### DIFF
--- a/src/pyload/plugins/accounts/UlozTo.py
+++ b/src/pyload/plugins/accounts/UlozTo.py
@@ -23,7 +23,7 @@ class UlozTo(BaseAccount):
         ("GammaC0de", "nitzo2001[AT]yahoo[DOT]com"),
     ]
 
-    INFO_PATTERN = r'title="credit in use"><\/span>\s*([\d.,]+) ([\w^_]+)\s*<\/td>\s*<td class="right">([\d.]+)<\/td>'
+    INFO_PATTERN = r'<span>Closest expiration<\/span>\s*<span class="highlight">([\d.,]+)\s*([\w^_]+)<\/span>\s*<span>on (\d{2}\.\d{2}.\d{4})<\/span>'
 
     def grab_info(self, user, password, data):
         html = self.load("https://ulozto.net/platby")

--- a/src/pyload/plugins/accounts/UlozTo.py
+++ b/src/pyload/plugins/accounts/UlozTo.py
@@ -11,7 +11,7 @@ from ..helpers import parse_html_form
 class UlozTo(BaseAccount):
     __name__ = "UlozTo"
     __type__ = "account"
-    __version__ = "0.35"
+    __version__ = "0.36"
     __status__ = "testing"
 
     __description__ = """Uloz.to account plugin"""


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

The `INFO_PATTERN` for UlozTo account is not longer working, therefore I introduced a new one that works.

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

I added my UlozTo account with active data plan, but in "Accounts" section was written that the plugin was not able to obtain information about my account and the PyLoad was using for my downloads free links.

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

No additional references.
