### PR TITLE
fix: race condition on shared account info causes KeyError during download

### DIFF
--- a/src/pyload/plugins/base/account.py
+++ b/src/pyload/plugins/base/account.py
@@ -495,7 +495,7 @@ class BaseAccount(BasePlugin):
 
         else:
             self.user = user
-            self.info.clear()
+            self.sync()
             self.req.close()
 
             self.req = self.pyload.request_factory.get_request(


### PR DESCRIPTION
## Problem

`BaseAccount.choose()` clears `self.info` before resyncing it for the newly selected user:

```python
self.user = user
self.info.clear()
self.req.close()
...
if not self.logged:
    self.relogin()
```

The account plugin instance is shared across every download thread for a given hoster (`AccountManager.get_account_plugin` caches a single instance per plugin). Downloader plugins read `self.account.info["login"]["password"]` directly, without holding the account's lock.

When one thread runs `choose()` and clears `info` while another thread is mid-download reading from it, the reader can observe an empty dict and crash:

```
File "pyload/plugins/downloaders/AlldebridCom.py", line 83, in handle_premium
    "apikey": self.account.info["login"]["password"],
              ~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'login'
```

This affects every downloader that reads `account.info["login"][...]` directly (AlldebridCom, PremiumizeMe, RealDebrid, TorboxApp, FikperCom, ZeveraCom, and others), and shows up intermittently under concurrent downloads, causing some files in a batch to fail while others succeed.

A prior change (add some more locks) added `@lock` to `login()`, `logout()`, and `sync()`, but the readers in the downloader plugins never acquire that lock, so the empty-dict window was never actually closed.

## Fix

Replace `self.info.clear()` with `self.sync()`. `sync()` already runs a few lines later via the `self.logged` check, so the explicit clear is redundant. Calling `sync()` directly rebuilds `info["login"]`/`info["data"]` for the new user in place, so `self.info` transitions straight from the old user's data to the new user's data and is never left empty for a reader on another thread to observe.