### PR TITLE
CI: run tests for all os and python versions

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -133,11 +133,18 @@ jobs:
         run: tox -e ${{ matrix.toxenv || env.toxenv }} --sitepackages --workdir ${{ env.toxworkdir }}
 
       - name: Run unit tests
-        if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.13'
-        run: python3 -m pytest tests/unit --cov pyload --cov-report markdown-append:$GITHUB_STEP_SUMMARY
+        shell: bash
+        run: |
+          COVERAGE_ARGS=""
+
+          # Only run tests with coverage for one os & python version combination
+          if [[ "${{ matrix.os }}" == ubuntu* && "${{ matrix.python-version }}" == "3.13" ]]; then
+            COVERAGE_ARGS="--cov pyload --cov-report markdown-append:$GITHUB_STEP_SUMMARY"
+          fi
+
+          python3 -m pytest tests/unit $COVERAGE_ARGS
 
       - name: Run integration tests
-        if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.13'
         run: python3 -m pytest tests/integration
 
       - name: Test OpenAPI spec generator


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

Run the unit and integration tests on all operating systems and python versions in GitHub CI.
Run the unit tests with coverage report only once (currently in ubuntu and python 3.13 combination).

Example run: https://github.com/Sab44/pyload/actions/runs/24706948202

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
