### PR TITLE
Fix Filer.net (new API as of Dec 25)

### DIFF
--- a/src/pyload/plugins/accounts/FilerNet.py
+++ b/src/pyload/plugins/accounts/FilerNet.py
@@ -1,15 +1,13 @@
 import json
 import time
 
-from pyload.core.network.http.exceptions import BadHeader
-
 from ..base.account import BaseAccount
 
 
 class FilerNet(BaseAccount):
     __name__ = "FilerNet"
     __type__ = "account"
-    __version__ = "0.17"
+    __version__ = "0.18"
     __status__ = "testing"
 
     __description__ = """Filer.net account plugin"""
@@ -22,34 +20,35 @@ class FilerNet(BaseAccount):
     # See https://filer.net/api
     API_URL = "https://filer.net/api/"
 
-    def api_request(self, method, **kwargs):
-        try:
-            json_data = self.load(self.API_URL + method, post=kwargs)
-        except BadHeader as exc:
-            json_data = exc.content
-
-        return json.loads(json_data)
-
     def grab_info(self, user, password, data):
-        api_data = self.api_request("user/account")
+        self.req.add_auth(f"{user}:{password}")
+        try:
+            json_data = self.load(self.API_URL + "profile.json")
+            api_data = json.loads(json_data)["data"]
+        except Exception as e:
+            self.log_error(str(e))
+            return {"premium": False, "validuntil": None, "trafficleft": None}
+        finally:
+            self.req.remove_auth()
 
-        premium = api_data["status"] == "Premium"
+        premium = api_data["premium"]
 
         #: Free user
         if premium is False:
             return {"premium": False, "validuntil": None, "trafficleft": None}
 
-        validuntil = time.mktime(time.strptime(api_data["premiumUntil"], "%Y-%m-%dT%H:%M:%S%z"))
-        trafficleft = self.parse_traffic(api_data["traffic"])
+        validuntil = api_data["until"]
+        trafficleft = api_data["traffic_left"]
 
         return {"premium": premium, "validuntil": validuntil, "trafficleft": trafficleft}
 
     def signin(self, user, password, data):
-        api_data = self.api_request("user/account")
-        if "message" not in api_data:
+        self.req.add_auth(f"{user}:{password}")
+        try:
+            self.load(self.API_URL + "profile.json")
+        except Exception as e:
+            self.fail_login(str(e))
+        else:
             self.skip_login()
-
-        api_data = self.api_request("user/login", email=user, password=password)
-        if api_data.get("message", "") != "Login successful":
-            self.log_error(api_data["message"])
-            self.fail_login()
+        finally:
+            self.req.remove_auth()

--- a/src/pyload/plugins/accounts/FilerNet.py
+++ b/src/pyload/plugins/accounts/FilerNet.py
@@ -1,5 +1,5 @@
 import json
-import time
+from pyload.core.network.http.exceptions import BadHeader
 
 from ..base.account import BaseAccount
 
@@ -20,35 +20,36 @@ class FilerNet(BaseAccount):
     # See https://filer.net/api
     API_URL = "https://filer.net/api/"
 
-    def grab_info(self, user, password, data):
-        self.req.add_auth(f"{user}:{password}")
+    def api_request(self, method, user=None, password=None):
         try:
-            json_data = self.load(self.API_URL + "profile.json")
-            api_data = json.loads(json_data)["data"]
-        except Exception as e:
-            self.log_error(str(e))
-            return {"premium": False, "validuntil": None, "trafficleft": None}
+            if user and password:
+                self.req.add_auth(f"{user}:{password}")
+            json_data = self.load(f"{self.API_URL}{method}.json")
+        except BadHeader as exc:
+            json_data = exc.content
         finally:
-            self.req.remove_auth()
+            if user and password:
+                self.req.remove_auth()
 
+        return json.loads(json_data)
+
+    def grab_info(self, user, password, data):
+        api_data = self.api_request("profile", user, password)
         premium = api_data["premium"]
+        if premium:
+            validuntil = api_data["data"]["until"]
+            trafficleft = api_data["data"]["traffic_left"]
+        else:
+            validuntil = None
+            trafficleft = None
 
