### PR TITLE
FuckingFast: Add downloader plugin

### DIFF
--- a/src/pyload/plugins/downloaders/FuckingfastCo.py
+++ b/src/pyload/plugins/downloaders/FuckingfastCo.py
@@ -5,7 +5,7 @@ from ..base.simple_downloader import SimpleDownloader
 
 class FuckingfastCo(SimpleDownloader):
     __name__ = "FuckingfastCo"
-    __version__ = "0.1"
+    __version__ = "0.01"
     __type__ = "downloader"
     __status__ = "testing"
 


### PR DESCRIPTION
### Describe the changes

This adds a downloader plugin for the `FuckingFast` service. No account required, no captchas. This is just a simple downloader plugin to resolve the direct links of the files.