### PR TITLE
Fix Improper Neutralization of Input Server-Side Template Injection

### DIFF
--- a/src/pyload/webui/app/static/js/captcha-interactive.user.js
+++ b/src/pyload/webui/app/static/js/captcha-interactive.user.js
@@ -103,9 +103,23 @@
             }
           };
 
+          // Define allowed actions and their handlers here
+          const gpyloadActions = {
+            // Example action: 'showAlert'
+            showAlert: function(request, gpyload, data) {
+              alert(data && data.message ? data.message : "No message provided.");
+            },
+            // Add more allowed actions here
+            // e.g., 'doSomething': function(request, gpyload, data) { ... }
+          };
+
           try {
-            let scriptFunction = new Function('request', 'gpyload', '"use strict";' + request.params.script.code);
-            scriptFunction(request, gpyload);
+            // Instead of executing arbitrary code, dispatch based on an allowed action
+            if (request.params.script.action && typeof gpyloadActions[request.params.script.action] === "function") {
+              gpyloadActions[request.params.script.action](request, gpyload, request.params.script.data);
+            } else {
+              throw new Error("Unknown or missing action in script payload");
+            }
           } catch(err) {
             console.error("pyLoad: Script aborted: " + err.name + ": " + err.message + " (" + err.stack +")");
             return;


### PR DESCRIPTION
https://github.com/pyload/pyload/blob/70a44fe02c03bce92337b5d370d2a45caa4de3d4/src/pyload/webui/app/static/js/captcha-interactive.user.js#L107-L108


Directly evaluating user input (an HTTP request parameter) as code without properly sanitizing the input first allows an attacker arbitrary code execution. This can occur when user input is treated as JavaScript, or passed to a framework which interprets it as an expression to be evaluated. Examples include AngularJS expressions or JQuery selectors.

The following shows part of the page URL being evaluated as JavaScript code. This allows an attacker to provide JavaScript within the URL. If an attacker can persuade a user to click on a link to such a URL, the attacker can evaluate arbitrary JavaScript in the browser of the user to, for steal cookies containing session information.
```
eval(document.location.href.substring(document.location.href.indexOf("default=")+8))
```

The following example shows a Pug template being constructed from user input, allowing attackers to run arbitrary code via a payload such as `#{global.process.exit(1)}`.
```js
const express = require('express')
var pug = require('pug');
const app = express()

app.post('/', (req, res) => {
    var input = req.query.username;
    var template = `
doctype
html
head
    title= 'Hello world'
body
    form(action='/' method='post')
        input#name.form-control(type='text)
        button.btn.btn-primary(type='submit') Submit
    p Hello `+ input
    var fn = pug.compile(template);
    var html = fn();
    res.send(html);
})
```
Below is an how to use a template engine without any risk of template injection. The user input is included via an interpolation expression #{username} whose value is provided as an option to the template, instead of being part of the template string itself:

```js
const express = require('express')
var pug = require('pug');
const app = express()

app.post('/', (req, res) => {
    var input = req.query.username;
    var template = `
doctype
html
head
    title= 'Hello world'
body
    form(action='/' method='post')
        input#name.form-control(type='text)
        button.btn.btn-primary(type='submit') Submit
    p Hello #{username}`
    var fn = pug.compile(template);
    var html = fn({username: input});
    res.send(html);
})
```
---

The best way to fix this problem is to avoid using the `Function` constructor (or `eval`) to execute user-provided code, even if it is signed. Instead, define a set of allowed actions or commands that the script can perform, and dispatch them based on the parsed and verified input. If dynamic code execution is absolutely necessary, consider using a secure sandboxed environment (such as an iframe with a restrictive CSP, or a library like [vm2](https://github.com/patriksimek/vm2) in Node.js), but this is not possible in a browser userscript context.

**Detailed fix:**  
- Instead of executing arbitrary code from `request.params.script.code`, define a whitelist of allowed actions or commands that can be performed, and dispatch based on the action specified in the signed payload.
- Parse the signed payload as data, not as code.
- Remove the use of `new Function` and replace it with a dispatcher that calls predefined functions based on the action in the payload.
- If the payload must contain code, only allow it to be data (e.g., a JSON object with parameters), not executable code.

**Required changes:**  
- Remove or replace the block that creates and executes the function from `request.params.script.code`.
- Implement a dispatcher that maps allowed actions to handler functions.
- Ensure that only data, not code, is passed in the signed payload.


#### References
[Code Injection](https://www.owasp.org/index.php/Code_Injection)
[Code Injection](https://en.wikipedia.org/wiki/Code_injection)
[Server-Side Template Injection](https://portswigger.net/research/server-side-template-injection)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
[CWE-95](https://cwe.mitre.org/data/definitions/95.html)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CWE-116](https://cwe.mitre.org/data/definitions/116.html)