### PR TITLE
Introduce Pydantic data models and API type annotations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,7 @@ install_requires =
     # requests-html~=0.10
     semver~=2.10
     setuptools>=38.3
+    pydantic~=2.10.6
 python_requires = >=3.6
 
 [options.packages.find]

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -393,7 +393,7 @@ class Api:
     @permission(Perms.LIST)
     def status_downloads(self):
         """
-        Status off all currently running downloads.
+        Status of all currently running downloads.
 
         :return: list of `DownloadStatus`
         """
@@ -404,22 +404,23 @@ class Api:
 
             data.append(
                 DownloadInfo(
-                    pyfile.id,
-                    pyfile.name,
-                    pyfile.get_speed(),
-                    pyfile.get_eta(),
-                    pyfile.format_eta(),
-                    pyfile.get_bytes_left(),
-                    pyfile.get_size(),
-                    pyfile.format_size(),
-                    pyfile.get_percent(),
-                    pyfile.status,
-                    pyfile.get_status_name(),
-                    pyfile.format_wait(),
-                    pyfile.wait_until,
-                    pyfile.packageid,
-                    pyfile.package().name,
-                    pyfile.pluginname,
+                    fid=pyfile.id,
+                    name=pyfile.name,
+                    speed=pyfile.get_speed(),
+                    eta=pyfile.get_eta(),
+                    format_eta=pyfile.format_eta(),
+                    bleft=pyfile.get_bytes_left(),
+                    size=pyfile.get_size(),
+                    format_size=pyfile.format_size(),
+                    percent=pyfile.get_percent(),
+                    status=pyfile.status,
+                    statusmsg=pyfile.get_status_name(),
+                    format_wait=pyfile.format_wait(),
+                    wait_until=pyfile.wait_until,
+                    package_id=pyfile.packageid,
+                    package_name=pyfile.package().name,
+                    plugin=pyfile.pluginname,
+                    info=""
                 )
             )
 

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -494,7 +494,7 @@ class Api:
 
     @legacy("parseURLs")
     @permission(Perms.ADD)
-    def parse_urls(self, html: Optional[str], url: Optional[str]) -> dict[str, list[str]]:
+    def parse_urls(self, html: Optional[str] = None, url: Optional[str] = None) -> dict[str, list[str]]:
         """
         Parses html content or any arbitrary text for links and returns result of
         `check_urls`
@@ -1236,7 +1236,7 @@ class Api:
 
     @legacy("updateAccount")
     @permission(Perms.ACCOUNTS)
-    def update_account(self, plugin: str, account: str, password: Optional[str], options: dict[str: Any] = {}) -> None:
+    def update_account(self, plugin: str, account: str, password: Optional[str] = None, options: dict[str: Any] = {}) -> None:
         """
         Changes pw/options for specific account.
         """

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -395,7 +395,7 @@ class Api:
         """
         Status of all currently running downloads.
 
-        :return: list of `DownloadStatus`
+        :return: list of `DownloadInfo`
         """
         data = []
         for pyfile in self.pyload.thread_manager.get_active_files():

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -1180,13 +1180,13 @@ class Api:
             accounts.extend(
                 [
                     AccountInfo(
-                        acc["validuntil"],
-                        acc["login"],
-                        acc["options"],
-                        acc["valid"],
-                        acc["trafficleft"],
-                        acc["premium"],
-                        acc["type"],
+                        validuntil=acc["validuntil"],
+                        login=acc["login"],
+                        options=acc["options"],
+                        valid=acc["valid"],
+                        trafficleft=acc["trafficleft"],
+                        premium=acc["premium"],
+                        type=acc["type"],
                     )
                     for acc in group
                 ]

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -142,11 +142,10 @@ class Api:
             for key, data in sub.items():
                 if key in ("desc", "outline"):
                     continue
-                item = ConfigItem()
-                item.name = key
-                item.description = data["desc"]
-                item.value = str(data["value"])
-                item.type = data["type"]
+                item = ConfigItem(name=key,
+                                  description=data["desc"],
+                                  value=str(data["value"]),
+                                  type=data["type"])
                 items.append(item)
             section.items = items
             sections[section_name] = section

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -13,12 +13,27 @@ import os
 import re
 import time
 from enum import IntFlag
-from typing import Any, AnyStr
+from typing import Any, AnyStr, Optional
 
 from pyload import PKGDIR
-from ..datatypes.data import *
-from ..datatypes.enums import *
-from ..datatypes.exceptions import *
+from ..datatypes.data import (
+    AccountInfo,
+    CaptchaTask,
+    ConfigItem,
+    ConfigSection,
+    DownloadInfo,
+    EventInfo,
+    FileData,
+    OldUserData,
+    OnlineCheck,
+    OnlineStatus,
+    PackageData,
+    ServerStatus,
+    ServiceCall,
+    UserData,
+)
+from ..datatypes.enums import Destination, ElementType
+from ..datatypes.exceptions import PackageDoesNotExists, FileDoesNotExists, ServiceDoesNotExists, ServiceException
 from ..datatypes.pyfile import PyFile
 from ..log_factory import LogFactory
 from ..network.request_factory import get_url

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -293,14 +293,14 @@ class Api:
         :return: `ServerStatus`
         """
         server_status = ServerStatus(
-            self.pyload.thread_manager.pause,
-            len(self.pyload.thread_manager.processing_ids()),
-            self.pyload.files.get_queue_count(),
-            self.pyload.files.get_file_count(),
-            0,
-            not self.pyload.thread_manager.pause and self.is_time_download(),
-            self.pyload.config.get("reconnect", "enabled") and self.is_time_reconnect(),
-            self.is_captcha_waiting(),
+            pause=self.pyload.thread_manager.pause,
+            active=len(self.pyload.thread_manager.processing_ids()),
+            queue=self.pyload.files.get_queue_count(),
+            total=self.pyload.files.get_file_count(),
+            speed=0,
+            download=not self.pyload.thread_manager.pause and self.is_time_download(),
+            reconnect=self.pyload.config.get("reconnect", "enabled") and self.is_time_reconnect(),
+            captcha=self.is_captcha_waiting(),
         )
 
         for pyfile in [

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -1096,10 +1096,13 @@ class Api:
         if task:
             task.set_waiting_for_user(exclusive=exclusive)
             data, type, result = task.get_captcha()
-            t = CaptchaTask(int(task.id), json.dumps(data), type, result)
+            t = CaptchaTask(tid=int(task.id),
+                            data=json.dumps(data),
+                            type=type,
+                            result_type=result)
             return t
         else:
-            return CaptchaTask(-1)
+            return CaptchaTask(tid=-1)
 
     @legacy("getCaptchaTaskStatus")
     @permission(Perms.STATUS)

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -1295,11 +1295,11 @@ class Api:
         user = self.check_auth(username, password)
         if user:
             return OldUserData(
-                user["name"],
-                user["email"],
-                user["role"],
-                user["permission"],
-                user["template"],
+                name=user["name"],
+                email=user["email"],
+                role=user["role"],
+                permission=user["permission"],
+                template_name=user["template"],
             )
         else:
             return OldUserData()
@@ -1312,12 +1312,12 @@ class Api:
         user = self.check_auth(username, password)
         if user:
             return UserData(
-                user["id"],
-                user["name"],
-                user["email"],
-                user["role"],
-                user["permission"],
-                user["template"],
+                id=user["id"],
+                name=user["name"],
+                email=user["email"],
+                role=user["role"],
+                permission=user["permission"],
+                template=user["template"],
             )
         else:
             return UserData()
@@ -1330,11 +1330,11 @@ class Api:
         res = {}
         for id, data in self.pyload.db.get_all_user_data().items():
             res[data["name"]] = OldUserData(
-                data["name"],
-                data["email"],
-                data["role"],
-                data["permission"],
-                data["template"],
+                name=data["name"],
+                email=data["email"],
+                role=data["role"],
+                permission=data["permission"],
+                template_name=data["template"],
             )
 
         return res
@@ -1346,12 +1346,12 @@ class Api:
         res = {}
         for id, data in self.pyload.db.get_all_user_data().items():
             res[id] = UserData(
-                id,
-                data["name"],
-                data["email"],
-                data["role"],
-                data["permission"],
-                data["template"],
+                id=id,
+                name=data["name"],
+                email=data["email"],
+                role=data["role"],
+                permission=data["permission"],
+                template=data["template"],
             )
         return res
 

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -137,7 +137,6 @@ class Api:
     def _convert_config_format(self, c):
         sections = {}
         for section_name, sub in c.items():
-            section = ConfigSection(section_name, sub["desc"])
             items = []
             for key, data in sub.items():
                 if key in ("desc", "outline"):
@@ -147,10 +146,12 @@ class Api:
                                   value=str(data["value"]),
                                   type=data["type"])
                 items.append(item)
