### PR TITLE
Make search for plugins in settings more fuzzy

### DIFF
--- a/src/pyload/webui/app/themes/modern/templates/js/settings.js
+++ b/src/pyload/webui/app/themes/modern/templates/js/settings.js
@@ -193,7 +193,7 @@ class SettingsUI {
     const search = (query) => {
       let results = [];
       if (query) {
-        results = pluginList.filter(p => p[1].toLowerCase().startsWith(query.toLowerCase()));
+        results = pluginList.filter(p => p[1].toLowerCase().includes(query.toLowerCase()));
       } else {
         results = pluginList;
       }

--- a/src/pyload/webui/app/themes/pyplex/templates/js/settings.js
+++ b/src/pyload/webui/app/themes/pyplex/templates/js/settings.js
@@ -193,7 +193,7 @@ class SettingsUI {
     const search = (query) => {
       let results = [];
       if (query) {
-        results = pluginList.filter(p => p[1].toLowerCase().startsWith(query.toLowerCase()));
+        results = pluginList.filter(p => p[1].toLowerCase().includes(query.toLowerCase()));
       } else {
         results = pluginList;
       }


### PR DESCRIPTION
### Describe the changes

Use `String.prototype.includes()` instead of `String.prototype.startsWith()` for the search of plugins in the settings.

<!-- WRITE HERE -->

### Is this related to a problem?

Currently, the search only matches the beginning of a plugin. This is not very helpful if the full name of a plugin is not known. For example, a search for "9kw" would not find the plugin "Captcha9kw". Due to the large amount if plugins it is also difficult to find plugins by simply scrolling through.

This PR changes the search so it checks whether the search string is not only matched to the beginning of a plugins name but if the string a somewhere contained.

### Additional references

Unfortunately, this change has also some drawbacks: e.g. filtering plugin names by starting letter. But, currently, the plugins are sorted alphabetically, therefore this type of search can be done by looking at the list alone.

Alternatively, the search function could be changed to `String.prototype.search()` to allow Regular Expressions which would allow more powerful search queries.