-        #: Free user
-        if premium is False:
-            return {"premium": False, "validuntil": None, "trafficleft": None}
-
-        validuntil = api_data["until"]
-        trafficleft = api_data["traffic_left"]
-
-        return {"premium": premium, "validuntil": validuntil, "trafficleft": trafficleft}
+        return {
+            "premium": premium,
+            "validuntil": validuntil,
+            "trafficleft": trafficleft
+        }
 
     def signin(self, user, password, data):
-        self.req.add_auth(f"{user}:{password}")
-        try:
-            self.load(self.API_URL + "profile.json")
-        except Exception as e:
-            self.fail_login(str(e))
-        else:
-            self.skip_login()
-        finally:
-            self.req.remove_auth()
+        api_data = self.api_request("profile", user, password)
+        if api_data["code"] != 200:
+            self.fail_login(api_data["status"])

--- a/src/pyload/plugins/downloaders/FilerNet.py
+++ b/src/pyload/plugins/downloaders/FilerNet.py
@@ -3,21 +3,20 @@ import re
 
 from pyload.core.network.http.exceptions import BadHeader
 
-from ..anticaptchas.HCaptcha import HCaptcha
 from ..base.simple_downloader import SimpleDownloader
 
 
 class FilerNet(SimpleDownloader):
     __name__ = "FilerNet"
     __type__ = "downloader"
-    __version__ = "0.35"
+    __version__ = "0.36"
     __status__ = "testing"
 
     __pattern__ = r"https?://(?:www\.)?filer\.net/get/(?P<ID>\w+)"
     __config__ = [
         ("enabled", "bool", "Activated", True),
         ("use_premium", "bool", "Use premium account if available", True),
-        ("fallback", "bool", "Fallback to free download if premium fails", True),
+        ("fallback", "bool", "Fallback to free download if premium fails", False),
         ("chk_filesize", "bool", "Check file size", True),
         ("max_wait", "int", "Reconnect if waiting time is greater than minutes", 10),
     ]
@@ -30,17 +29,12 @@ class FilerNet(SimpleDownloader):
         ("GammaC0de", "nitzo2001[AT]yahoo[DOT]com"),
     ]
 
-    HCAPTCHA_KEY = "45623a98-7b08-43ae-b758-c21c13024e2a"
+    # See https://filer.net/api/json
+    API_URL = "https://filer.net/api"
 
-    # See https://filer.net/api
-    API_URL = "https://filer.net/api/"
-
-    def api_request(self, method, is_post=True, **kwargs):
+    def api_request(self, endpoint, **kwargs):
         try:
-            if is_post:
-                json_data = self.load(self.API_URL + method, post=kwargs)
-            else:
-                json_data = self.load(self.API_URL + method, get=kwargs)
+            json_data = self.load(f"{self.API_URL}/{endpoint}", get=kwargs or None, redirect=False)
         except BadHeader as exc:
             json_data = exc.content
 
@@ -50,47 +44,45 @@ class FilerNet(SimpleDownloader):
         info = {}
         file_id = re.match(self.__pattern__, url).group("ID")
 
-        api_data = self.api_request(f"file/{file_id}")
-        if api_data.get("message") == "File not found":
-            info["status"] = 1
+        api_data = self.api_request(f"status/{file_id}.json")
+        if api_data.get("code") == 500:
+            info["status"] = 1  #: offline
         else:
+            data = api_data["data"]
             info.update({
-                "name": api_data["name"],
-                "size": api_data["size"],
-                "premium_only": api_data["premiumOnly"],
-                "status": 2
+                "name": data["file_name"],
+                "size": data["file_size"],
+                "premium_only": data["premium_only"],
+                "status": 2,  #: online
             })
 
         return info
 
     def handle_free(self, pyfile):