-            section.items = items
+            section = ConfigSection(name=section_name,
+                                    description=sub["desc"],
+                                    items=items,
+                                    outline=sub.get("outline"))
             sections[section_name] = section
-            if "outline" in sub:
-                section.outline = sub["outline"]
+
         return sections
 
     @legacy("getConfigValue")

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -523,7 +523,11 @@ class Api:
         rid = self.pyload.thread_manager.create_result_thread(data, False)
 
         tmp = [
-            (url, (url, OnlineStatus(url, pluginname, "unknown", 3, 0)))
+            (url, (url, OnlineStatus(name=url,
+                                     plugin=pluginname,
+                                     packagename="unknown",
+                                     status=3,
+                                     size=0)))
             for url, pluginname in data
         ]
         data = parse_names(tmp)

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -634,13 +634,13 @@ class Api:
             raise PackageDoesNotExists(package_id)
 
         pdata = PackageData(
-            data["id"],
-            data["name"],
-            data["folder"],
-            data["site"],
-            data["password"],
-            data["queue"],
-            data["order"],
+            pid=data["id"],
+            name=data["name"],
+            folder=data["folder"],
+            site=data["site"],
+            password=data["password"],
+            dest=data["queue"],
+            order=data["order"],
             links=[self._convert_py_file(x) for x in data["links"].values()],
         )
 
@@ -662,13 +662,13 @@ class Api:
             raise PackageDoesNotExists(package_id)
 
         pdata = PackageData(
-            data["id"],
-            data["name"],
-            data["folder"],
-            data["site"],
-            data["password"],
-            data["queue"],
-            data["order"],
+            pid=data["id"],
+            name=data["name"],
+            folder=data["folder"],
+            site=data["site"],
+            password=data["password"],
+            dest=data["queue"],
+            order=data["order"],
             fids=[int(x) for x in data["links"]],
         )
 
@@ -724,21 +724,21 @@ class Api:
         Returns info about queue and packages, **not** about files, see `get_queue_data` \
         or `get_package_data` instead.
 
