### PR TITLE
Add OrigridIo hoster plugin

### DIFF
--- a/src/pyload/plugins/downloaders/OrigridIo.py
+++ b/src/pyload/plugins/downloaders/OrigridIo.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # pyLoad hoster plugin for Origrid (https://origrid.io)
 #
 # Origrid serves everything a downloader needs from plain HTML: no captcha, no
@@ -38,18 +36,29 @@ class OrigridIo(SimpleDownloader):
 
     # Name and size come from stable data-origrid anchors, not from CSS classes.
     NAME_PATTERN = r'data-origrid="name"[^>]*>(?P<N>[^<]+)<'
-    # Bytes crudos en vez de "306.1 MB": no hay que parsear unidades ni depender
-    # del locale del servidor, y no pierde precision al redondear.
-    SIZE_PATTERN = r'data-origrid-bytes="(?P<S>\d+)"' 
-    OFFLINE_PATTERN = r"This link doesn&#39;t lead to a file|This link doesn't lead to a file"
+    SIZE_PATTERN = r'data-origrid-bytes="(?P<S>\d+)"'
+    # Two distinct dead-link states, and the page distinguishes them:
+    #   - unknown id     -> "This link doesn't lead to a file"
+    #   - expired file   -> banner carrying data-origrid="offline"
+    # The anchor comes first because it is the stable one: the visible copy is
+    # translated and rewritten, the attribute is not.
+    # The expired case was missing until 2026-09-07. Without it the link matched
+    # neither online nor offline, so pyLoad treated it as a temporary error and
+    # retried in a loop instead of marking it dead.
+    OFFLINE_PATTERN = (
+        r'data-origrid="offline"'
+        r"|This link doesn&#39;t lead to a file|This link doesn't lead to a file"
+    )
 
     # The download anchor is present in the server HTML (no JS needed). The token
     # is single-use-ish and short-lived, so it is read per request rather than cached.
     LINK_FREE_PATTERN = r'data-origrid="download"[^>]*href="(?P<L>/dl/[^"]+)"'
 
+    URL_REPLACEMENTS = [(__pattern__ + ".*", r"https://origrid.io/d/\g<ID>")]
+
     def setup(self):
-        # Origrid puts no cap on concurrent downloads and serves 302s to storage
-        # with Accept-Ranges, so resuming and chunking are both safe.
+        # Origrid sets no cap on concurrent downloads and redirects (302) to
+        # storage with Accept-Ranges, so resuming and chunking are both safe.
         self.multi_dl = True
         self.resume_download = True
         self.chunk_limit = -1

--- a/src/pyload/plugins/downloaders/OrigridIo.py
+++ b/src/pyload/plugins/downloaders/OrigridIo.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# pyLoad hoster plugin for Origrid (https://origrid.io)
+#
+# Origrid serves everything a downloader needs from plain HTML: no captcha, no
+# wait timer, no account, no anti-bot wall. Name, size and the direct link are
+# all in the server-rendered page, so this plugin needs no JS unpacking — unlike
+# most hosts, where half the plugin is undoing someone's obfuscation.
+#
+# The `data-origrid="…"` attributes the patterns below key on are a deliberate,
+# documented contract on Origrid's side (see the note at the top of
+# src/routes/d/[id]/+page.svelte). They exist precisely so this plugin doesn't
+# depend on CSS class names, which carry a build hash and change on every deploy.
+
+import re
+
+from ..base.simple_downloader import SimpleDownloader
+
+
+class OrigridIo(SimpleDownloader):
+    __name__ = "OrigridIo"
+    __type__ = "downloader"
+    __version__ = "0.01"
+    __status__ = "testing"
+
+    __pattern__ = r"https?://(?:www\.)?origrid\.io/d/(?P<ID>[\w\-]+)"
+    __config__ = [
+        ("enabled", "bool", "Activated", True),
+        ("use_premium", "bool", "Use premium account if available", True),
+        ("fallback", "bool", "Fallback to free download if premium fails", True),
+        ("chk_filesize", "bool", "Check file size", True),
+        ("max_wait", "int", "Reconnect if waiting time is greater than minutes", 10),
+    ]
+
+    __description__ = """Origrid.io downloader plugin"""
+    __license__ = "GPLv3"
+    __authors__ = [("Origrid", "admin@origrid.io")]
+
+    # Name and size come from stable data-origrid anchors, not from CSS classes.
+    NAME_PATTERN = r'data-origrid="name"[^>]*>(?P<N>[^<]+)<'
+    # Bytes crudos en vez de "306.1 MB": no hay que parsear unidades ni depender
+    # del locale del servidor, y no pierde precision al redondear.
+    SIZE_PATTERN = r'data-origrid-bytes="(?P<S>\d+)"' 
+    OFFLINE_PATTERN = r"This link doesn&#39;t lead to a file|This link doesn't lead to a file"
+
+    # The download anchor is present in the server HTML (no JS needed). The token
+    # is single-use-ish and short-lived, so it is read per request rather than cached.
+    LINK_FREE_PATTERN = r'data-origrid="download"[^>]*href="(?P<L>/dl/[^"]+)"'
+
+    def setup(self):
+        # Origrid puts no cap on concurrent downloads and serves 302s to storage
+        # with Accept-Ranges, so resuming and chunking are both safe.
+        self.multi_dl = True
+        self.resume_download = True
+        self.chunk_limit = -1
+
+    def handle_free(self, pyfile):
+        m = re.search(self.LINK_FREE_PATTERN, self.data)
+        if m is None:
+            self.error(self._("Download link not found"))
+
+        link = m.group("L")
+        if link.startswith("/"):
+            link = "https://origrid.io" + link
+        self.link = link


### PR DESCRIPTION
Adds a downloader plugin for **Origrid** (https://origrid.io), a large-file host.

**Full disclosure: I'm the operator of Origrid**, so please treat this as a vendor submission and verify independently — everything below can be checked with `curl` against a live link.

### Why it's short

No JS unpacking needed. Name, size and the direct link are all in the server-rendered HTML, and the free path has no captcha, no wait timer and no account requirement, so `SimpleDownloader` covers it with four patterns and a five-line `handle_free`.

### What it resolves, and how you can check it

Take any file page, e.g. `https://origrid.io/d/85k3lFZNL`:

- **Name** — `data-origrid="name"` on the `<h1>`
- **Size** — `data-origrid-bytes` carries the exact byte count, so there's no unit parsing or rounding
- **Offline** — HTTP 404 with `This link doesn't lead to a file`
- **Direct link** — `data-origrid="download"` on the anchor; it 302s to storage with `Accept-Ranges: bytes`, and range requests return `206 Partial Content`, so `resume_download` and chunking both work

### About the `data-origrid` attributes

They're a deliberate contract on the host's side, not incidental markup. Origrid's frontend is SvelteKit, whose CSS class names carry a build hash and change on every deploy — a plugin keyed on classes would break at the first release. The attributes are documented as public contract in their source and covered by a test on their side that fails if one is renamed or if the download anchor stops being server-rendered.

Mentioning it because it's the part most likely to rot silently, and it shouldn't.

### Notes

- `chunk_limit = -1` and `multi_dl = True`: the host caps neither concurrent downloads nor connections on the free path.
- No premium handling. Paid tiers exist but only change size limits and ads, not the download flow, so there's nothing for the plugin to do differently.

Happy to adjust anything to match your conventions.
