### PR TITLE
Replace dependency Js2py with dukpy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ install_requires =
     cryptography>=35.0.0;platform_python_implementation!="PyPy"
     cryptography>=35.0.0,<40.0.0;platform_python_implementation=='PyPy'
     filetype~=1.0
-    Js2Py~=0.7
+    dukPy~=0.3
     pycurl~=7.43
     certifi
     # requests-html~=0.10

--- a/src/pyload/core/utils/misc.py
+++ b/src/pyload/core/utils/misc.py
@@ -3,9 +3,7 @@
 import random
 import string
 
-import js2py
-
-js2py.disable_pyimport()
+import dukpy
 
 
 def random_string(length):
@@ -23,7 +21,7 @@ def is_plural(value):
 
 def eval_js(script, es6=False):
     # return requests_html.HTML().render(script=script, reload=False)
-    return (js2py.eval_js6 if es6 else js2py.eval_js)(script)
+    return dukpy.evaljs(script)
 
 
 def accumulate(iterable, to_map=None):

--- a/src/pyload/plugins/addons/ExtractArchive.py
+++ b/src/pyload/plugins/addons/ExtractArchive.py
@@ -118,8 +118,7 @@ class ExtractArchive(BaseAddon):
     def activate(self):
         for p in ("HjSplit", "UnRar", "SevenZip", "UnZip", "UnTar"):
             try:
-                module = self.pyload.plugin_manager.load_module("extractor", p)
-                klass = getattr(module, p)
+                klass = self.pyload.plugin_manager.load_class("extractor", p)
                 if klass.find():
                     self.extractors.append(klass)
                 if klass.REPAIR:


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

Replace js2py dependency with dukpy

<!-- WRITE HERE -->

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

js2py is not compatible with Python 3.12 and prevents pyLoad from starting. There may be more incompatibilities with Python 3.12 but at least pyLoad now starts. 

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
