### PR TITLE
Fix some HTML markup errors in template files

### DIFF
--- a/src/pyload/webui/app/themes/modern/templates/base.html
+++ b/src/pyload/webui/app/themes/modern/templates/base.html
@@ -244,7 +244,7 @@
 <script type="text/javascript" src="{{theme_static('vendor/jQuery/jQuery UI/jquery-ui.min.js')}}"></script>
 <script type="text/javascript" src="{{theme_static('vendor/mdtoast/js/mdtoast.min.js')}}"></script>
 <script type="text/javascript" src="{{theme_static('vendor/Bootstrap/js/bootstrap.min.js')}}"></script>
-<script type="text/javascript" src="{{theme_template('js/base.js')}}" nopoll={{no_status_polling}}></script>
+<script type="text/javascript" src="{{theme_template('js/base.js')}}" nopoll="{{no_status_polling}}"></script>
 
 {% block footer %}
 {% endblock %}

--- a/src/pyload/webui/app/themes/pyplex/templates/base.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/base.html
@@ -146,7 +146,7 @@
         </ul>
         {% if user.is_authenticated %}
           <ul class="nav navbar-nav navbar-right">
-            <li><span class="navbar-text"><span class="glyphicon glyphicon-user" title="{{user.name}}></span><span class="hidden-sm hidden-md"> {{user.name}}</span></span></li>
+            <li><span class="navbar-text"><span class="glyphicon glyphicon-user" title="{{user.name}}"></span><span class="hidden-sm hidden-md"> {{user.name}}</span></span></li>
             <li><a href="{{url_for("app.logout")}}" class="action logout" rel="nofollow"><span class="glyphicon glyphicon-log-out"></span><span class="hidden-sm hidden-md">  {{_('Logout')}}</span></a></li>
             <li ondragstart="return false;" {{selected('info')}}><a href="{{url_for("app.info")}}"  class="action info" rel="nofollow"><span class="glyphicon glyphicon-info-sign"></span><span class="hidden-sm hidden-md">  {{_('Info')}}</span></a></li>
           </ul>
@@ -244,7 +244,7 @@
 <script type="text/javascript" src="{{theme_static('vendor/jQuery/jQuery UI/jquery-ui.min.js')}}"></script>
 <script type="text/javascript" src="{{theme_static('vendor/mdtoast/js/mdtoast.min.js')}}"></script>
 <script type="text/javascript" src="{{theme_static('vendor/Bootstrap/js/bootstrap.min.js')}}"></script>
-<script type="text/javascript" src="{{theme_template('js/base.js')}}" nopoll={{no_status_polling}}></script>
+<script type="text/javascript" src="{{theme_template('js/base.js')}}" nopoll="{{no_status_polling}}"></script>
 
 {% block footer %}
 {% endblock %}

--- a/src/pyload/webui/app/themes/pyplex/templates/captcha.html
+++ b/src/pyload/webui/app/themes/pyplex/templates/captcha.html
@@ -31,7 +31,7 @@
               </iframe>
             </div>
             <div id="cap_interactive_loading">
-              <p style="white-space: nowrap;">{{_("The captcha may take a few seconds to load.")}}</p></p>
+              <p style="white-space: nowrap;">{{_("The captcha may take a few seconds to load.")}}</p>
               <p>{{_("Note: to solve this interactive captcha")}}<br>
               {{_("Please install the <a href='https://tampermonkey.net/' target='_blank'>Tampermonkey</a> add-on in your browser and add the ")}}<a href="{{url_for('static', filename='js/captcha-interactive.user.js')}}">{{_("pyload userscript")}}</a>.</p>
             </div>


### PR DESCRIPTION
### Describe the changes

Fix some minor HTML markup errors in the "modern" and "pyplex" theme template files, like missing closing quotation marks, superfluous tags and empty attributes.

### Is this related to a problem?

No.

### Additional references

The markup could be improved further, e. g. via HTML validation tools like [W3C Validator](https://validator.w3.org).
