### PR TITLE
Fix NameError when logging a missing extraction target

### DIFF
--- a/src/pyload/plugins/addons/ExtractArchive.py
+++ b/src/pyload/plugins/addons/ExtractArchive.py
@@ -297,7 +297,7 @@ class ExtractArchive(BaseAddon):
 
                         for fid, fname, fout in targets:
                             if not exists(fname):
-                                self.log_debug(name, "File not found")
+                                self.log_debug(fname, "File not found")
                                 continue
 
                             name = os.path.basename(fname)


### PR DESCRIPTION
## Description

In `ExtractArchive._extract`, the "file not found" branch logs `name` before it is assigned:

```python
for fid, fname, fout in targets:
    if not exists(fname):
        self.log_debug(name, "File not found")   # name is unbound here
        continue

    name = os.path.basename(fname)
    self.log_info(name, self._("Extract to: {}").format(fout))
```

`name` is only bound *after* the guard. On the first missing target this raises `NameError: name 'name' is not defined`; on a later iteration it logs a stale filename left over from a previous loop pass.

## Fix

Use the loop variable `fname`, which is the file being checked, in the debug log.

## How reached

Triggered during archive extraction when a listed target file is missing on disk (e.g. an incomplete/partially-deleted multi-volume archive).