-        if self.info["premium_only"] is True and not self.premium:
-            self.fail(self._("File can be downloaded by premium users only"))
-
-        file_id = self.info["pattern"]["ID"]
-
-        self.captcha = HCaptcha(pyfile)
-        captcha_response = self.captcha.challenge(self.HCAPTCHA_KEY)
-
-        api_data = self.api_request(f"file/request/{file_id}", is_post=False, hCaptchaToken=captcha_response)
-        error = api_data.get("error")
-        if error:
-            self.log_error(error)
-            if error == "HOURLY_DOWNLOAD_LIMIT":
-                self.retry(wait=3600)
-            elif error == "CONCURRENT_DOWNLOAD_LIMIT":
-                self.temp_offline()
-            else:
-                self.fail(error)
-
-        wait_time = api_data["wt"]
-        self.wait(wait_time)
-        api_data = self.api_request("file/download", ticket=api_data["t"])
-        if "error" in api_data:
-            self.fail(api_data["error"])
-        else:
-            self.link = api_data["downloadUrl"]
+        self.fail(self._("Only premium users can download from Filer.net"))
 
     def handle_premium(self, pyfile):
-        self.handle_free(pyfile)
+        file_id = self.info["pattern"]["ID"]
+
+        user = self.account.user
+        password = self.account.info["login"]["password"]
+        self.req.add_auth(f"{user}:{password}")
+        try:
+            api_data = self.api_request(f"dl/{file_id}.json")
+        finally:
+            self.req.remove_auth()
+
+        code = api_data.get("code")
+        if code == 401:
+            self.fail(self._("Authentication required"))
+        elif code == 403:
+            self.fail(self._("Premium account required"))
+        elif code == 429:
+            self.temp_offline(self._("Concurrent download limit reached"))
+        elif code == 500:
+            self.offline()
+        elif code == 503:
+            self.temp_offline(self._("No download server available"))
+
+        self.link = api_data["data"]["download_url"]
 

--- a/src/pyload/plugins/downloaders/FilerNet.py
+++ b/src/pyload/plugins/downloaders/FilerNet.py
@@ -3,6 +3,7 @@ import re
 
 from pyload.core.network.http.exceptions import BadHeader
 
+from ..anticaptchas.HCaptcha import HCaptcha
 from ..base.simple_downloader import SimpleDownloader
 
 
@@ -29,6 +30,8 @@ class FilerNet(SimpleDownloader):
         ("GammaC0de", "nitzo2001[AT]yahoo[DOT]com"),
     ]
 
+    HCAPTCHA_KEY = "45623a98-7b08-43ae-b758-c21c13024e2a"
+
     # See https://filer.net/api
     API_URL = "https://filer.net/api/"
 
@@ -42,6 +45,17 @@ class FilerNet(SimpleDownloader):
         finally:
             if user and password:
                 self.req.remove_auth()
+
+        return json.loads(json_data)
+
+    def old_api_request(self, method, is_post=True, **kwargs):
+        try:
+            if is_post:
+                json_data = self.load(self.API_URL + method, post=kwargs)
+            else:
+                json_data = self.load(self.API_URL + method, get=kwargs)
+        except BadHeader as exc:
+            json_data = exc.content
 
         return json.loads(json_data)
 
@@ -66,7 +80,38 @@ class FilerNet(SimpleDownloader):
     def handle_free(self, pyfile):
         if self.info["premium_only"] is True and not self.premium:
             self.fail(self._("File can be downloaded by premium users only"))
-        self.fail(self._("Only premium users can download from Filer.net"))
+
+        if self.account:
+            self.fail(self._("Free account downloads are unsupported"))
+
+        file_id = self.info["pattern"]["ID"]
+
+        self.captcha = HCaptcha(pyfile)
+        captcha_response = self.captcha.challenge(self.HCAPTCHA_KEY)
+        api_data = self.old_api_request(f"file/request/{file_id}", False, hCaptchaToken=captcha_response)
+        error = api_data.get("error")
+        if error:
+            self.log_error(error)
+            if error == "HOURLY_DOWNLOAD_LIMIT":
+                self.retry(wait=3600)
+            elif error in ("CONCURRENT_DOWNLOAD_LIMIT", "TICKET_LIMIT_REACHED"):
+                self.temp_offline()
+            else:
+                self.fail(error)
+
+
+        wait_time = api_data["wt"]
+        self.wait(wait_time)
+        api_data = self.old_api_request("file/download", True, ticket=api_data["t"])
+        error = api_data.get("error")
+        if error:
+            self.log_error(error)
+            if error == "HOURLY_DOWNLOAD_LIMIT":
+                self.retry(wait=3600)
+            else:
+                self.fail(error)
+        else:
+            self.link = api_data["downloadUrl"]
 
     def handle_premium(self, pyfile):
         file_id = self.info["pattern"]["ID"]

