### PR TITLE
resolved utf8 decoding error

### DIFF
--- a/src/pyload/plugins/downloaders/XDCC.py
+++ b/src/pyload/plugins/downloaders/XDCC.py
@@ -57,7 +57,7 @@ class IRC:
         start_time = time.time()
         while time.time() - start_time < timeout:
             if self._data_available():
-                self.receive_buffer += to_str(self.irc_sock.recv(1 << 10))
+                self.receive_buffer += to_str(self.irc_sock.recv(1 << 10), encoding="latin-1")
                 self.lines += self.receive_buffer.split("\r\n")
                 self.receive_buffer = self.lines.pop()
 


### PR DESCRIPTION
### Describe the changes

Just changed the default UTF-8 encoding to Latin-1.

### Is this related to a problem?

https://github.com/pyload/pyload/issues/4401
UnicodeDecodeError on channel join with message containing non-ASCII chars

If the response line contains non-ASCII chars, line 60 was throwing an exception.
`UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 96: invalid continuation byte`