### PR TITLE
Fix first use of api key where last_used is not set and causes a crash

### DIFF
--- a/src/pyload/webui/app/helpers.py
+++ b/src/pyload/webui/app/helpers.py
@@ -293,8 +293,6 @@ def apikey_auth(func):
                 key_name = key_info["data"]["name"]
                 user_data = api.pyload.db.get_all_user_data().get(user_id)
                 if user_data:
-                    now = int(time.time() * 1000)
-                    last_used = int(key_info["data"]["last_used"] * 1000)
                     user_info = {
                         "id": user_id,
                         "name": user_data["name"],
@@ -303,6 +301,8 @@ def apikey_auth(func):
                     }
                     flask.g.user_info = user_info
                     # Log if it has not been used for more than 1 hour
+                    now = int(time.time() * 1000)
+                    last_used = key_info["data"]["last_used"] or 0
                     if now >= last_used + 3_600_000:
                         log.info(f"API authentication successful for user {user_info['name']} using the '{key_name}' API key [CLIENT: {client_ip}]")
                     return decorated(*args, **kwargs)


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

<!-- WRITE HERE -->

The very first time an API key is used, i.e. the first request that is made with it will cause an exception:
```
  Traceback (most recent call last):
  File "../pyload/.venv/lib/python3.14/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "../pyload/.venv/lib/python3.14/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "../pyload/src/pyload/webui/app/helpers.py", line 297, in decorated_function
    last_used = int(key_info["data"]["last_used"] * 1000)
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```
The reason for this is that `last_used` is not present in the database yet, it is only set in `src/pyload/core/api/__init__.py` **after** `key_data` has been retrieved. So the `key_info` at this point will not contain a value. This is fixed with this PR.

Also the conversion to `int` and multiplication by 1000 is already done when `last_used` is set / updated so I don't think it's correct to do it again when retrieving the value.

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