--- a/src/pyload/plugins/downloaders/FilerNet.py
+++ b/src/pyload/plugins/downloaders/FilerNet.py
@@ -16,7 +16,7 @@ class FilerNet(SimpleDownloader):
     __config__ = [
         ("enabled", "bool", "Activated", True),
         ("use_premium", "bool", "Use premium account if available", True),
-        ("fallback", "bool", "Fallback to free download if premium fails", False),
+        ("fallback", "bool", "Fallback to free download if premium fails", True),
         ("chk_filesize", "bool", "Check file size", True),
         ("max_wait", "int", "Reconnect if waiting time is greater than minutes", 10),
     ]
@@ -29,14 +29,19 @@ class FilerNet(SimpleDownloader):
         ("GammaC0de", "nitzo2001[AT]yahoo[DOT]com"),
     ]
 
-    # See https://filer.net/api/json
-    API_URL = "https://filer.net/api"
+    # See https://filer.net/api
+    API_URL = "https://filer.net/api/"
 
-    def api_request(self, endpoint, **kwargs):
+    def api_request(self, method, user=None, password=None):
         try:
-            json_data = self.load(f"{self.API_URL}/{endpoint}", get=kwargs or None, redirect=False)
+            if user and password:
+                self.req.add_auth(f"{user}:{password}")
+            json_data = self.load(f"{self.API_URL}{method}.json")
         except BadHeader as exc:
             json_data = exc.content
+        finally:
+            if user and password:
+                self.req.remove_auth()
 
         return json.loads(json_data)
 
@@ -44,10 +49,8 @@ class FilerNet(SimpleDownloader):
         info = {}
         file_id = re.match(self.__pattern__, url).group("ID")
 
-        api_data = self.api_request(f"status/{file_id}.json")
-        if api_data.get("code") == 500:
-            info["status"] = 1  #: offline
-        else:
+        api_data = self.api_request(f"status/{file_id}")
+        if api_data["code"] == 200:
             data = api_data["data"]
             info.update({
                 "name": data["file_name"],
@@ -55,10 +58,14 @@ class FilerNet(SimpleDownloader):
                 "premium_only": data["premium_only"],
                 "status": 2,  #: online
             })
+        else:
+            info["status"] = 1  #: offline
 
         return info
 
     def handle_free(self, pyfile):
+        if self.info["premium_only"] is True and not self.premium:
+            self.fail(self._("File can be downloaded by premium users only"))
         self.fail(self._("Only premium users can download from Filer.net"))
 
     def handle_premium(self, pyfile):
@@ -66,23 +73,13 @@ class FilerNet(SimpleDownloader):
 
         user = self.account.user
         password = self.account.info["login"]["password"]
-        self.req.add_auth(f"{user}:{password}")
-        try:
-            api_data = self.api_request(f"dl/{file_id}.json")
-        finally:
-            self.req.remove_auth()
+        api_data = self.api_request(f"dl/{file_id}", user, password)
+        code = api_data["code"]
+        if code == 200:
+            self.link = api_data["data"]["download_url"]
 
-        code = api_data.get("code")
-        if code == 401:
-            self.fail(self._("Authentication required"))
-        elif code == 403:
-            self.fail(self._("Premium account required"))
         elif code == 429:
             self.temp_offline(self._("Concurrent download limit reached"))
-        elif code == 500:
-            self.offline()
         elif code == 503:
             self.temp_offline(self._("No download server available"))
