### PR TITLE
[DdownloadCom] Use HTTPS for plugin URL

### DIFF
--- a/src/pyload/plugins/accounts/DdownloadCom.py
+++ b/src/pyload/plugins/accounts/DdownloadCom.py
@@ -20,7 +20,7 @@ class DdownloadCom(XFSAccount):
     __authors__ = [("GammaC0de", "nitzo2001[AT]yahoo[DOT]com")]
 
     PLUGIN_DOMAIN = "ddownload.com"
-    PLUGIN_URL = "http://ddownload.com"
+    PLUGIN_URL = "https://ddownload.com"
 
     PREMIUM_PATTERN = r'<[^<]+ma-ultimate-pill[^>]+>Ultimate<'
     TRAFFIC_LEFT_PATTERN = r'\s*<span id="trafficValue">(?P<S>-?\d+)</span>'

--- a/src/pyload/plugins/accounts/DdownloadCom.py
+++ b/src/pyload/plugins/accounts/DdownloadCom.py
@@ -12,7 +12,7 @@ from ..helpers import parse_html_form, search_pattern
 class DdownloadCom(XFSAccount):
     __name__ = "DdownloadCom"
     __type__ = "account"
-    __version__ = "0.11"
+    __version__ = "0.12"
     __status__ = "testing"
 
     __description__ = """Ddownload.com account plugin"""


### PR DESCRIPTION
DdownloadCom still uses `http://ddownload.com` as `PLUGIN_URL`.

DDownload redirects HTTP requests to HTTPS, but this causes the interactive
Turnstile captcha to fail when the pyLoad WebUI itself is accessed over HTTPS.

The browser blocks the initial `http://ddownload.com/` request as mixed active
content before the redirect to HTTPS can occur.

Changing `PLUGIN_URL` to `https://ddownload.com` fixes the interactive captcha
when pyLoad is accessed through an HTTPS reverse proxy.

Tested with pyLoad-ng running in Docker behind an HTTPS reverse proxy.