### PR TITLE
delete_files: support deleting multiple files

### DIFF
--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -702,7 +702,9 @@ class Api:
 
     @legacy("deleteFiles")
     @permission(Perms.DELETE)
-    def delete_files(self, file_ids):
+    def delete_files(self, *args, file_ids=None):
+        file_ids = args or file_ids
+        if not file_ids: return
         """
         Deletes several file entries from pyload.
 


### PR DESCRIPTION
either via multiple [comma-joined args](https://github.com/pyload/pyload/blob/bc692f3d770de519f52c455ba2e18bccd99dc7bf/src/pyload/webui/app/blueprints/api_blueprint.py#L54)
`GET /api/delete_files/1,2,3`

```
>>> from ast import literal_eval; args = "1,2,3".split(","); [literal_eval(x) for x in args]
[1, 2, 3]
```

or via the kwarg `file_ids` [in json format](https://github.com/pyload/pyload/blob/bc692f3d770de519f52c455ba2e18bccd99dc7bf/src/pyload/webui/app/blueprints/api_blueprint.py#L81C15-L81C17)
`GET /api/delete_files?file_ids=[1,2,3]`

```
>>> from ast import literal_eval; kwarg = "[1,2,3]"; literal_eval(kwarg)
[1, 2, 3]
```

both variants were not working before
either because delete_files accepted only one arg
or because delete_files did not accept kwargs

probably more api methods will need this kind of patch...