-
-        self.link = api_data["data"]["download_url"]
 


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Filer.net has a new API since at least December of 2025 (see: https://filer.net/news).
The API no longer exposes the Captcha for Free Downloads and uses HTTP-Basic-Auth for Premium API Requests.
My changes only refer to the Premium API, I think for Free/No Account this would need to be reimplemented not using their API, but by parsing the actual Download page you see in the browser.
As that would also require finding the captcha and handing it off to some other plugin I skipped that part for now.

At least this way the premium downloads for Filer,net work again. 🤷

<!-- WRITE HERE -->

### Is this related to a problem?

The old FilerNet Plugins used the now outdated/no longer available API from before December 2025 and didn't work anymore.

<!-- WRITE HERE - OPTIONAL -->

### Additional references
Works fine on my machine now:
```
1743 | 2026-03-29 21:11:12 | DEBUG | pyload | ACCOUNT FilerNet: LOAD URL https://filer.net/api/profile.json \| get=None \| post=None \| referrer=True \| cookies=True \| just_header=False \| decode=True \| multipart=False \| redirect=True \| req=None
-- | -- | -- | -- | --
1744 | 2026-03-29 21:11:13 | DEBUG | pyload | ACCOUNT FilerNet: Account info for user `mas****`: {'login': {'password': '**********', 'stats': [1, 1774811449.3991172], 'timestamp': 1774810499.1533709, 'valid': True}, 'data': {'login': 'mas****', 'options': {'limit_dl': ['0']}, 'plugin': <Account FilerNet>, 'premium': True, 'trafficleft': 52978773966, 'type': 'FilerNet', 'validuntil': 1777390105}}
1745 | 2026-03-29 21:11:13 | DEBUG | pyload | ACCOUNT FilerNet: Using account mas*******
1746 | 2026-03-29 21:11:13 | INFO | pyload | DOWNLOADER FilerNet[10]: Processing url: https://filer.net/get/
2026-03-29 21:11:14 | INFO | pyload | DOWNLOADER FilerNet[10]: Grabbing link info...
-- | -- | -- | --
1754 | 2026-03-29 21:11:14 | DEBUG | pyload | DOWNLOADER FilerNet[10]: LOAD URL https://filer.net/api/status/*****.json \| get=None \| post=None \| referrer=True \| cookies=True \| just_header=False \| decode=True \| multipart=False \| redirect=False \| req=None
1755 | 2026-03-29 21:11:14 | DEBUG | pyload | DOWNLOADER FilerNet[10]: Link info: {'name': '*****', 'hash': {}, 'pattern': {'ID': '*****'}, 'size': 1047527424, 'status': 2, 'url': 'https://filer.net/get/*****', 'premium_only': False}
1756 | 2026-03-29 21:11:14 | DEBUG | pyload | DOWNLOADER FilerNet[10]: Previous link info: {}
1757 | 2026-03-29 21:11:14 | INFO | pyload | DOWNLOADER FilerNet[10]: Link name: *********
1758 | 2026-03-29 21:11:14 | INFO | pyload | DOWNLOADER FilerNet[10]: Link size: ***.00 MiB (*** bytes)
1759 | 2026-03-29 21:11:14 | INFO | pyload | DOWNLOADER FilerNet[10]: Link status: online
1760 | 2026-03-29 21:11:14 | INFO | pyload | DOWNLOADER FilerNet[10]: Processing as premium download...
1761 | 2026-03-29 21:11:14 | DEBUG | pyload | DOWNLOADER FilerNet[10]: LOAD URL https://filer.net/api/dl/***.json \| get=None \| post=None \| referrer=True \| cookies=True \| just_header=False \| decode=True \| multipart=False \| redirect=False \| req=None
1762 | 2026-03-29 21:11:16 | INFO | pyload | DOWNLOADER FilerNet[10]: Downloading file...
1763 | 2026-03-29 21:11:16 | DEBUG | pyload | DOWNLOADER FilerNet[10]: DOWNLOAD URL https://dl57.filer.net/dl/***/***/***/*** \| get={} \| post={} \| referrer=True \| cookies=True \| disposition=True \| resume=None \| chunks=None
1764 | 2026-03-29 21:11:17 | DEBUG | pyload | Content-Disposition: ***
```