### PR TITLE
UnRar: fix: preserve file paths in self.files

### DIFF
--- a/src/pyload/plugins/extractors/UnRar.py
+++ b/src/pyload/plugins/extractors/UnRar.py
@@ -332,8 +332,20 @@ class UnRar(BaseExtractor):
                 if smallest[1] == 0 or smallest[1] > s > 0:
                     smallest = (f, s)
 
+                # no!
+                # this was added in
+                # edfc2907fa833b44a7bb7b758af432089973c1e9
+                # fix extract archive functionality (#3797)
+                # https://github.com/pyload/pyload/pull/3797
+                # but this makes no sense
+                # why should we
+                # convert a path like "path/to/file.txt" to "file.txt"
+                # this never makes sense
+                # no matter the value of self.fullpath
+                r'''
                 if not self.fullpath:
                     f = os.path.basename(f)
+                '''
                 f = safejoin(self.dest, f)
                 files.add(f)
 


### PR DESCRIPTION
`f = os.path.basename(f)` is just wrong...

this was added in edfc2907fa833b44a7bb7b758af432089973c1e9

`git show -U9999 edfc2907fa833b44a7bb7b758af432089973c1e9`

```diff
     def list(self, password=None):
-        command = "l" if self.fullpath else "l"
+        p = self.call_cmd("l", self.filename, password=password)
 
-        p = self.call_cmd(command, self.filename, password=password)
-        out, err = (r.strip() if r else "" for r in p.communicate())
+        out, err = (to_str(r).strip() if r else "" for r in p.communicate())
 
         if any(e in err for e in ("Can not open", "cannot find the file")):
             raise ArchiveError(self._("Cannot open file"))
 
         if p.returncode > 1:
             raise ArchiveError(self._("Process return code: {}").format(p.returncode))
 
         files = set()
         for groups in self._RE_FILES.findall(out):
             f = groups[-1].strip()
+            if not self.fullpath:
+                f = os.path.basename(f)
             files.add(os.path.join(self.dest, f))
 
         self.files = list(files)
 
         return self.files
```


maybe this was done for "backward compatibility" with rar 4
because rar 4 listed only basenames, not full file paths
but we have rar 5 since 2013...
