### PR TITLE
POST request without valid auth does not return 401

### DIFF
--- a/src/pyload/webui/app/helpers.py
+++ b/src/pyload/webui/app/helpers.py
@@ -387,9 +387,9 @@ def apikey_auth(func):
                 return flask.json.jsonify({"error": key_info["error"]}), 401
 
         # No API auth - still use the decorated function but rely on session auth
-        csrf.protect()
         s = flask.session
         if is_authenticated(s):
+            csrf.protect()
             user_info = {
                 "id": s["id"],
                 "name": s["name"],


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes
When executing a POST API request with missing / invalid API key the response is
```
400
{"error": "CSRF token is invalid"}
```
when it should be 
```
401
{"error": "Invalid API credentials"}
```
for GET requests it is correct.

I have therefore moved the `csrf.protect()` so it is only executed if an authenticated session exists.
Otherwise we will always return `401`.

I don't think this causes any security concerns, but I'm no expert on security matters.

### Is this related to a problem?

Incorrect API response, confusing for clients.

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
