### PR TITLE
OpenAPI spec polishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli generate \
   -i /local/openapi-generator/openapi.json \
   -g java \
   -o /local/openapi-generator/out \
-  --additional-properties library=retrofit2,serializationLibrary=gson,openApiNullable=false,invokerPackage=org.pyload.android.openapi,apiPackage=org.pyload.android.openapi.api,modelPackage=org.pyload.android.openapi.models
+  --additional-properties library=retrofit2,serializationLibrary=gson,openApiNullable=false,hideGenerationTimestamp=true,invokerPackage=org.pyload.android.openapi,apiPackage=org.pyload.android.openapi.api,modelPackage=org.pyload.android.openapi.models
 ```
 
 If you are developing a client application for pyLoad, you can use this specification to generate a client

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -1258,7 +1258,7 @@ class Api:
         self.pyload.account_manager.remove_account(plugin, account)
 
     @legacy("checkAuth")
-    def check_auth(self, username: str, password: str) -> dict[str: Any]:
+    def check_auth(self, username: str, password: str) -> dict[str, Any]:
         """
         Check authentication and returns details.
 

--- a/src/pyload/webui/app/templates/swagger.html
+++ b/src/pyload/webui/app/templates/swagger.html
@@ -28,6 +28,7 @@
     url: baseUrl + "/api/openapi.json",
     persistAuthorization: true,
     dom_id: '#swagger-ui',
+    validatorUrl : null,
     presets: [
       SwaggerUIBundle.presets.apis,
       SwaggerUIStandalonePreset,


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

I noticed some minor issues and improvements to be done in regards to the OpenAPI addition:

1. Fixed an incorrect dict type format in function return type
2. Disabled the automatic validation of the OpenAPI spec in the Swagger UI
By default, the api spec is validated by swaggers online validator `https://validator.swagger.io`. This only works, if the OpenAPI spec's Swagger URL is publicly accessible. As this is very likely not the case for the vast majority of users I removed this, otherwise there would always be a state indicator at the bottom of the Swagger UI stating `INVALID`
```
{
  "schemaValidationMessages": [
    {
      "level": "error",
      "message": "Can't read from file http://<pyload base url>/api/openapi.json"
    }
  ]
}
```
3. Removed the timestamp from when a file was generated from the Android code and adapted the docs in the README here accordingly

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

n/a

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

n/a
