### PR TITLE
ArchiveOrg: Fix login check

### DIFF
--- a/src/pyload/plugins/accounts/ArchiveOrg.py
+++ b/src/pyload/plugins/accounts/ArchiveOrg.py
@@ -18,7 +18,7 @@ class ArchiveOrg(BaseAccount):
     __authors__ = [("GammaC0de", "nitzo2001[AT]yahoo[DOT]com")]
 
     LOGIN_URL = "https://archive.org/account/login"
-    LOGIN_CHECK_URL = "https://archive.org/account/index.php"
+    LOGIN_CHECK_URL = "https://archive.org/account/index.php?settings=1"
 
     def grab_info(self, user, password, data):
         return {'validuntil': None,
@@ -27,7 +27,7 @@ class ArchiveOrg(BaseAccount):
 
     def signin(self, user, password, data):
         html = self.load(self.LOGIN_CHECK_URL)
-        if "<title>cannot find account</title>" not in html:
+        if "You must be logged in to change your settings." not in html:
             self.skip_login()
 
         else:


### PR DESCRIPTION
### Describe the changes

This fixes the login check for archive.org.

### Is this related to a problem?

Despite adding an account for archive.org I got `401 Unauthorized` when I tried to download a file, that requires an account. This is because the login check failed and pyload skipped the login.