### PR TITLE
Fix NAME_PATTERN for Mediafire downloader

### DIFF
--- a/src/pyload/plugins/downloaders/MediafireCom.py
+++ b/src/pyload/plugins/downloaders/MediafireCom.py
@@ -9,7 +9,7 @@ from ..base.simple_downloader import SimpleDownloader
 class MediafireCom(SimpleDownloader):
     __name__ = "MediafireCom"
     __type__ = "downloader"
-    __version__ = "0.99"
+    __version__ = "0.100"
     __status__ = "testing"
 
     __pattern__ = r"https?://(?:www\.)?mediafire\.com/(file/|view/\??|download(\.php\?|/)|\?)(?P<ID>\w+)"

--- a/src/pyload/plugins/downloaders/MediafireCom.py
+++ b/src/pyload/plugins/downloaders/MediafireCom.py
@@ -30,7 +30,7 @@ class MediafireCom(SimpleDownloader):
         ("GammaC0de", "nitzo2001[AT]yahoo[DOT]com"),
     ]
 
-    NAME_PATTERN = r'<META NAME="description" CONTENT="(?P<N>.+?)"/>'
+    NAME_PATTERN = r'<meta itemprop="name" content="(?P<N>.+?)"/>'
     SIZE_PATTERN = r'<div class="fileName">(?P<N>.+?)</div>'
 
     TEMP_OFFLINE_PATTERN = r"^unmatchable$"


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

<!-- WRITE HERE -->

The Mediafire downloader NAME_PATTERN is not applicable to the latest Mediafire website. This leads to issues with chunked downloads (No `NAME_PATTERN` match means that all of the chunks get the same `file.` prefix so multiple mediafire downloads lead to unpredictable joins and exceptions) 

### Is this related to a problem?

No