### PR TITLE
Allow uploading dlc files straight to queue

### DIFF
--- a/openapi-generator/openapi.json
+++ b/openapi-generator/openapi.json
@@ -2622,6 +2622,11 @@
                     "type": "string",
                     "format": "binary",
                     "description": "file content"
+                  },
+                  "dest": {
+                    "$ref": "#/components/schemas/Destination",
+                    "default": 0,
+                    "description": "`Destination`"
                   }
                 },
                 "required": [

--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -1105,12 +1105,13 @@ class Api:
     @legacy("uploadContainer")
     @permission(Perms.ADD)
     @post
-    def upload_container(self, filename: str, data: bytes) -> None:
+    def upload_container(self, filename: str, data: bytes, dest: Destination = Destination.COLLECTOR) -> None:
         """
         Uploads and adds a container file to pyLoad.
 
         :param filename: file name - extension is important, so it can correctly decrypt
         :param data: file content
+        :param dest: `Destination`
         """
         upload_path = os.path.join(self.pyload.tempdir, "upload")
         os.makedirs(upload_path, exist_ok=True)
@@ -1119,7 +1120,7 @@ class Api:
         with open(fs.safejoin(upload_path, filename), "wb") as th:
             th.write(data)
 
-        self.add_package(th.name, [th.name], Destination.COLLECTOR)
+        self.add_package(th.name, [th.name], dest)
 
     @legacy("orderPackage")
     @permission(Perms.MODIFY)


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Currently, it's not possible to upload a dlc straight to the queue via the API.
Any workarounds to upload the dlc and move the package afterwards are tedious, as the package id is not known.

This change is backwards compatible as the `dest` value still defaults to collector.

It is possible via the UI, where if I understand it correctly, `add_package()` in the `json_blueprint` will be called and adds the path to the dlc file as a link and then processes it as a "normal" package and somewhere in the process this will be decrypted and resolved to actual filehoster links. Technically this part could now be refactored to call the api method in a more straightforward way, something like:

```
@bp.route("/json/add_package", methods=["POST"], endpoint="add_package")
# @apiver_check
@login_required("ADD")
def add_package():
    api = flask.current_app.config["PYLOAD_API"]

    dest = int(flask.request.form["add_dest"])

    try:
        file = flask.request.files["add_file"]

        if file.filename:
            api.upload_container(file.filename, file, dest)
            return jsonify(True)
        else:
            return jsonify(False), 400
    except Exception:
        pass

    package_name = flask.request.form.get("add_name", "New Package").strip()
    links = [l.strip() for l in flask.request.form["add_links"].splitlines()]

    urls = [url for url in links if url.strip()]
    pack = api.add_package(package_name, urls, dest)
    if pw := flask.request.form.get("add_password", "").strip("\n\r"):
        data = {"password": pw}
        api.set_package_data(pack, data)

    return jsonify(True)
```
This would no longer allow to set custom package names when uploading dlc files, but that also means the package name field would no longer be a required field when uploading a dlc so that's an improvement if you ask me.

Anyway, make of this what you want, I haven't included this refactor in this PR as I wasn't sure it's desired or not.

(Note: I haven't tested this refactor)

<!-- WRITE HERE -->

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->