### PR TITLE
make add_links fire UpdateEvent instead of ReloadAllEvent

### DIFF
--- a/src/pyload/core/managers/file_manager.py
+++ b/src/pyload/core/managers/file_manager.py
@@ -3,7 +3,7 @@ from threading import RLock
 
 from ..datatypes.enums import Destination
 from ..utils.struct.lock import lock
-from .event_manager import InsertEvent, ReloadAllEvent, RemoveEvent, UpdateEvent
+from .event_manager import InsertEvent, RemoveEvent, UpdateEvent
 
 
 def change(func):
@@ -133,8 +133,10 @@ class FileManager:
         self.pyload.db.add_links(data, package)
         self.pyload.thread_manager.create_info_thread(data, package)
 
-        # TODO: change from reload_all event to package update event
-        self.pyload.event_manager.add_event(ReloadAllEvent("collector"))
+        p = self.get_package(package)
+        self.pyload.event_manager.add_event(
+            UpdateEvent("pack", package, "collector" if not p.queue else "queue")
+        )
 
     # ----------------------------------------------------------------------
     @lock


### PR DESCRIPTION
### Describe the changes

 `add_links()` fired a `ReloadAllEvent("collector")` which was not correct, as noted in the TODO comment [355c3f8d7](https://github.com/pyload/pyload/blob/355c3f8d78a91f72d049e58f1edee8a972f845eb/src/pyload/core/managers/file_manager.py#L136).

Instead, in this PR triggers an `UpdateEvent("pack", ...)` with the corresponding package id and destination.


Also dropped the unused `ReloadAllEvent` import.

### Is this related to a problem?
Previously, there was no way to detect when links are added to a package.