### PR TITLE
Fix: Catch syntax error during literal eval if string contains dot character

### DIFF
--- a/src/pyload/webui/app/blueprints/api_blueprint.py
+++ b/src/pyload/webui/app/blueprints/api_blueprint.py
@@ -95,7 +95,7 @@ def _parse_parameter(param: str) -> Any:
     else:
         try:
             return literal_eval(param)
-        except ValueError:
+        except (ValueError, SyntaxError):
             # this is required to allow string parameters without extra quotes
             return literal_eval("\"" + param + "\"")
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Small fix for string parameters sent to the API which are not double quoted and contain a dot.
For example, when uploading a .dlc container, since the filename will be something like `1234.dlc` the call to `literal_eval(filename)` will try to resolve it as a number because it interprets the dot as a decimal separator and subsequently raises a `SyntaxError`.

<img width="1042" height="708" alt="Screenshot 2025-12-05 at 14 41 42" src="https://github.com/user-attachments/assets/712d7502-ab0e-4329-9b3b-518fa81d4b61" />

Now we catch the `SyntaxError` and resolve the parameter as string.

### Is this related to a problem?

API can be unreliable if string parameters are not double quoted and contain a dot.

### Additional references
n/a
