### PR TITLE
Fix API key error when sending requests

### DIFF
--- a/openapi-generator/openapi.json
+++ b/openapi-generator/openapi.json
@@ -3443,9 +3443,9 @@
     },
     "securitySchemes": {
       "ApiKeyAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "bearerFormat": "custom"
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
       }
     }
   },

--- a/src/pyload/webui/app/api_docs/openapi_specification_generator.py
+++ b/src/pyload/webui/app/api_docs/openapi_specification_generator.py
@@ -55,9 +55,9 @@ class OpenAPISpecificationGenerator:
                 "schemas": {},
                 "securitySchemes": {
                     "ApiKeyAuth": {
-                        "type": "http",
-                        "scheme": "bearer",
-                        "bearerFormat": "custom",
+                        "type": "apiKey",
+                        "in": "header",
+                        "name": "X-API-Key",
                     }
                 }
             },

--- a/src/pyload/webui/app/helpers.py
+++ b/src/pyload/webui/app/helpers.py
@@ -261,7 +261,7 @@ def apikey_auth(func):
                     user_data = api.pyload.db.get_all_user_data().get(user_id)
                     if user_data:
                         now = int(time.time() * 1000)
-                        timestamp = int(user_data["last_used"] * 1000)
+                        timestamp = int(key_info["data"]["last_used"] * 1000)
                         user_info = {
                             "id": user_id,
                             "name": user_data["name"],

--- a/src/pyload/webui/app/helpers.py
+++ b/src/pyload/webui/app/helpers.py
@@ -276,7 +276,10 @@ def apikey_auth(func):
 
                 else:
                     # Log failed API key authentication
-                    log.error(f"API authentication failed using API key {auth.token} [CLIENT: {client_ip}]")
+                    log_api_key = f"{auth.token[:4]}********{auth.token[-4:]}"
+                    if len(auth.token) <= 8:
+                        log_api_key = "*" * 8
+                    log.error(f"API authentication failed using API key {log_api_key} [CLIENT: {client_ip}]")
                     return flask.json.jsonify({"error": key_info["error"]}), 401
 
         # No API auth - still use the decorated function but rely on session auth

--- a/src/pyload/webui/app/helpers.py
+++ b/src/pyload/webui/app/helpers.py
@@ -248,13 +248,12 @@ def apikey_auth(func):
         client_ip = flask.request.headers.get("X-Forwarded-For", "").split(",")[0].strip() or flask.request.remote_addr
 
         # Check for API key in header
-        auth_header = flask.request.headers.get("Authorization")
-        if auth_header:
-            parts = auth_header.split()
+        auth = flask.request.authorization
+        if auth:
             # Check for valid API key pattern
-            if parts[0].lower() == 'bearer' and len(parts) == 2 and parts[1].startswith("pl_"):
+            if auth.token and auth.token.startswith("pl_"):
                 # Look up the API key in the database
-                key_info = api.check_apikey(parts[1])
+                key_info = api.check_apikey(auth.token)
                 if key_info["success"]:
                     # Get user info from the user_id in the key
                     user_id = key_info["data"]["user_id"]
@@ -277,7 +276,7 @@ def apikey_auth(func):
 
                 else:
                     # Log failed API key authentication
-                    log.error(f"API authentication failed using API key {parts[1]} [CLIENT: {client_ip}]")
+                    log.error(f"API authentication failed using API key {auth.token} [CLIENT: {client_ip}]")
                     return flask.json.jsonify({"error": key_info["error"]}), 401
 
         # No API auth - still use the decorated function but rely on session auth

--- a/src/pyload/webui/app/helpers.py
+++ b/src/pyload/webui/app/helpers.py
@@ -249,38 +249,36 @@ def apikey_auth(func):
 
         # Check for API key in header
         auth = flask.request.authorization
-        if auth:
-            # Check for valid API key pattern
-            if auth.token and auth.token.startswith("pl_"):
-                # Look up the API key in the database
-                key_info = api.check_apikey(auth.token)
-                if key_info["success"]:
-                    # Get user info from the user_id in the key
-                    user_id = key_info["data"]["user_id"]
-                    key_name = key_info["data"]["name"]
-                    user_data = api.pyload.db.get_all_user_data().get(user_id)
-                    if user_data:
-                        now = int(time.time() * 1000)
-                        timestamp = int(key_info["data"]["last_used"] * 1000)
-                        user_info = {
-                            "id": user_id,
-                            "name": user_data["name"],
-                            "role": user_data["role"],
-                            "permission": user_data["permission"],
-                        }
-                        flask.g.user_info = user_info
-                        # Log once per 8 hours
-                        if now >= timestamp + 480_000:
-                            log.info(f"API authentication successful for user {user_info['name']} using the '{key_name}' API key [CLIENT: {client_ip}]")
-                        return decorated(*args, **kwargs)
+        if auth and auth.token and auth.token.startswith("pl_"):
+            # Look up the API key in the database
+            key_info = api.check_apikey(auth.token)
+            if key_info["success"]:
+                # Get user info from the user_id in the key
+                user_id = key_info["data"]["user_id"]
+                key_name = key_info["data"]["name"]
+                user_data = api.pyload.db.get_all_user_data().get(user_id)
+                if user_data:
+                    now = int(time.time() * 1000)
+                    timestamp = int(key_info["data"]["last_used"] * 1000)
+                    user_info = {
+                        "id": user_id,
+                        "name": user_data["name"],
+                        "role": user_data["role"],
+                        "permission": user_data["permission"],
+                    }
+                    flask.g.user_info = user_info
+                    # Log once per 8 hours
+                    if now >= timestamp + 480_000:
+                        log.info(f"API authentication successful for user {user_info['name']} using the '{key_name}' API key [CLIENT: {client_ip}]")
+                    return decorated(*args, **kwargs)
 
-                else:
-                    # Log failed API key authentication
-                    log_api_key = f"{auth.token[:4]}********{auth.token[-4:]}"
-                    if len(auth.token) <= 8:
-                        log_api_key = "*" * 8
-                    log.error(f"API authentication failed using API key {log_api_key} [CLIENT: {client_ip}]")
-                    return flask.json.jsonify({"error": key_info["error"]}), 401
+            else:
+                # Log failed API key authentication
+                log_api_key = f"{auth.token[:4]}********{auth.token[-4:]}"
+                if len(auth.token) <= 8:
+                    log_api_key = "*" * 8
+                log.error(f"API authentication failed using API key {log_api_key} [CLIENT: {client_ip}]")
+                return flask.json.jsonify({"error": key_info["error"]}), 401
 
         # No API auth - still use the decorated function but rely on session auth
         csrf.protect()

--- a/src/pyload/webui/app/helpers.py
+++ b/src/pyload/webui/app/helpers.py
@@ -248,10 +248,10 @@ def apikey_auth(func):
         client_ip = flask.request.headers.get("X-Forwarded-For", "").split(",")[0].strip() or flask.request.remote_addr
 
         # Check for API key in header
-        auth = flask.request.authorization
-        if auth and auth.token and auth.token.startswith("pl_"):
+        api_key = flask.request.headers.get("X-API-Key")
+        if api_key and api_key.startswith("pl_"):
             # Look up the API key in the database
-            key_info = api.check_apikey(auth.token)
+            key_info = api.check_apikey(api_key)
             if key_info["success"]:
                 # Get user info from the user_id in the key
                 user_id = key_info["data"]["user_id"]
@@ -259,7 +259,7 @@ def apikey_auth(func):
                 user_data = api.pyload.db.get_all_user_data().get(user_id)
                 if user_data:
                     now = int(time.time() * 1000)
-                    timestamp = int(key_info["data"]["last_used"] * 1000)
+                    last_used = int(key_info["data"]["last_used"] * 1000)
                     user_info = {
                         "id": user_id,
                         "name": user_data["name"],
@@ -267,15 +267,15 @@ def apikey_auth(func):
                         "permission": user_data["permission"],
                     }
                     flask.g.user_info = user_info
-                    # Log once per 8 hours
-                    if now >= timestamp + 480_000:
+                    # Log if it has not been used for more than 1 hour
+                    if now >= last_used + 3_600_000:
                         log.info(f"API authentication successful for user {user_info['name']} using the '{key_name}' API key [CLIENT: {client_ip}]")
                     return decorated(*args, **kwargs)
 
             else:
                 # Log failed API key authentication
-                log_api_key = f"{auth.token[:4]}********{auth.token[-4:]}"
-                if len(auth.token) <= 8:
+                log_api_key = f"{api_key[:4]}********{api_key[-4:]}"
+                if len(api_key) <= 8:
                     log_api_key = "*" * 8
                 log.error(f"API authentication failed using API key {log_api_key} [CLIENT: {client_ip}]")
                 return flask.json.jsonify({"error": key_info["error"]}), 401


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

I have tested the intended flow:

1. Create API key
2. Send request with API key
```
curl -X 'GET' \
  'http://localhost:8000/api/status_server' \
  -H 'accept: application/json' \
  -H 'Authorization: Bearer pl_xxxxx'
```

Got an error:
```
  File ".../pyload/src/pyload/webui/app/helpers.py", line 265, in decorated_function
    timestamp = int(user_data["last_used"] * 1000)
                    ~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'last_used'
```

It is fixed with this PR.

It also adds 2 more commits:

1. Revert to using the `flask.request.authorization` object for code readability
2. Remove clear text logging of the full api key

### Is this related to a problem?

API keys not working at all.

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
