### PR TITLE
Use Root Folder Handle for File Key

### DIFF
--- a/src/pyload/plugins/downloaders/MegaCoNz.py
+++ b/src/pyload/plugins/downloaders/MegaCoNz.py
@@ -487,6 +487,32 @@ class MegaCoNz(BaseDownloader):
                 self.pyfile.name = name
                 self.skip(self._("File exists."))
 
+    def find_root_node(self, res_f):
+        """
+        Build a tree of the folder nodes. Return the handle of the top-most node.
+        """
+        tree = {}
+        for node in res_f:
+            if node['t'] == 1 and node['h'] and node['p']:
+                tree[node['h']] = node['p']
+
+        for key, val in tree.items():
+            if val not in tree:
+                return key
+
+    def build_key_dict(self, node_k):
+        """
+        Take a node's k value, and produce a dictionary.
+        """
+        dict = {}
+        node_k = node_k.split('/')
+        for key_data in node_k:
+            h = key_data[:key_data.index(':')]
+            l = key_data[key_data.index(':') + 1:]
+            dict[h] = l
+
+        return dict
+
     def process(self, pyfile):
         node_id = self.info['pattern']['NID']
         public = node_id in ("", None)
@@ -511,9 +537,17 @@ class MegaCoNz(BaseDownloader):
             elif isinstance(res, dict) and 'e' in res:
                 mega.check_error(res['e'])
 
+            root_handle = self.find_root_node(res['f'])
+            self.log_debug("Root Folder Handle: {}".format(root_handle))
             for node in res['f']:
                 if node['t'] == 0 and ":" in node["k"] and node['h'] == node_id:
-                    master_key = MegaCrypto.decrypt_key(node['k'][node['k'].index(':') + 1:], master_key)
+                    keys = self.build_key_dict(node['k'])
+                    file_key = keys[root_handle]
+                    if not file_key:
+                        self.log_error(self._("Root folder handle not found in file keys"))
+                        self.fail(self._("Root folder handle not found in file keys"))
+
+                    master_key = MegaCrypto.decrypt_key(file_key, master_key)
                     break
 
             else:

--- a/src/pyload/plugins/downloaders/MegaCoNz.py
+++ b/src/pyload/plugins/downloaders/MegaCoNz.py
@@ -342,7 +342,7 @@ class MegaClient:
 class MegaCoNz(BaseDownloader):
     __name__ = "MegaCoNz"
     __type__ = "downloader"
-    __version__ = "0.59"
+    __version__ = "0.60"
     __status__ = "testing"
 
     __pattern__ = r"https?://(?:www\.)?mega(?:\.co)?\.nz/(?:file/(?P<ID1>[\w^_]+)#(?P<K1>[\w\-,=]+)|folder/(?P<ID2>[\w^_]+)#(?P<K2>[\w\-,=]+)/file/(?P<NID>[\w^_]+)|#!(?P<ID3>[\w^_]+)!(?P<K3>[\w\-,=]+))"
@@ -542,7 +542,7 @@ class MegaCoNz(BaseDownloader):
             for node in res['f']:
                 if node['t'] == 0 and ":" in node["k"] and node['h'] == node_id:
                     keys = self.build_key_dict(node['k'])
-                    file_key = keys[root_handle]
+                    file_key = keys.get(root_handle)
                     if not file_key:
                         self.log_error(self._("Root folder handle not found in file keys"))
                         self.fail(self._("Root folder handle not found in file keys"))


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

The MegaCoNZ plugin currently assumes a single file key. There are cases where multiple file keys can be provided, depending on which share key is to be used to decrypt the file key. The current logic does a very simple string split of the handle and the encoded+encrypted key, which never works in cases where files have multiple keys.

This implementation adds logic to more intelligently pick which file key to use:
* Determines the handle name of the root directory node in the share, by looking for the node whose parent isn't in the directory tree. This parent is assumed to be some folder in a user's private share.
* Parses the file key list into a dictionary, and then looks for the file key using the root directory node's handle out of the full list. 

It also adds a debug log of which node it determined to be the root node, so that the outcome of what key is being looked for can be determined from logs if something does go wrong. 

### Is this related to a problem?

This will resolve #4727. 

### Risks

Because this does change the logic behind picking the key to use, it isn't without some risk. While I've tested it against a few shares (ones that worked fine without the change, and ones that required the change to fully download without errors), it's possible that there are some edge cases I'm not aware of.