### PR TITLE
Fix API keys without expiry date being considered invalid

### DIFF
--- a/src/pyload/core/database/apikey_database.py
+++ b/src/pyload/core/database/apikey_database.py
@@ -100,7 +100,7 @@ class ApikeyDatabaseMethods:
         :return: dict with key info or empty dict if not found
         """
         self.c.execute(
-            "SELECT id, user_id, name, key_hash, created_at, expires_at, last_used FROM apikeys WHERE id=? AND expires_at>?",
+            "SELECT id, user_id, name, key_hash, created_at, expires_at, last_used FROM apikeys WHERE id=? AND (expires_at>? OR expires_at=0)",
             (key_id, int(time.time() * 1000)),
         )
         r = self.c.fetchone()


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

The recent addition of expiry date validation broke API keys which do not have an expiry date set i.e. are valid indefinitely. Those have `expires_at` set to 0. As the current check only checks whether `expires_at > int(time.time() * 1000)` those keys will be incorrectly considered invalid.

I adapted the database query and added an OR condition so those API keys are considered valid again.

### Is this related to a problem?

API keys without expiration date are not working.

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
