### PR TITLE
Use default encoding 'utf-8' if charset not found

### DIFF
--- a/src/pyload/core/network/http/http_request.py
+++ b/src/pyload/core/network/http/http_request.py
@@ -515,7 +515,7 @@ class HTTPRequest:
             for content_value in self.response_headers.get_list("Content-Type"):
                 content_type, content_params = parse_header_line(content_value)
                 if (content_type.startswith("text/") or content_type.startswith("application/")) and "charset" in content_params:
-                    encoding = content_params["charset"]
+                    encoding = content_params.get("charset", "utf-8")
                     break
 
         try:


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

<!-- A clear and concise description of what you've done. -->

<!-- WRITE HERE -->
The goal is to have a default charset if it is not defined in the Content-Type response header.
### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->
For the application 9kw this charset isn't defined. And the http request crash as charset isn't defined.
https://www.9kw.eu/index.cgi?action=usercaptchaguthaben&apikey=APIKEY&pyload=1&source=pyload

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
