### PR TITLE
Call secure_filename for folder when adding new package

### DIFF
--- a/src/pyload/core/api/__init__.py
+++ b/src/pyload/core/api/__init__.py
@@ -559,17 +559,8 @@ class Api:
         else:
             folder = ""
 
-        folder = (
-            folder.replace("http://", "")
-            .replace("https://", "")
-            .replace("../", "_")
-            .replace("..\\", "_")
-            .replace(":", "")
-            .replace("/", "_")
-            .replace("\\", "_")
-            .replace("\r", "_")
-            .replace("\n", "_")
-        )
+        folder = folder.replace("http://", "").replace("https://", "")
+        folder = secure_filename(folder)
 
         sanitized_name = name.replace("\n", "\\n").replace("\r", "\\r")
         package_id = self.pyload.files.add_package(sanitized_name, folder, Destination(dest))

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -170,3 +170,30 @@ class TestPackages:
         )
 
         assert response.status_code == 200
+
+    def test_package_folder_is_sanitized(self, api_key, client):
+        # Add a dummy package to the collector
+        response = client.post(
+            "/api/add_package",
+            json={
+                "name": "https://TEST strange package:name\\",
+                "links": [
+                    "https://localhost/non-existent-file.zip"
+                ],
+                "dest": 0
+            },
+            headers={API_KEY_HEADER: api_key}
+        )
+
+        assert response.status_code == 200
+        package_id = response.text
+
+        # Get package data for dummy package
+        response = client.get(
+            "api/get_package_data",
+            query_string={"package_id": package_id},
+            headers={API_KEY_HEADER: api_key}
+        )
+
+        assert response.status_code == 200
+        assert response.json["folder"] == "TEST_strange_packagename"


### PR DESCRIPTION
<!-- ANNOTATIONS LIKE THIS WILL NOT BE VISIBLE IN YOUR TICKET -->

### Describe the changes

The following problem happened to me:

1. Add a link with a package name that contains a space e.g. "My Test": `add_package` https://github.com/pyload/pyload/blob/d90a5f49802e2456a3e362cf73891ae978273399/src/pyload/core/api/__init__.py#L548 will not strip the spaces from the `folder` variable
2. Edit the package afterwards and e.g. enter a password for the package, then save it: `edit_package` https://github.com/pyload/pyload/blob/d90a5f49802e2456a3e362cf73891ae978273399/src/pyload/webui/app/blueprints/json_blueprint.py#L205 will overwrite the folder and strip any spaces from it: `pack_folder = secure_filename(pack_folder)`
3. If the file(s) already started to download, extraction will fail as it will try to find the file in `/downloads/My_Test/` when it is actually in `/downloads/My Test/`

This PR fixes this by calling `secure_filename` on the initial folder that is created when adding a package that will strip spaces (among others).

Added a test method for this as well to verify the behaviour.

I don't think this will have any side effects but I'm not 100% sure.

### Is this related to a problem?

<!-- A description of the problem you ran into. -->

<!-- WRITE HERE - OPTIONAL -->

### Additional references

<!-- Any other reference, related issues, pull requests or screenshots about this request. -->

<!-- WRITE HERE - OPTIONAL -->
