### PR TITLE
Basic auth in openapi spec

### DIFF
--- a/openapi-generator/openapi.json
+++ b/openapi-generator/openapi.json
@@ -1,72 +1,16 @@
 {
   "info": {
     "title": "pyLoad API Documentation - OpenAPI",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "openapi": "3.1.1",
   "tags": [
-    {
-      "name": "pyLoad Authentication",
-      "description": ""
-    },
     {
       "name": "pyLoad REST",
       "description": ""
     }
   ],
   "paths": {
-    "/api/login": {
-      "post": {
-        "security": [],
-        "summary": "Login into pyLoad, this must be called when using rpc before any methods can be used.",
-        "tags": [
-          "pyLoad Authentication"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "username": {
-                    "type": "string",
-                    "default": "pyload"
-                  },
-                  "password": {
-                    "type": "string",
-                    "default": "pyload"
-                  }
-                },
-                "required": [
-                  "username",
-                  "password"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Session data if successful, False otherwise"
-          }
-        }
-      }
-    },
-    "/api/logout": {
-      "get": {
-        "security": [],
-        "summary": "Logout current user, clear session data",
-        "tags": [
-          "pyLoad Authentication"
-        ],
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        }
-      }
-    },
     "/api/add_files": {
       "post": {
         "summary": "Adds files to specific package.",
@@ -3500,16 +3444,15 @@
       }
     },
     "securitySchemes": {
-      "cookieAuth": {
-        "type": "apiKey",
-        "in": "cookie",
-        "name": "pyload_session_8000"
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic"
       }
     }
   },
   "security": [
     {
-      "cookieAuth": []
+      "basicAuth": []
     }
   ]
 }

