### PR TITLE
[UnRar] Allow extraction ignoring file attributes

### DIFF
--- a/src/pyload/plugins/extractors/UnRar.py
+++ b/src/pyload/plugins/extractors/UnRar.py
@@ -13,10 +13,13 @@ from pyload.plugins.helpers import renice
 class UnRar(BaseExtractor):
     __name__ = "UnRar"
     __type__ = "extractor"
-    __version__ = "1.47"
+    __version__ = "1.48"
     __status__ = "testing"
 
-    __config__ = [("ignore_warnings", "bool", "Ignore unrar warnings", False)]
+    __config__ = [
+        ("ignore_warnings", "bool", "Ignore unrar warnings", False),
+        ("ignore_file_attributes", "bool", "Ignore File Attributes", False)
+    ]
 
     __description__ = """RAR extractor plugin"""
     __license__ = "GPLv3"
@@ -273,6 +276,9 @@ class UnRar(BaseExtractor):
 
         if self.keepbroken:
             args.append("-kb")
+
+        if self.config.get("ignore_file_attributes", True):
+            args.append("-ai")
 
         # NOTE: return codes are not reliable, some kind of threading, cleanup
         # whatever issue


### PR DESCRIPTION
### Describe the changes
This adds a new (default off) option which if enabled passes `-ai` to `unrar`, which ignores file attributes stored in RAR archives.

This should help with cases where file permissions are set to odd values that may result in users not being able to modify extracted files. By ignoring attributes, permissions are handled by the underlying OS functions of creating a file.

### Is this related to a problem?
I run pyload-ng on a NAS where file and directory permissions are set up using ACLs. When unpacking RAR archives I was greeted with permission errors when trying to move or rename files that were inside nested directories in the RAR archive. Some of the files also had odd permissions set by default. This should™ alleviate this issue entirely. And if not... well, I'm sure it'll help *someone*.

### Additional references

The same issue was discussed 9 years(!) ago on the NZBGet forums and this sollution seems to have helped the user:
https://forum.nzbget.net/viewtopic.php?t=1550
edit:
Tried it out from inside the Docker container's shell and can confirm this also solved my permissions issue with an archive.