-        :return: list of `PackageInfo`
+        :return: list of `PackageData`
         """
         return [
             PackageData(
-                pack["id"],
-                pack["name"],
-                pack["folder"],
-                pack["site"],
-                pack["password"],
-                pack["queue"],
-                pack["order"],
-                pack["linksdone"],
-                pack["sizedone"],
-                pack["sizetotal"],
-                pack["linkstotal"],
+                pid=pack["id"],
+                name=pack["name"],
+                folder=pack["folder"],
+                site=pack["site"],
+                password=pack["password"],
+                dest=pack["queue"],
+                order=pack["order"],
+                linksdone=pack["linksdone"],
+                sizedone=pack["sizedone"],
+                sizetotal=pack["sizetotal"],
+                linkstotal=pack["linkstotal"],
             )
             for pack in self.pyload.files.get_info_data(Destination.QUEUE).values()
         ]
@@ -755,16 +755,16 @@ class Api:
         """
         return [
             PackageData(
-                pack["id"],
-                pack["name"],
-                pack["folder"],
-                pack["site"],
-                pack["password"],
-                pack["queue"],
-                pack["order"],
-                pack["linksdone"],
-                pack["sizedone"],
-                pack["sizetotal"],
+                pid=pack["id"],
+                name=pack["name"],
+                folder=pack["folder"],
+                site=pack["site"],
+                password=pack["password"],
+                dest=pack["queue"],
+                order=pack["order"],
+                linksdone=pack["linksdone"],
+                sizedone=pack["sizedone"],
+                sizetotal=pack["sizetotal"],
                 links=[self._convert_py_file(x) for x in pack["links"].values()],
             )
             for pack in self.pyload.files.get_complete_data(Destination.QUEUE).values()
@@ -780,17 +780,17 @@ class Api:
         """
         return [
             PackageData(
-                pack["id"],
-                pack["name"],
-                pack["folder"],
-                pack["site"],
-                pack["password"],
-                pack["queue"],
-                pack["order"],
-                pack["linksdone"],
-                pack["sizedone"],
-                pack["sizetotal"],
-                pack["linkstotal"],
+                pid=pack["id"],
+                name=pack["name"],
+                folder=pack["folder"],
+                site=pack["site"],
+                password=pack["password"],
+                dest=pack["queue"],
+                order=pack["order"],
+                linksdone=pack["linksdone"],
+                sizedone=pack["sizedone"],
+                sizetotal=pack["sizetotal"],
+                linkstotal=pack["linkstotal"],
             )
             for pack in self.pyload.files.get_info_data(Destination.COLLECTOR).values()
         ]
@@ -805,16 +805,16 @@ class Api:
         """
         return [
             PackageData(
-                pack["id"],
-                pack["name"],
-                pack["folder"],
-                pack["site"],
-                pack["password"],
-                pack["queue"],
-                pack["order"],
-                pack["linksdone"],
-                pack["sizedone"],
-                pack["sizetotal"],
+                pid=pack["id"],
+                name=pack["name"],
+                folder=pack["folder"],
+                site=pack["site"],
+                password=pack["password"],
+                dest=pack["queue"],
+                order=pack["order"],
+                linksdone=pack["linksdone"],
+                sizedone=pack["sizedone"],
+                sizetotal=pack["sizetotal"],
                 links=[self._convert_py_file(x) for x in pack["links"].values()],
             )
             for pack in self.pyload.files.get_complete_data(

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -1398,7 +1398,11 @@ class Api:
             plugin, func =  service_name.split(".")
         except ValueError:
             raise ServiceDoesNotExists()
-        info = ServiceCall(plugin, func, arguments, parse_arguments)
+
+        info = ServiceCall(plugin=plugin,
+                           func=func,
+                           arguments=arguments,
+                           parse_arguments=parse_arguments)
         return self.call(info)
 
     @permission(Perms.STATUS)

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -513,7 +513,7 @@ class Api:
     @permission(Perms.ADD)
     def check_online_status(self, urls):
         """
-        initiates online status check.
+        Initiates online status check.
 
         :param urls:
         :return: initial set of data as `OnlineCheck` instance containing the result id
@@ -534,7 +534,7 @@ class Api:
                 status.packagename = k
                 result[url] = status
 
-        return OnlineCheck(rid, result)
+        return OnlineCheck(rid=rid, data=result)
 
     @legacy("checkOnlineStatusContainer")
     @permission(Perms.ADD)
@@ -570,9 +570,9 @@ class Api:
 
         if "ALL_INFO_FETCHED" in result:
             del result["ALL_INFO_FETCHED"]
-            return OnlineCheck(-1, result)
+            return OnlineCheck(rid=-1, data=result)
         else:
-            return OnlineCheck(rid, result)
+            return OnlineCheck(rid=rid, data=result)
 
     @legacy("generatePackages")
     @permission(Perms.ADD)

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -1408,7 +1408,7 @@ class Api:
         return plugin in cont and func in cont[plugin]
 
     @permission(Perms.STATUS)
-    def service_call(self, service_name: str, arguments: Optional[tuple], parse_arguments: bool = False) -> str:
+    def service_call(self, service_name: str, arguments: Optional[list[Any]], parse_arguments: bool = False) -> str:
         """
         Calls a service (a method in addon plugin).
 

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -494,7 +494,7 @@ class Api:
 
     @legacy("parseURLs")
     @permission(Perms.ADD)
-    def parse_urls(self, html: str = None, url: str = None) -> dict[str, list[str]]:
+    def parse_urls(self, html: Optional[str], url: Optional[str]) -> dict[str, list[str]]:
         """
         Parses html content or any arbitrary text for links and returns result of
         `check_urls`
@@ -1236,7 +1236,7 @@ class Api:
 
     @legacy("updateAccount")
     @permission(Perms.ACCOUNTS)
-    def update_account(self, plugin: str, account: str, password: str = None, options: dict[str: Any] = {}) -> None:
+    def update_account(self, plugin: str, account: str, password: Optional[str], options: dict[str: Any] = {}) -> None:
         """
         Changes pw/options for specific account.
         """

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -263,7 +263,7 @@ class Api:
 
     @legacy("pauseServer")
     @permission(Perms.STATUS)
-    def pause_server(self):
+    def pause_server(self) -> None:
         """
         Pause server: It won't start any new downloads, but nothing gets aborted.
         """
@@ -300,7 +300,7 @@ class Api:
         return self.pyload.config.get("reconnect", "enabled")
 
     @permission(Perms.STATUS)
-    def toggle_proxy(self):
+    def toggle_proxy(self) -> bool:
         """
         Toggle proxy activation.
 

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -1139,7 +1139,7 @@ class Api:
         Lists occurred events, may be affected to changes in the future.
 
         :param uuid:
-        :return: list of `Events`
+        :return: list of `EventInfo`
         """
         events = self.pyload.event_manager.get_events(uuid)
         new_events = []
@@ -1148,8 +1148,7 @@ class Api:
             return (Destination.QUEUE if d == "queue" else Destination.COLLECTOR).value
 
         for e in events:
-            event = EventInfo()
-            event.eventname = e[0]
+            event = EventInfo(eventname=e[0])
             if e[0] in ("update", "remove", "insert"):
                 event.id = e[3]
                 event.type = (

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -120,17 +120,17 @@ class Api:
 
     def _convert_py_file(self, p):
         f = FileData(
-            p["id"],
-            p["url"],
-            p["name"],
-            p["plugin"],
-            p["size"],
-            p["format_size"],
-            p["status"],
-            p["statusmsg"],
-            p["package"],
-            p["error"],
-            p["order"],
+            fid=p["id"],
+            url=p["url"],
+            name=p["name"],
+            plugin=p["plugin"],
+            size=p["size"],
+            format_size=p["format_size"],
+            status=p["status"],
+            statusmsg=p["statusmsg"],
+            package_id=p["package"],
+            error=p["error"],
+            order=p["order"]
         )
         return f
 

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -13,9 +13,9 @@ import os
 import re
 import time
 from enum import IntFlag
+from typing import Any, AnyStr
 
 from pyload import PKGDIR
-
 from ..datatypes.data import *
 from ..datatypes.enums import *
 from ..datatypes.exceptions import *
@@ -118,7 +118,7 @@ class Api:
         self.pyload = core
         self._ = core._
 
-    def _convert_py_file(self, p):
+    def _convert_py_file(self, p) -> FileData:
         f = FileData(
             fid=p["id"],
             url=p["url"],
@@ -134,7 +134,7 @@ class Api:
         )
         return f
 
-    def _convert_config_format(self, c):
+    def _convert_config_format(self, c) -> dict[str, ConfigSection]:
         sections = {}
         for section_name, sub in c.items():
             items = []
@@ -156,7 +156,7 @@ class Api:
 
     @legacy("getConfigValue")
     @permission(Perms.SETTINGS)
-    def get_config_value(self, category, option, section="core"):
+    def get_config_value(self, category: str, option: str, section: str = "core") -> Any:
         """
         Retrieve config value.
 
@@ -173,7 +173,7 @@ class Api:
 
     @legacy("setConfigValue")
     @permission(Perms.SETTINGS)
-    def set_config_value(self, category, option, value, section="core"):
+    def set_config_value(self, category: str, option: str, value: Any, section: str ="core") -> None:
         """
         Set new config value.
 
@@ -210,16 +210,16 @@ class Api:
 
     @legacy("getConfig")
     @permission(Perms.SETTINGS)
-    def get_config(self):
+    def get_config(self) -> dict[str, ConfigSection]:
         """
         Retrieves complete config of core.
 
-        :return: list of `ConfigSection`
+        :return: dict of section name to `ConfigSection`
         """
         return self._convert_config_format(self.pyload.config.config)
 
     @legacy("getConfigDict")
-    def get_config_dict(self):
+    def get_config_dict(self) -> dict[Any, Any]:
         """
         Retrieves complete config in dict format, not for RPC.
 
@@ -229,16 +229,16 @@ class Api:
 
     @legacy("getPluginConfig")
     @permission(Perms.SETTINGS)
-    def get_plugin_config(self):
+    def get_plugin_config(self) -> dict[str, ConfigSection]:
         """
         Retrieves complete config for all plugins.
 
-        :return: list of `ConfigSection`
+        :return: dict of section name to `ConfigSection`
         """
         return self._convert_config_format(self.pyload.config.plugin)
 
     @legacy("getPluginConfigDict")
-    def get_plugin_config_dict(self):
+    def get_plugin_config_dict(self) -> dict[Any, Any]:
         """
         Plugin config as dict, not for RPC.
 
@@ -256,7 +256,7 @@ class Api:
 
     @legacy("unpauseServer")
     @permission(Perms.STATUS)
-    def unpause_server(self):
+    def unpause_server(self) -> None:
         """
         Unpause server: New Downloads will be started.
         """
@@ -264,7 +264,7 @@ class Api:
 
     @legacy("togglePause")
     @permission(Perms.STATUS)
-    def toggle_pause(self):
+    def toggle_pause(self) -> bool:
         """
         Toggle pause state.
 
@@ -275,7 +275,7 @@ class Api:
 
     @legacy("toggleReconnect")
     @permission(Perms.STATUS)
-    def toggle_reconnect(self):
+    def toggle_reconnect(self) -> bool:
         """
         Toggle reconnect activation.
 
@@ -286,7 +286,7 @@ class Api:
 
     @legacy("statusServer")
     @permission(Perms.LIST)
-    def status_server(self):
+    def status_server(self) -> ServerStatus:
         """
         Some general information about the current status of pyLoad.
 
@@ -314,7 +314,7 @@ class Api:
 
     @legacy("freeSpace")
     @permission(Perms.STATUS)
-    def free_space(self):
+    def free_space(self) -> int:
         """
         Available free space at download directory in bytes.
         """
@@ -322,19 +322,19 @@ class Api:
 
     @legacy("getServerVersion")
     @permission(Perms.ANY)
-    def get_server_version(self):
+    def get_server_version(self) -> str:
         """
         pyLoad Core version.
         """
         return self.pyload.version
 
-    def kill(self):
+    def kill(self) -> None:
         """
         Clean way to quit pyLoad.
         """
         self.pyload._do_exit = True
 
-    def restart(self):
+    def restart(self) -> None:
         """
         Restart pyload core.
         """
@@ -342,7 +342,7 @@ class Api:
 
     @legacy("getLog")
     @permission(Perms.LOGS)
-    def get_log(self, offset=0):
+    def get_log(self, offset: int = 0) -> list[str]:
         """
         Returns most recent log entries.
 
@@ -365,7 +365,7 @@ class Api:
 
     @legacy("isTimeDownload")
     @permission(Perms.STATUS)
-    def is_time_download(self):
+    def is_time_download(self) -> bool:
         """
         Checks if pyload will start new downloads according to time in config.
 
@@ -377,7 +377,7 @@ class Api:
 
     @legacy("isTimeReconnect")
     @permission(Perms.STATUS)
-    def is_time_reconnect(self):
+    def is_time_reconnect(self) -> bool:
         """
         Checks if pyload will try to make a reconnect.
 
@@ -391,7 +391,7 @@ class Api:
 
     @legacy("statusDownloads")
     @permission(Perms.LIST)
-    def status_downloads(self):
+    def status_downloads(self) -> list[DownloadInfo]:
         """
         Status of all currently running downloads.
 
@@ -428,7 +428,7 @@ class Api:
 
     @legacy("addPackage")
     @permission(Perms.ADD)
-    def add_package(self, name, links, dest=Destination.QUEUE):
+    def add_package(self, name: str, links: list[str], dest: int = Destination.QUEUE) -> int:
         """
         Adds a package, with links to desired destination.
 
@@ -468,7 +468,7 @@ class Api:
 
     @legacy("parseURLs")
     @permission(Perms.ADD)
-    def parse_urls(self, html=None, url=None):
+    def parse_urls(self, html: str = None, url: str = None) -> dict[str, list[str]]:
         """
         Parses html content or any arbitrary text for links and returns result of
         `check_urls`
@@ -477,23 +477,22 @@ class Api:
         :param url: url to load html source from
         :return:
         """
-        urls = []
+        urls = set()
 
         if html:
-            urls += urlmatcher.findall(html)
+            urls.update(urlmatcher.findall(html))
 
         if url:
             page = get_url(url)
-            urls += urlmatcher.findall(page)
+            urls.update(urlmatcher.findall(page))
 
-        # remove duplicates
-        return self.check_urls(set(urls))
+        return self.check_urls(list(urls))
 
     @legacy("checkURLs")
     @permission(Perms.ADD)
-    def check_urls(self, urls):
+    def check_urls(self, urls: list[str]) -> dict[str, list[str]]:
         """
-        Gets urls and returns pluginname mapped to list of matches urls.
+        Gets urls and returns pluginname mapped to list of matched urls.
 
         :param urls:
         :return: {plugin: urls}
@@ -511,7 +510,7 @@ class Api:
 
     @legacy("checkOnlineStatus")
     @permission(Perms.ADD)
-    def check_online_status(self, urls):
+    def check_online_status(self, urls: list[str]) -> OnlineCheck:
         """
         Initiates online status check.
 
@@ -542,7 +541,7 @@ class Api:
 
     @legacy("checkOnlineStatusContainer")
     @permission(Perms.ADD)
-    def check_online_status_container(self, urls, container, data):
+    def check_online_status_container(self, urls: list[str], container: str, data: AnyStr) -> OnlineCheck:
         """
         checks online status of urls and a submitted container file.
 
@@ -563,7 +562,7 @@ class Api:
 
     @legacy("pollResults")
     @permission(Perms.ADD)
-    def poll_results(self, rid):
+    def poll_results(self, rid: int) -> OnlineCheck:
         """
         Polls the result available for ResultID.
 
@@ -580,7 +579,7 @@ class Api:
 
     @legacy("generatePackages")
     @permission(Perms.ADD)
-    def generate_packages(self, links):
+    def generate_packages(self, links: list[str]) -> dict[str, list[str]]:
         """
         Parses links, generates packages names from urls.
 
@@ -592,7 +591,7 @@ class Api:
 
     @legacy("generateAndAddPackages")
     @permission(Perms.ADD)
-    def generate_and_add_packages(self, links, dest=Destination.COLLECTOR):
+    def generate_and_add_packages(self, links: list[str], dest: int = Destination.COLLECTOR) -> list[int]:
         """
         Generates and add packages.
 
@@ -607,7 +606,7 @@ class Api:
 
     @legacy("checkAndAddPackages")
     @permission(Perms.ADD)
-    def check_and_add_packages(self, links, dest=Destination.COLLECTOR):
+    def check_and_add_packages(self, links: list[str], dest: int = Destination.COLLECTOR) -> None:
         """
         Checks online status, retrieves names, and will add packages.
         Because of these packages are not added immediately, only for internal use.
@@ -621,7 +620,7 @@ class Api:
 
     @legacy("getPackageData")
     @permission(Perms.LIST)
-    def get_package_data(self, package_id):
+    def get_package_data(self, package_id: int) -> PackageData:
         """
         Returns complete information about package, and included files.
 
@@ -648,7 +647,7 @@ class Api:
 
     @legacy("getPackageInfo")
     @permission(Perms.LIST)
-    def get_package_info(self, package_id):
+    def get_package_info(self, package_id: int) -> PackageData:
         """
         Returns information about package, without detailed information about containing
         files.
@@ -676,7 +675,7 @@ class Api:
 
     @legacy("getFileData")
     @permission(Perms.LIST)
-    def get_file_data(self, file_id):
+    def get_file_data(self, file_id: int) -> FileData:
         """
         Get complete information about a specific file.
 
@@ -693,7 +692,7 @@ class Api:
 
     @legacy("deleteFiles")
     @permission(Perms.DELETE)
-    def delete_files(self, file_ids):
+    def delete_files(self, file_ids: list[int]) -> None:
         """
         Deletes several file entries from pyload.
 
@@ -706,7 +705,7 @@ class Api:
 
     @legacy("deletePackages")
     @permission(Perms.DELETE)
-    def delete_packages(self, package_ids):
+    def delete_packages(self, package_ids: list[int]) -> None:
         """
         Deletes packages and containing links.
 
@@ -719,7 +718,7 @@ class Api:
 
     @legacy("getQueue")
     @permission(Perms.LIST)
-    def get_queue(self):
+    def get_queue(self) -> list[PackageData]:
         """
         Returns info about queue and packages, **not** about files, see `get_queue_data` \
         or `get_package_data` instead.
@@ -745,7 +744,7 @@ class Api:
 
     @legacy("getQueueData")
     @permission(Perms.LIST)
-    def get_queue_data(self):
+    def get_queue_data(self) -> list[PackageData]:
         """
         Return complete data about everything in queue, this is very expensive use it
         sparely.
@@ -772,11 +771,11 @@ class Api:
 
     @legacy("getCollector")
     @permission(Perms.LIST)
-    def get_collector(self):
+    def get_collector(self) -> list[PackageData]:
         """
         same as `get_queue` for collector.
 
-        :return: list of `PackageInfo`
+        :return: list of `PackageData`
         """
         return [
             PackageData(
@@ -797,11 +796,11 @@ class Api:
 
     @legacy("getCollectorData")
     @permission(Perms.LIST)
-    def get_collector_data(self):
+    def get_collector_data(self) -> list[PackageData]:
         """
         same as `get_queue_data` for collector.
 
-        :return: list of `PackageInfo`
+        :return: list of `PackageData`
         """
         return [
             PackageData(
@@ -824,7 +823,7 @@ class Api:
 
     @legacy("addFiles")
     @permission(Perms.ADD)
-    def add_files(self, package_id, links):
+    def add_files(self, package_id: int, links: list[str]) -> None:
         """
         Adds files to specific package.
 
@@ -842,7 +841,7 @@ class Api:
 
     @legacy("pushToQueue")
     @permission(Perms.MODIFY)
-    def push_to_queue(self, package_id):
+    def push_to_queue(self, package_id: int) -> None:
         """
         Moves package from Collector to Queue.
 
@@ -852,7 +851,7 @@ class Api:
 
     @legacy("pullFromQueue")
     @permission(Perms.MODIFY)
-    def pull_from_queue(self, package_id):
+    def pull_from_queue(self, package_id: int) -> None:
         """
         Moves package from Queue to Collector.
 
@@ -862,7 +861,7 @@ class Api:
 
     @legacy("restartPackage")
     @permission(Perms.MODIFY)
-    def restart_package(self, package_id):
+    def restart_package(self, package_id: int) -> None:
         """
         Restarts a package, resets every containing files.
 
@@ -872,7 +871,7 @@ class Api:
 
     @legacy("restartFile")
     @permission(Perms.MODIFY)
-    def restart_file(self, file_id):
+    def restart_file(self, file_id: int) -> None:
         """
         Resets file status, so it will be downloaded again.
 
@@ -882,7 +881,7 @@ class Api:
 
     @legacy("recheckPackage")
     @permission(Perms.MODIFY)
-    def recheck_package(self, package_id):
+    def recheck_package(self, package_id: int) -> None:
         """
         Probes online status of all files in a package, also a default action when
         package is added.
@@ -894,7 +893,7 @@ class Api:
 
     @legacy("stopAllDownloads")
     @permission(Perms.MODIFY)
-    def stop_all_downloads(self):
+    def stop_all_downloads(self) -> None:
         """
         Aborts all running downloads.
         """
@@ -904,7 +903,7 @@ class Api:
 
     @legacy("stopDownloads")
     @permission(Perms.MODIFY)
-    def stop_downloads(self, file_ids):
+    def stop_downloads(self, file_ids: list[int]) -> None:
         """
         Aborts specific downloads.
 
@@ -918,7 +917,7 @@ class Api:
 
     @legacy("setPackageName")
     @permission(Perms.MODIFY)
-    def set_package_name(self, package_id, name):
+    def set_package_name(self, package_id: int, name: str) -> None:
         """
         Renames a package.
 
@@ -931,7 +930,7 @@ class Api:
 
     @legacy("movePackage")
     @permission(Perms.MODIFY)
-    def move_package(self, destination, package_id):
+    def move_package(self, destination: int, package_id: int) -> None:
         """
         Set a new package location.
 
@@ -947,7 +946,7 @@ class Api:
 
     @legacy("moveFiles")
     @permission(Perms.MODIFY)
-    def move_files(self, file_ids, package_id):
+    def move_files(self, file_ids: list[int], package_id: int) -> None:
         """
         Move multiple files to another package.
 
@@ -960,7 +959,7 @@ class Api:
 
     @legacy("uploadContainer")
     @permission(Perms.ADD)
-    def upload_container(self, filename, data):
+    def upload_container(self, filename: str, data: AnyStr) -> None:
         """
         Uploads and adds a container file to pyLoad.
 
@@ -979,7 +978,7 @@ class Api:
 
     @legacy("orderPackage")
     @permission(Perms.MODIFY)
-    def order_package(self, package_id, position):
+    def order_package(self, package_id: int, position: int) -> None:
         """
         Gives a package a new position.
 
@@ -990,7 +989,7 @@ class Api:
 
     @legacy("orderFile")
     @permission(Perms.MODIFY)
-    def order_file(self, file_id, position):
+    def order_file(self, file_id: int, position: int) -> None:
         """
         Gives a new position to a file within its package.
 
@@ -1001,7 +1000,7 @@ class Api:
 
     @legacy("setPackageData")
     @permission(Perms.MODIFY)
-    def set_package_data(self, package_id, data):
+    def set_package_data(self, package_id: int, data: dict[str, Any]) -> None:
         """
         Allows to modify several package attributes.
 
@@ -1022,7 +1021,7 @@ class Api:
 
     @legacy("deleteFinished")
     @permission(Perms.DELETE)
-    def delete_finished(self):
+    def delete_finished(self) -> list[int]:
         """
         Deletes all finished files and completely finished packages.
 
@@ -1032,7 +1031,7 @@ class Api:
 
     @legacy("restartFailed")
     @permission(Perms.MODIFY)
-    def restart_failed(self):
+    def restart_failed(self) -> None:
         """
         Restarts all failed failes.
         """
@@ -1040,7 +1039,7 @@ class Api:
 
     @legacy("getPackageOrder")
     @permission(Perms.LIST)
-    def get_package_order(self, destination):
+    def get_package_order(self, destination: int) -> dict[int, int]:
         """
         Returns information about package order.
 
@@ -1059,7 +1058,7 @@ class Api:
 
     @legacy("getFileOrder")
     @permission(Perms.LIST)
-    def get_file_order(self, package_id):
+    def get_file_order(self, package_id: int) -> dict[int, int]:
         """
         Information about file order within package.
 
@@ -1076,9 +1075,9 @@ class Api:
 
     @legacy("isCaptchaWaiting")
     @permission(Perms.STATUS)
-    def is_captcha_waiting(self):
+    def is_captcha_waiting(self) -> bool:
         """
-        Indicates wether a captcha task is available.
+        Indicates whether a captcha task is available.
 
         :return: bool
         """
@@ -1088,7 +1087,7 @@ class Api:
 
     @legacy("getCaptchaTask")
     @permission(Perms.STATUS)
-    def get_captcha_task(self, exclusive=False):
+    def get_captcha_task(self, exclusive: bool = False) -> CaptchaTask:
         """
         Returns a captcha task.
 
@@ -1110,7 +1109,7 @@ class Api:
 
     @legacy("getCaptchaTaskStatus")
     @permission(Perms.STATUS)
-    def get_captcha_task_status(self, tid):
+    def get_captcha_task_status(self, tid: int) -> str:
         """
         Get information about captcha task.
 
@@ -1123,7 +1122,7 @@ class Api:
 
     @legacy("setCaptchaResult")
     @permission(Perms.STATUS)
-    def set_captcha_result(self, tid, result):
+    def set_captcha_result(self, tid: int, result: str) -> None:
         """
         Set result for a captcha task.
 
@@ -1138,7 +1137,7 @@ class Api:
 
     @legacy("getEvents")
     @permission(Perms.STATUS)
-    def get_events(self, uuid):
+    def get_events(self, uuid: str) -> list[EventInfo]:
         """
         Lists occurred events, may be affected to changes in the future.
 
@@ -1173,7 +1172,7 @@ class Api:
 
     @legacy("getAccounts")
     @permission(Perms.ACCOUNTS)
-    def get_accounts(self, refresh):
+    def get_accounts(self, refresh: bool) -> list[AccountInfo]:
         """
         Get information about all entered accounts.
 
@@ -1201,7 +1200,7 @@ class Api:
 
     @legacy("getAccountTypes")
     @permission(Perms.ANY)
-    def get_account_types(self):
+    def get_account_types(self) -> list[str]:
         """
         All available account types.
 
@@ -1211,7 +1210,7 @@ class Api:
 
     @legacy("updateAccount")
     @permission(Perms.ACCOUNTS)
-    def update_account(self, plugin, account, password=None, options={}):
+    def update_account(self, plugin: str, account: str, password: str = None, options: dict[str: Any] = {}) -> None:
         """
         Changes pw/options for specific account.
         """
@@ -1219,7 +1218,7 @@ class Api:
 
     @legacy("removeAccount")
     @permission(Perms.ACCOUNTS)
-    def remove_account(self, plugin, account):
+    def remove_account(self, plugin: str, account: str) -> None:
         """
         Remove account from pyload.
 
@@ -1229,7 +1228,7 @@ class Api:
         self.pyload.account_manager.remove_account(plugin, account)
 
     @permission(Perms.ANY)
-    def login(self, username, password):
+    def login(self, username: str, password: str) -> bool:
         """
         Login into pyLoad, this **must** be called when using rpc before any methods can
         be used.
@@ -1241,7 +1240,7 @@ class Api:
         return True if self.check_auth(username, password) else False
 
     @legacy("checkAuth")
-    def check_auth(self, username, password):
+    def check_auth(self, username: str, password: str) -> dict[str: Any]:
         """
         Check authentication and returns details.
 
@@ -1251,7 +1250,7 @@ class Api:
         """
         return self.pyload.db.check_auth(username, password)
 
-    def user_exists(self, username):
+    def user_exists(self, username: str) -> bool:
         """
         Check if a user actually exists in the database.
 
@@ -1261,7 +1260,7 @@ class Api:
         return self.pyload.db.user_exists(username)
 
     @legacy("isAuthorized")
-    def is_authorized(self, func, userdata):
+    def is_authorized(self, func: str, userdata: dict[str, Any]) -> bool:
         """
         checks if the user is authorized for specific method.
 
@@ -1279,16 +1278,16 @@ class Api:
             return False
 
     @permission(Perms.SETTINGS)
-    def get_userdir(self):
+    def get_userdir(self) -> str:
         return os.path.realpath(self.pyload.userdir)
 
     @permission(Perms.SETTINGS)
-    def get_cachedir(self):
+    def get_cachedir(self) -> str:
         return os.path.realpath(self.pyload.tempdir)
 
     #: Old API
     @permission(Perms.ANY)
-    def getUserData(self, username, password):
+    def getUserData(self, username: str, password: str) -> OldUserData:
         """
         similar to `check_auth` but returns UserData thrift type.
         """
@@ -1305,7 +1304,7 @@ class Api:
             return OldUserData()
 
     @permission(Perms.ANY)
-    def get_userdata(self, username, password):
+    def get_userdata(self, username: str, password: str) -> UserData:
         """
         similar to `check_auth` but returns UserData thrift type.
         """
@@ -1323,7 +1322,7 @@ class Api:
             return UserData()
 
     #: Old API
-    def getAllUserData(self):
+    def getAllUserData(self) -> dict[str, OldUserData]:
         """
         returns all known user and info.
         """
@@ -1339,7 +1338,7 @@ class Api:
 
         return res
 
-    def get_all_userdata(self):
+    def get_all_userdata(self) -> dict[int, UserData]:
         """
         returns all known user and info.
         """
@@ -1357,7 +1356,7 @@ class Api:
 
     @legacy("getServices")
     @permission(Perms.STATUS)
-    def get_services(self):
+    def get_services(self) -> dict[str, dict[str, str]]:
         """
         A dict of available services, these can be defined by addon plugins.
 
@@ -1371,7 +1370,7 @@ class Api:
 
     @legacy("hasService")
     @permission(Perms.STATUS)
-    def has_service(self, plugin, func):
+    def has_service(self, plugin: str, func: str) -> bool:
         """
         Checks whether a service is available.
 
@@ -1383,7 +1382,7 @@ class Api:
         return plugin in cont and func in cont[plugin]
 
     @permission(Perms.STATUS)
-    def service_call(self, service_name, arguments, parse_arguments=False):
+    def service_call(self, service_name: str, arguments: Optional[tuple], parse_arguments: bool = False) -> str:
         """
         Calls a service (a method in addon plugin).
 
@@ -1406,7 +1405,7 @@ class Api:
         return self.call(info)
 
     @permission(Perms.STATUS)
-    def call(self, info):
+    def call(self, info: ServiceCall) -> str:
         """
         Calls a service (a method in addon plugin).
 
@@ -1431,7 +1430,7 @@ class Api:
 
     @legacy("getAllInfo")
     @permission(Perms.STATUS)
-    def get_all_info(self):
+    def get_all_info(self) -> dict[str, dict[str, str]]:
         """
         Returns all information stored by addon plugins. Values are always strings.
 
@@ -1441,7 +1440,7 @@ class Api:
 
     @legacy("getInfoByPlugin")
     @permission(Perms.STATUS)
-    def get_info_by_plugin(self, plugin):
+    def get_info_by_plugin(self, plugin: str) -> dict[str, str]:
         """
         Returns information stored by a specific plugin.
 
@@ -1450,26 +1449,28 @@ class Api:
         """
         return self.pyload.addon_manager.get_info(plugin)
 
-    def add_user(self, user, newpw, role=0, perms=0):
+    def add_user(self, user: str, newpw: str, role: int = 0, perms: int = 0) -> bool:
         """
         creates new user login.
         """
         return self.pyload.db.add_user(user, newpw, role, perms)
 
-    def remove_user(self, user):
+    def remove_user(self, user: str) -> bool:
         """
         deletes a user login.
         """
-        return self.pyload.db.remove_user(user)
+        self.pyload.db.remove_user(user)
+        # TODO: fix db method to return bool
+        return True
 
     @legacy("changePassword")
-    def change_password(self, user, oldpw, newpw):
+    def change_password(self, user: str, oldpw: str, newpw: str) -> bool:
         """
         changes password for specific user.
         """
         return self.pyload.db.change_password(user, oldpw, newpw)
 
     @legacy("setUserPermission")
-    def set_user_permission(self, user, permission, role):
+    def set_user_permission(self, user: str, permission: int, role: int) -> None:
         self.pyload.db.set_permission(user, permission)
         self.pyload.db.set_role(user, role)

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -46,14 +46,11 @@ class ConfigItem(BaseModel):
     type: str
 
 
-class ConfigSection(AbstractData):
-    __slots__ = ["name", "description", "items", "outline"]
-
-    def __init__(self, name=None, description=None, items=None, outline=None):
-        self.name = name
-        self.description = description
-        self.items = items
-        self.outline = outline
+class ConfigSection(BaseModel):
+    name: str
+    description: str
+    items: list[ConfigItem]
+    outline: str | None
 
 
 class DownloadInfo(BaseModel):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -134,7 +134,7 @@ class OldUserData(BaseModel):
 
 
 class UserData(BaseModel):
-    id: Optional[int]
+    id: Optional[int] = None
     name: Optional[str] = None
     email: Optional[str] = None
     role: Optional[int] = None

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -135,14 +135,11 @@ class ServerStatus(BaseModel):
     captcha: bool
 
 
-class ServiceCall(AbstractData):
-    __slots__ = ["plugin", "func", "arguments", "parse_arguments"]
-
-    def __init__(self, plugin=None, func=None, arguments=None, parse_arguments=None):
-        self.plugin = plugin
-        self.func = func
-        self.arguments = arguments
-        self.parse_arguments = parse_arguments
+class ServiceCall(BaseModel):
+    plugin: str
+    func: str
+    arguments: Optional[tuple]
+    parse_arguments: bool
 
 
 #: Needed by legacy API

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -124,37 +124,15 @@ class PackageData(BaseModel):
     fids: Optional[list[int]] = None
 
 
-class ServerStatus(AbstractData):
-    __slots__ = [
-        "pause",
-        "active",
-        "queue",
-        "total",
-        "speed",
-        "download",
-        "reconnect",
-        "captcha",
-    ]
-
-    def __init__(
-        self,
-        pause=None,
-        active=None,
-        queue=None,
-        total=None,
-        speed=None,
-        download=None,
-        reconnect=None,
-        captcha=None,
-    ):
-        self.pause = pause
-        self.active = active
-        self.queue = queue
-        self.total = total
-        self.speed = speed
-        self.download = download
-        self.reconnect = reconnect
-        self.captcha = captcha
+class ServerStatus(BaseModel):
+    pause: bool
+    active: int
+    queue: int
+    total: int
+    speed: int
+    download: bool
+    reconnect: bool
+    captcha: bool
 
 
 class ServiceCall(AbstractData):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collections.abc import Mapping
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -34,9 +35,9 @@ class AccountInfo(BaseModel):
 
 class CaptchaTask(BaseModel):
     tid: int
-    data: dict = None
-    type: str = None
-    result_type: str = None
+    data: Optional[dict] = None
+    type: Optional[str] = None
+    result_type: Optional[str] = None
 
 
 class ConfigItem(BaseModel):
@@ -50,7 +51,7 @@ class ConfigSection(BaseModel):
     name: str
     description: str
     items: list[ConfigItem]
-    outline: str | None
+    outline: Optional[str]
 
 
 class DownloadInfo(BaseModel):
@@ -75,9 +76,9 @@ class DownloadInfo(BaseModel):
 
 class EventInfo(BaseModel):
     eventname: str
-    id: str | None = None
-    type: int | None = None
-    destination: int | None = None
+    id: Optional[str] = None
+    type: Optional[int] = None
+    destination: Optional[int] = None
 
 
 class FileData(BaseModel):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -73,14 +73,11 @@ class DownloadInfo(BaseModel):
     info: str # NOTE: needed by webui, remove in future...
 
 
-class EventInfo(AbstractData):
-    __slots__ = ["eventname", "id", "type", "destination"]
-
-    def __init__(self, eventname=None, id=None, type=None, destination=None):
-        self.eventname = eventname
-        self.id = id
-        self.type = type
-        self.destination = destination
+class EventInfo(BaseModel):
+    eventname: str
+    id: str | None = None
+    type: int | None = None
+    destination: int | None = None
 
 
 class FileData(AbstractData):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -2,6 +2,8 @@
 
 from collections.abc import Mapping
 
+from pydantic import BaseModel
+
 
 class AbstractData(Mapping):
     __slots__ = []
@@ -80,64 +82,24 @@ class ConfigSection(AbstractData):
         self.outline = outline
 
 
-class DownloadInfo(AbstractData):
-    __slots__ = [
-        "fid",
-        "name",
-        "speed",
-        "eta",
-        "format_eta",
-        "bleft",
-        "size",
-        "format_size",
-        "percent",
-        "status",
-        "statusmsg",
-        "format_wait",
-        "wait_until",
-        "package_id",
-        "package_name",
-        "plugin",
-        "info",  # NOTE: needed by webui, remove in future...
-    ]
-
-    def __init__(
-        self,
-        fid=None,
-        name=None,
-        speed=None,
-        eta=None,
-        format_eta=None,
-        bleft=None,
-        size=None,
-        format_size=None,
-        percent=None,
-        status=None,
-        statusmsg=None,
-        format_wait=None,
-        wait_until=None,
-        package_id=None,
-        package_name=None,
-        plugin=None,
-        info=None,
-    ):
-        self.fid = fid
-        self.name = name
-        self.speed = speed
-        self.eta = eta
-        self.format_eta = format_eta
-        self.bleft = bleft
-        self.size = size
-        self.format_size = format_size
-        self.percent = percent
-        self.status = status
-        self.statusmsg = statusmsg
-        self.format_wait = format_wait
-        self.wait_until = wait_until
-        self.package_id = package_id
-        self.package_name = package_name
-        self.plugin = plugin
-        self.info = info
+class DownloadInfo(BaseModel):
+    fid: int
+    name: str
+    speed: float
+    eta: int
+    format_eta: str
+    bleft: int
+    size: int
+    format_size: str
+    percent: int
+    status: int
+    statusmsg: str
+    format_wait: str
+    wait_until: int
+    package_id: int
+    package_name: str
+    plugin: str
+    info: str # NOTE: needed by webui, remove in future...
 
 
 class EventInfo(AbstractData):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -143,28 +143,18 @@ class ServiceCall(BaseModel):
 
 
 #: Needed by legacy API
-class OldUserData(AbstractData):
-    __slots__ = ["name", "email", "role", "permission", "template_name"]
-
-    def __init__(
-        self, name=None, email=None, role=None, permission=None, template_name=None
-    ):
-        self.name = name
-        self.email = email
-        self.role = role
-        self.permission = permission
-        self.template_name = template_name
+class OldUserData(BaseModel):
+    name: Optional[str] = None
+    email: Optional[str] = None
+    role: Optional[int] = None
+    permission: Optional[int] = None
+    template_name: Optional[str] = None
 
 
-class UserData(AbstractData):
-    __slots__ = ["id", "name", "email", "role", "permission", "template"]
-
-    def __init__(
-        self, id=None, name=None, email=None, role=None, permission=None, template=None
-    ):
-        self.id = id
-        self.name = name
-        self.email = email
-        self.role = role
-        self.permission = permission
-        self.template = template
+class UserData(BaseModel):
+    id: Optional[int]
+    name: Optional[str] = None
+    email: Optional[str] = None
+    role: Optional[int] = None
+    permission: Optional[int] = None
+    template: Optional[str] = None

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -39,14 +39,11 @@ class CaptchaTask(BaseModel):
     result_type: str = None
 
 
-class ConfigItem(AbstractData):
-    __slots__ = ["name", "description", "value", "type"]
-
-    def __init__(self, name=None, description=None, value=None, type=None):
-        self.name = name
-        self.description = description
-        self.value = value
-        self.type = type
+class ConfigItem(BaseModel):
+    name: str
+    description: str
+    value: str
+    type: str
 
 
 class ConfigSection(AbstractData):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Optional
+from typing import Optional, Any
 
 from pydantic import BaseModel
 
@@ -121,7 +121,7 @@ class ServerStatus(BaseModel):
 class ServiceCall(BaseModel):
     plugin: str
     func: str
-    arguments: Optional[tuple]
+    arguments: Optional[list[Any]]
     parse_arguments: bool
 
 

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -1,26 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from collections.abc import Mapping
 from typing import Optional
 
 from pydantic import BaseModel
-
-
-class AbstractData(Mapping):
-    __slots__ = []
-
-    def __getitem__(self, name):
-        return getattr(self, name)
-
-    def __setitem__(self, name, value):
-        return setattr(self, name, value)
-
-    def __iter__(self):
-        for attr in self.__slots__:
-            yield attr
-
-    def __len__(self):
-        return len(self.__slots__)
 
 
 class AccountInfo(BaseModel):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -108,52 +108,20 @@ class OnlineStatus(BaseModel):
     size: int
 
 
-class PackageData(AbstractData):
-    __slots__ = [
-        "pid",
-        "name",
-        "folder",
-        "site",
-        "password",
-        "dest",
-        "order",
-        "linksdone",
-        "sizedone",
-        "sizetotal",
-        "linkstotal",
-        "links",
-        "fids",
-    ]
-
-    def __init__(
-        self,
-        pid=None,
-        name=None,
-        folder=None,
-        site=None,
-        password=None,
-        dest=None,
-        order=None,
-        linksdone=None,
-        sizedone=None,
-        sizetotal=None,
-        linkstotal=None,
-        links=None,
-        fids=None,
-    ):
-        self.pid = pid
-        self.name = name
-        self.folder = folder
-        self.site = site
-        self.password = password
-        self.dest = dest
-        self.order = order
-        self.linksdone = linksdone
-        self.sizedone = sizedone
-        self.sizetotal = sizetotal
-        self.linkstotal = linkstotal
-        self.links = links
-        self.fids = fids
+class PackageData(BaseModel):
+    pid: int
+    name: str
+    folder: str
+    site: str
+    password: str
+    dest: int
+    order: int
+    linksdone: Optional[int] = None
+    sizedone: Optional[int] = None
+    sizetotal: Optional[int] = None
+    linkstotal: Optional[int] = None
+    links: Optional[list[FileData]] = None
+    fids: Optional[list[int]] = None
 
 
 class ServerStatus(AbstractData):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -80,47 +80,18 @@ class EventInfo(BaseModel):
     destination: int | None = None
 
 
-class FileData(AbstractData):
-    __slots__ = [
-        "fid",
-        "url",
-        "name",
-        "plugin",
-        "size",
-        "format_size",
-        "status",
-        "statusmsg",
-        "package_id",
-        "error",
-        "order",
-    ]
-
-    def __init__(
-        self,
-        fid=None,
-        url=None,
-        name=None,
-        plugin=None,
-        size=None,
-        format_size=None,
-        status=None,
-        statusmsg=None,
-        package_id=None,
-        error=None,
-        order=None,
-    ):
-        self.fid = fid
-        self.url = url
-        self.name = name
-        self.plugin = plugin
-        self.size = size
-        self.format_size = format_size
-        self.status = status
-        self.statusmsg = statusmsg
-        self.package_id = package_id
-        self.error = error
-        self.order = order
-
+class FileData(BaseModel):
+    fid: int
+    url: str
+    name: str
+    plugin: str
+    size: int
+    format_size: str
+    status: int
+    statusmsg: str
+    package_id: int
+    error: str
+    order: int
 
 class InteractionTask(AbstractData):
     __slots__ = [

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -94,12 +94,9 @@ class FileData(BaseModel):
     order: int
 
 
-class OnlineCheck(AbstractData):
-    __slots__ = ["rid", "data"]
-
-    def __init__(self, rid=None, data=None):
-        self.rid = rid
-        self.data = data
+class OnlineCheck(BaseModel):
+    rid: int
+    data: dict
 
 
 class OnlineStatus(AbstractData):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -22,34 +22,14 @@ class AbstractData(Mapping):
         return len(self.__slots__)
 
 
-class AccountInfo(AbstractData):
-    __slots__ = [
-        "validuntil",
-        "login",
-        "options",
-        "valid",
-        "trafficleft",
-        "premium",
-        "type",
-    ]
-
-    def __init__(
-        self,
-        validuntil=None,
-        login=None,
-        options=None,
-        valid=None,
-        trafficleft=None,
-        premium=None,
-        type=None,
-    ):
-        self.validuntil = validuntil
-        self.login = login
-        self.options = options
-        self.valid = valid
-        self.trafficleft = trafficleft
-        self.premium = premium
-        self.type = type
+class AccountInfo(BaseModel):
+    validuntil: float
+    login: str
+    options: dict
+    valid: bool
+    trafficleft: int
+    premium: bool
+    type: str
 
 
 class CaptchaTask(AbstractData):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -32,14 +32,11 @@ class AccountInfo(BaseModel):
     type: str
 
 
-class CaptchaTask(AbstractData):
-    __slots__ = ["tid", "data", "type", "result_type"]
-
-    def __init__(self, tid=None, data=None, type=None, result_type=None):
-        self.tid = tid
-        self.data = data
-        self.type = type
-        self.result_type = result_type
+class CaptchaTask(BaseModel):
+    tid: int
+    data: dict = None
+    type: str = None
+    result_type: str = None
 
 
 class ConfigItem(AbstractData):

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -93,41 +93,6 @@ class FileData(BaseModel):
     error: str
     order: int
 
-class InteractionTask(AbstractData):
-    __slots__ = [
-        "iid",
-        "input",
-        "structure",
-        "preset",
-        "output",
-        "data",
-        "title",
-        "description",
-        "plugin",
-    ]
-
-    def __init__(
-        self,
-        iid=None,
-        input=None,
-        structure=None,
-        preset=None,
-        output=None,
-        data=None,
-        title=None,
-        description=None,
-        plugin=None,
-    ):
-        self.iid = iid
-        self.input = input
-        self.structure = structure
-        self.preset = preset
-        self.output = output
-        self.data = data
-        self.title = title
-        self.description = description
-        self.plugin = plugin
-
 
 class OnlineCheck(AbstractData):
     __slots__ = ["rid", "data"]

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -99,17 +99,12 @@ class OnlineCheck(BaseModel):
     data: dict
 
 
-class OnlineStatus(AbstractData):
-    __slots__ = ["name", "plugin", "packagename", "status", "size"]
-
-    def __init__(
-        self, name=None, plugin=None, packagename=None, status=None, size=None
-    ):
-        self.name = name
-        self.plugin = plugin
-        self.packagename = packagename
-        self.status = status
-        self.size = size
+class OnlineStatus(BaseModel):
+    name: str
+    plugin: str
+    packagename: str
+    status: int
+    size: int
 
 
 class PackageData(AbstractData):

--- a/src/pyload/core/threads/info_thread.py
+++ b/src/pyload/core/threads/info_thread.py
@@ -134,7 +134,12 @@ class InfoThread(PluginThread):
         if len(self.cache) >= 20 or force:
             # used for package generating
             tmp = [
-                (name, (url, OnlineStatus(name, plugin, "unknown", status, int(size))))
+                (name, (url, OnlineStatus(name=name,
+                                          plugin=plugin,
+                                          packagename="unknown",
+                                          status=status,
+                                          size=int(size)
+                                          )))
                 for name, size, status, url in self.cache
             ]
 

--- a/src/pyload/core/utils/old/packagetools.py
+++ b/src/pyload/core/utils/old/packagetools.py
@@ -24,7 +24,7 @@ def parse_names(files):
     Generates packages names from name, data lists.
 
     :param files: list of (name, data)
-    :return: packagenames mapt to data lists (eg. urls)
+    :return: packagenames map to data lists (eg. urls)
     """
     packs = {}
 

--- a/src/pyload/core/utils/purge.py
+++ b/src/pyload/core/utils/purge.py
@@ -72,5 +72,12 @@ def truncate(text, to_length):
 def uniquify(seq):
     """Remove duplicates from list preserving order."""
     seen = set()
-    seen_add = seen.add
-    return type(seq)(x for x in seq if x not in seen and not seen_add(x))
+    result = []
+
+    for item in seq:
+        hashable_item = tuple(item) if isinstance(item, list) else item
+        if hashable_item not in seen:
+            seen.add(hashable_item)
+            result.append(item)
+
+    return type(seq)(result)

--- a/src/pyload/webui/app/blueprints/app_blueprint.py
+++ b/src/pyload/webui/app/blueprints/app_blueprint.py
@@ -103,10 +103,10 @@ def dashboard():
     links = api.status_downloads()
 
     for link in links:
-        if link["status"] == 12:
-            current_size = link["size"] - link["bleft"]
-            formatted_speed = format.speed(link["speed"])
-            link["info"] = f"{current_size} KiB @ {formatted_speed}"
+        if link.status == 12:
+            current_size = link.size - link.bleft
+            formatted_speed = format.speed(link.speed)
+            link.info = f"{current_size} KiB @ {formatted_speed}"
 
     return render_template("dashboard.html", res=links)
 

--- a/src/pyload/webui/app/blueprints/app_blueprint.py
+++ b/src/pyload/webui/app/blueprints/app_blueprint.py
@@ -116,7 +116,7 @@ def dashboard():
 def queue():
     api = flask.current_app.config["PYLOAD_API"]
     queue = api.get_queue()
-    queue.sort(key=operator.attrgetter("order"))
+    queue.sort(key=lambda x: x.order)
 
     return render_template("packages.html", content=queue, target=1)
 
@@ -126,8 +126,7 @@ def queue():
 def collector():
     api = flask.current_app.config["PYLOAD_API"]
     queue = api.get_collector()
-
-    queue.sort(key=operator.attrgetter("order"))
+    queue.sort(key=lambda x: x.order)
 
     return render_template("packages.html", content=queue, target=0)
 

--- a/src/pyload/webui/app/blueprints/app_blueprint.py
+++ b/src/pyload/webui/app/blueprints/app_blueprint.py
@@ -74,8 +74,8 @@ def login():
     if api.get_config_value("webui", "autologin"):
         allusers = api.get_all_userdata()
         if len(allusers) == 1:  # TODO: check if localhost
-            user_info = list(allusers.values())[0]
-            set_session(user_info)
+            userdata = list(allusers.values())[0]
+            set_session(userdata.model_dump())
             # NOTE: Double-check authentication here because if session[name] is empty,
             #       next login_required redirects here again and all loop out.
             if is_authenticated():
@@ -244,9 +244,9 @@ def settings():
     all_users = api.get_all_userdata()
     users = {}
     for userdata in all_users.values():
-        name = userdata["name"]
-        users[name] = {"perms": get_permission(userdata["permission"])}
-        users[name]["perms"]["admin"] = userdata["role"] == 0
+        name = userdata.name
+        users[name] = {"perms": get_permission(userdata.permission)}
+        users[name]["perms"]["admin"] = userdata.role == 0
 
     admin_menu = {
         "permlist": permlist(),

--- a/src/pyload/webui/app/blueprints/json_blueprint.py
+++ b/src/pyload/webui/app/blueprints/json_blueprint.py
@@ -31,20 +31,20 @@ def links():
         links = api.status_downloads()
         ids = []
         for link in links:
-            ids.append(link["fid"])
+            ids.append(link.fid)
 
-            if link["status"] == 12:  #: downloading
-                formatted_eta = link["format_eta"]
-                formatted_speed = format.speed(link["speed"])
-                link["info"] = f"{formatted_eta} @ {formatted_speed}"
+            if link.status == 12:  #: downloading
+                formatted_eta = link.format_eta
+                formatted_speed = format.speed(link.speed)
+                link.info = f"{formatted_eta} @ {formatted_speed}"
 
-            elif link["status"] == 5:  #: waiting
-                link["percent"] = 0
-                link["size"] = 0
-                link["bleft"] = 0
-                link["info"] = api._("waiting {}").format(link["format_wait"])
+            elif link.status == 5:  #: waiting
+                link.percent = 0
+                link.size = 0
+                link.bleft = 0
+                link.info = api._("waiting {}").format(link.format_wait)
             else:
-                link["info"] = ""
+                link.info = ""
 
         return jsonify(links=links, ids=ids)
 

--- a/src/pyload/webui/app/blueprints/json_blueprint.py
+++ b/src/pyload/webui/app/blueprints/json_blueprint.py
@@ -373,10 +373,10 @@ def update_users():
     users = {}
 
     # NOTE: messy code...
-    for data in all_users.values():
-        name = data["name"]
-        users[name] = {"perms": get_permission(data["permission"])}
-        users[name]["perms"]["admin"] = data["role"] == 0
+    for userdata in all_users.values():
+        name = userdata.name
+        users[name] = {"perms": get_permission(userdata.permission)}
+        users[name]["perms"]["admin"] = userdata.role == 0
 
     s = flask.session
     for name in list(users):

--- a/src/pyload/webui/app/blueprints/json_blueprint.py
+++ b/src/pyload/webui/app/blueprints/json_blueprint.py
@@ -52,25 +52,6 @@ def links():
         return jsonify(False), 500
 
 
-@bp.route("/json/packages", endpoint="packages")
-# @apiver_check
-@login_required("LIST")
-def packages():
-    api = flask.current_app.config["PYLOAD_API"]
-    try:
-        data = api.get_queue()
-
-        for package in data:
-            package["links"] = []
-            for file in api.get_package_files(package["id"]):
-                package["links"].append(api.get_file_info(file))
-
-        return jsonify(data)
-
-    except Exception:
-        return jsonify(False), 500
-
-
 @bp.route("/json/package", endpoint="package")
 # @apiver_check
 @login_required("LIST")
@@ -80,9 +61,9 @@ def package():
         id = int(flask.request.args.get('id'))
         data = api.get_package_data(id)
 
-        tmp = data["links"]
+        tmp = data.links
         tmp.sort(key=lambda entry: entry.order)
-        data["links"] = tmp
+        data.links = tmp
         return jsonify(data)
 
     except Exception:

--- a/src/pyload/webui/app/blueprints/json_blueprint.py
+++ b/src/pyload/webui/app/blueprints/json_blueprint.py
@@ -81,7 +81,7 @@ def package():
         data = api.get_package_data(id)
 
         tmp = data["links"]
-        tmp.sort(key=lambda entry: entry["order"])
+        tmp.sort(key=lambda entry: entry.order)
         data["links"] = tmp
         return jsonify(data)
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

As outlined in [my comment](https://github.com/pyload/pyload/issues/4414#issuecomment-2742702273) on [#4414](https://github.com/pyload/pyload/issues/4414) this is the first step to enable automatic API documentation.

- All API methods are type annotated, both parameters and return types
- All non-primitive data types are moved to Pydantic models for automatic validation

So far, everything seems to work just fine.

With this, we can parse the existing methods into an OpenAPI specificaton, will submit this in a follow-up PR. I have a working draft, but it needs some polishing.

I've tried to encapsulate all changes to logical commits to make the review easier. In any case, I'd say this should probably stay on the develop branch for a couple of weeks before merging into main to make sure it doesn't cause any issues.

<!-- A clear and concise description of what you've done. -->

### Additional references

Related issue #4414 

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
