### PR TITLE
[PixeldrainCom] Fix API URL and Auth header issue

### DIFF
--- a/src/pyload/plugins/accounts/PixeldrainCom.py
+++ b/src/pyload/plugins/accounts/PixeldrainCom.py
@@ -9,7 +9,7 @@ from ..base.account import BaseAccount
 class PixeldrainCom(BaseAccount):
     __name__ = "PixeldrainCom"
     __type__ = "account"
-    __version__ = "0.01"
+    __version__ = "0.02"
     __status__ = "testing"
 
     __description__ = """Pixeldrain.com account plugin"""
@@ -17,7 +17,7 @@ class PixeldrainCom(BaseAccount):
     __authors__ = [("GammaC0de", "nitzo2001[AT]yahoo[DOT]com")]
 
     #: See https://pixeldrain.com/api/
-    API_URL = "https://pixeldrain.com/api/"
+    API_URL = "https://pixeldrain.com/api"
 
     def grab_info(self, user, password, data):
         # unfortunately, there is no method for account info, assume premium

--- a/src/pyload/plugins/downloaders/PixeldrainCom.py
+++ b/src/pyload/plugins/downloaders/PixeldrainCom.py
@@ -7,7 +7,7 @@ from ..base.simple_downloader import SimpleDownloader
 class PixeldrainCom(SimpleDownloader):
     __name__ = "PixeldrainCom"
     __type__ = "downloader"
-    __version__ = "0.03"
+    __version__ = "0.04"
     __status__ = "testing"
 
     __pattern__ = r"https?://(?:www\.)?pixeldrain\.com/u/(?P<ID>\w+)"
@@ -26,7 +26,7 @@ class PixeldrainCom(SimpleDownloader):
     DIRECT_LINK = False
 
     #: See https://pixeldrain.com/api/
-    API_URL = "https://pixeldrain.com/api/"
+    API_URL = "https://pixeldrain.com/api"
 
     def api_info(self, url):
         file_id = re.match(self.__pattern__, url).group("ID")
@@ -41,7 +41,8 @@ class PixeldrainCom(SimpleDownloader):
 
     def setup(self):
         if self.premium:
-            self.req.add_auth(":{}".format(self.account.info["login"]["password"]))
+            api_key = self.account.info["login"]["password"]
+            self.req.http.auth = ("", api_key)
 
     def handle_free(self, pyfile):
         file_id = self.info["pattern"]["ID"]


### PR DESCRIPTION
### Describe the changes

Configuring an account for `Pixeldrain.com` caused all Pixeldrain downloads to fail.  This is because the `if self.premium` path was broken.

Changes:
* There's an unnecessary trailing slash in the `API_URL`.
* The Basic Auth header was being incorrect formatted, and all API calls thus resulted in `401 Unauthorized`.

These changes allow downloads to work again even if you have a premium account configured, as API calls with an API key now work. The logs clearly show the download process taking the premium route.

However, downloads still seem to be running at non-premium speed. I'm assuming this is because this is a very early and experimental plugin. Either way, this is a step forward. 
