### PR TITLE
Fix ServerStatus speed type

### DIFF
--- a/openapi-generator/openapi.json
+++ b/openapi-generator/openapi.json
@@ -3407,8 +3407,9 @@
             "type": "integer"
           },
           "speed": {
+            "format": "float",
             "title": "Speed",
-            "type": "integer"
+            "type": "number"
           },
           "download": {
             "title": "Download",

--- a/src/pyload/core/datatypes/data.py
+++ b/src/pyload/core/datatypes/data.py
@@ -117,7 +117,7 @@ class ServerStatus(BaseModel):
     active: int
     queue: int
     total: int
-    speed: int
+    speed: float = Field(json_schema_extra=FLOAT_JSON_SCHEMA)
     download: bool
     reconnect: bool
     captcha: bool


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Found another one. Hopefully we will have all the typing sorted out soon.

Change `speed` property of `ServerStatus` from `int` to `float`.
`ServerStatus` speed should be the same type as `DownloadInfo` speed.
Calling `GET` on `/api/status_server` returns
```
{"pause": false, "active": 1, "queue": 3, "total": 101, "speed": 209242.0, "download": true, "reconnect": false, "captcha": false, "proxy": false}
```
therefore some clients will fail to parse `speed` into `int`. Even though it is byte/s and therefore should never contain anything else but 0 after the decimal point.

### Is this related to a problem?

Some OpenAPI client libraries failing to parse `ServerStatus`.

### Additional references

n/a