--- a/openapi-generator/openapi.json
+++ b/openapi-generator/openapi.json
@@ -2773,6 +2773,7 @@
           "validuntil": {
             "anyOf": [
               {
+                "format": "float",
                 "type": "number"
               },
               {
@@ -2780,7 +2781,6 @@
               }
             ],
             "default": null,
-            "format": "float",
             "title": "Validuntil"
           },
           "login": {

--- a/openapi-generator/openapi.json
+++ b/openapi-generator/openapi.json
@@ -2798,6 +2798,7 @@
           "trafficleft": {
             "anyOf": [
               {
+                "format": "int64",
                 "type": "integer"
               },
               {
@@ -2805,9 +2806,7 @@
               }
             ],
             "default": null,
-            "format": "int64",
-            "title": "Trafficleft",
-            "type": "integer"
+            "title": "Trafficleft"
           },
           "premium": {
             "title": "Premium",

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -20,8 +20,22 @@ OPTIONAL_INT64_JSON_SCHEMA = {
     ]
 }
 
+FLOAT_JSON_SCHEMA = {
+    "type": "number",
+    "format": "float"
+}
+
+OPTIONAL_FLOAT_JSON_SCHEMA = {
+    "anyOf": [
+        FLOAT_JSON_SCHEMA,
+        {
+            "type": "null"
+        }
+    ]
+}
+
 class AccountInfo(BaseModel):
-    validuntil: Optional[float] = Field(default=None, json_schema_extra={"format": "float"})
+    validuntil: Optional[float] = Field(default=None, json_schema_extra=OPTIONAL_FLOAT_JSON_SCHEMA)
     login: str
     options: dict
     valid: bool
@@ -54,7 +68,7 @@ class ConfigSection(BaseModel):
 class DownloadInfo(BaseModel):
     fid: int
     name: str
-    speed: float = Field(json_schema_extra={"format": "float"})
+    speed: float = Field(json_schema_extra=FLOAT_JSON_SCHEMA)
     eta: int
     format_eta: str
     bleft: int = Field(json_schema_extra=INT64_JSON_SCHEMA)
@@ -64,7 +78,7 @@ class DownloadInfo(BaseModel):
     status: DownloadStatus
     statusmsg: str
     format_wait: str
-    wait_until: float = Field(json_schema_extra={"format": "float"})
+    wait_until: float = Field(json_schema_extra=FLOAT_JSON_SCHEMA)
     package_id: int
     package_name: str
     plugin: str

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -25,7 +25,7 @@ class AccountInfo(BaseModel):
     login: str
     options: dict
     valid: bool
-    trafficleft: Optional[int] = Field(default=None, json_schema_extra=INT64_JSON_SCHEMA)
+    trafficleft: Optional[int] = Field(default=None, json_schema_extra=OPTIONAL_INT64_JSON_SCHEMA)
     premium: bool
     type: str
 

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -5,34 +5,11 @@ from typing import Optional, Any
 from pydantic import BaseModel, Field
 
 from pyload.core.datatypes.enums import DownloadStatus
+from pyload.core.datatypes.json_schema_extras import FLOAT_JSON_SCHEMA
+from pyload.core.datatypes.json_schema_extras import INT64_JSON_SCHEMA
+from pyload.core.datatypes.json_schema_extras import OPTIONAL_FLOAT_JSON_SCHEMA
+from pyload.core.datatypes.json_schema_extras import OPTIONAL_INT64_JSON_SCHEMA
 
-INT64_JSON_SCHEMA = {
-    "type": "integer",
-    "format": "int64"
-}
-
-OPTIONAL_INT64_JSON_SCHEMA = {
-    "anyOf": [
-        INT64_JSON_SCHEMA,
-        {
-            "type": "null"
-        }
-    ]
-}
-
-FLOAT_JSON_SCHEMA = {
-    "type": "number",
-    "format": "float"
-}
-
-OPTIONAL_FLOAT_JSON_SCHEMA = {
-    "anyOf": [
-        FLOAT_JSON_SCHEMA,
-        {
-            "type": "null"
-        }
-    ]
-}
 
 class AccountInfo(BaseModel):
     validuntil: Optional[float] = Field(default=None, json_schema_extra=OPTIONAL_FLOAT_JSON_SCHEMA)

--- a/src/pyload/core/datatypes/json_schema_extras.py
+++ b/src/pyload/core/datatypes/json_schema_extras.py
@@ -1,0 +1,27 @@
+INT64_JSON_SCHEMA = {
+    "type": "integer",
+    "format": "int64"
+}
+
+OPTIONAL_INT64_JSON_SCHEMA = {
+    "anyOf": [
+        INT64_JSON_SCHEMA,
+        {
+            "type": "null"
+        }
+    ]
+}
+
+FLOAT_JSON_SCHEMA = {
+    "type": "number",
+    "format": "float"
+}
+
+OPTIONAL_FLOAT_JSON_SCHEMA = {
+    "anyOf": [
+        FLOAT_JSON_SCHEMA,
+        {
+            "type": "null"
+        }
+    ]
+}

--- a/src/pyload/webui/app/api_docs/openapi_specification_generator.py
+++ b/src/pyload/webui/app/api_docs/openapi_specification_generator.py
@@ -43,81 +43,24 @@ class OpenAPISpecificationGenerator:
         self.spec: dict[str, Any] = {
             "info": {
                 "title": "pyLoad API Documentation - OpenAPI",
-                "version": "1.0.0"
+                "version": "1.1.0"
             },
             "openapi": "3.1.1",
             "tags": [{
-                "name": "pyLoad Authentication",
-                "description": ""
-            }, {
                 "name": "pyLoad REST",
                 "description": ""
             }],
-            "paths": {
-                "/api/login": {
-                    "post": {
-                        "security": [],
-                        "summary": "Login into pyLoad, this must be called when using rpc before any methods can be used.",
-                        "tags": [
-                            "pyLoad Authentication"
-                        ],
-                        "requestBody": {
-                            "required": True,
-                            "content": {
-                                "application/x-www-form-urlencoded": {
-                                    "schema": {
-                                        "type": "object",
-                                        "properties": {
-                                            "username": {
-                                                "type": "string",
-                                                "default": "pyload"
-                                            },
-                                            "password": {
-                                                "type": "string",
-                                                "default": "pyload"
-                                            }
-                                        },
-                                        "required": [
-                                            "username",
-                                            "password"
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "responses": {
-                            "200": {
-                                "description": "Session data if successful, False otherwise",
-                            }
-                        }
-                    }
-                },
-                "/api/logout": {
-                    "get": {
-                        "security": [],
-                        "summary": "Logout current user, clear session data",
-                        "tags": [
-                            "pyLoad Authentication"
-                        ],
-                        "responses": {
-                            "200": {
-                                "description": "",
-                            }
-                        }
-                    }
-                }
-            },
+            "paths": {},
             "components": {
                 "schemas": {},
                 "securitySchemes": {
-                    "cookieAuth": {
-                        "type": "apiKey",
-                        "in": "cookie",
-                        "name": "pyload_session_" + str(api.get_config_value("webui", "port"))
+                    "basicAuth": {
+                        "type": "http",
+                        "scheme": "basic",
                     }
                 }
             },
-            "security": [{"cookieAuth": []}]
+            "security": [{"basicAuth": []}]
         }
 
     def generate_openapi_json(self) -> dict[str, Any]:
@@ -130,7 +73,7 @@ class OpenAPISpecificationGenerator:
             return self.spec
 
         for name, method in inspect.getmembers(self.api, predicate=inspect.ismethod):
-            if name.startswith('_') or name in legacy_map.values() or name == "login":
+            if name.startswith('_') or name in legacy_map.values():
                 continue
 
             docstring = inspect.getdoc(method) or "No documentation available"


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Not sure if intentional, but the `/api/login` endpoint can no longer be called with the current changes on `develop`.
The response will always be `{"error": "CSRF token is invalid"}`. Or am I missing something?

Anyway, with the support of http basic auth, we can switch to that instead which is an improvement in every way possible.

* adapted the openapi generator and recreated resulting openapi specification
* fixed some bugs with JSON schemas for optional properties

### Additional references

https://swagger.io/docs/specification/v3_0/authentication/basic-authentication/
