### PR TITLE
Fix uncontrolled data used in path expression blueprints

### DIFF
--- a/src/pyload/webui/app/blueprints/json_blueprint.py
+++ b/src/pyload/webui/app/blueprints/json_blueprint.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+from werkzeug.utils import secure_filename
 
 import flask
 from flask.json import jsonify
@@ -151,8 +152,9 @@ def add_package():
             if not package_name or package_name == "New Package":
                 package_name = file.filename
 
+            safe_filename = secure_filename(file.filename)
             file_path = os.path.join(
-                api.get_config_value("general", "storage_folder"), "tmp_" + file.filename
+                api.get_config_value("general", "storage_folder"), "tmp_" + safe_filename
             )
             file.save(file_path)
             links.insert(0, file_path)


### PR DESCRIPTION
https://github.com/pyload/pyload/blob/df094db67ec6e25294a9ac0ddb4375fd7fb9ba00/src/pyload/webui/app/blueprints/json_blueprint.py#L155-L155
https://github.com/pyload/pyload/blob/df094db67ec6e25294a9ac0ddb4375fd7fb9ba00/src/pyload/webui/app/blueprints/json_blueprint.py#L157-L157

Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.



fix the `json_blueprint` need to validate and sanitize the `file.filename` before using it in the `os.path.join` function. The best approach is to use the `werkzeug.utils.secure_filename` function, which ensures that the filename is safe by removing any special characters and directory traversal sequences. This will prevent attackers from manipulating the file path.
- Import the `secure_filename` function from `werkzeug.utils`.
- Replace the direct use of `file.filename` with `secure_filename(file.filename)` when constructing the `file_path`.
- Ensure that the rest of the functionality remains unchanged.

[werkzeug.utils.secure_filename](http://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename)